### PR TITLE
Add sketch of potential measures API

### DIFF
--- a/measure_definitions.py
+++ b/measure_definitions.py
@@ -105,33 +105,32 @@ had_matching_event = event.exists_for_patient()
 # These are static methods which just live on `Measures` for the sake of convenience and
 # keeping the namespace clean.
 
-intervals = Measures.by_month(start="2020-12-01", end="2021-04-01")
 
-measures = Measures()
-
-measures.define_measure(
-    id="total",
+# To reduce repetition, default values which will be shared across multiple measures can
+# be supplied to the `Measures()` constructor
+measures = Measures(
     # Numerator can be any boolean or integer PatientSeries
     numerator=had_matching_event,
     # Denominator can also be any boolean or integer PatientSeries. The denominator
     # functions like `Dataset.define_population()` so only patients appearing in the
     # denominator can appear in the numerator.
     denominator=population,
+    # This can be any list of start/end date pairs – they don't have to be regular
+    # or contiguous
+    intervals=Measures.by_month(start="2020-12-01", end="2021-04-01"),
+)
+
+measures.define_measure(
+    id="total",
     # I'm not wild about the use of `dict` here but I can't think of a better
     # syntactic solution.
     group_by=dict(
         age_band=age_band,
     ),
-    # This can be any list of start/end date pairs – they don't have to be regular
-    # or contiguous
-    intervals=intervals,
 )
 
 measures.define_measure(
     id="event_code",
-    numerator=had_matching_event,
-    # All these measures use the same denominator but they don't have to
-    denominator=population,
     # The only restriction on `group_by` is that where multiple measures use the
     # same column name they must also share the same column definition. This allows
     # us to combine all the measures in a single output file, and I don't think is
@@ -140,28 +139,20 @@ measures.define_measure(
         age_band=age_band,
         event_code=event.snomedct_code,
     ),
-    # Likewise, all these measures use the same intervals, but they don't have to
-    intervals=intervals,
 )
 
 measures.define_measure(
     id="practice",
-    numerator=had_matching_event,
-    denominator=population,
     group_by=dict(
         age_band=age_band,
         practice=practice.practice_pseudo_id,
     ),
-    intervals=intervals,
 )
 
 measures.define_measure(
-    id="practice",
-    numerator=had_matching_event,
-    denominator=population,
+    id="region",
     group_by=dict(
         age_band=age_band,
         region=practice.nuts1_region_name,
     ),
-    intervals=intervals,
 )

--- a/measure_definitions.py
+++ b/measure_definitions.py
@@ -1,0 +1,168 @@
+from databuilder.ehrql import case, when
+
+# I'm importing from a separate `measures` module here, but I think there's an argument
+# that this should all be importable from the `ehrql` namespace
+from databuilder.measures import (
+    INTERVAL_END_DATE,
+    INTERVAL_START_DATE,
+    Intervals,
+    Measure,
+)
+from databuilder.tables.beta.tpp import (
+    clinical_events,
+    ons_deaths,
+    patients,
+    practice_registrations,
+)
+
+# Note that the INTERVAL_START_DATE/INTERVAL_END_DATE values are ehrQL parameters (or
+# placeholders). From the point of view of the rest of ehrQL they are just
+# `DatePatientSeries` instances like any other. But they have no date associated with
+# them and so can't be executed until we substitue in a concrete date value.
+#
+# We're using a start/end pair rather than a single INDEX_DATE so we don't have to
+# hardcode the interval duration into the definition.
+#
+# I used uppercase for these names as they are, technically, constants. But I'm open to
+# the accusation that this is all a bit Java and it would be more readable if they were
+# lowercase.
+
+
+# DEMOGRAPHICS
+#
+
+practice = practice_registrations.for_patient_on(INTERVAL_START_DATE)
+
+has_died = ons_deaths.where(ons_deaths.date <= INTERVAL_START_DATE).exists_for_patient()
+
+age = patients.age_on(INTERVAL_START_DATE)
+
+age_band = case(
+    when((age >= 0) & (age <= 4)).then("0-4"),
+    when((age >= 5) & (age <= 9)).then("5-9"),
+    when((age >= 10) & (age <= 14)).then("10-14"),
+    when((age >= 15) & (age <= 19)).then("15-19"),
+    when((age >= 20) & (age <= 24)).then("20-24"),
+    when((age >= 25) & (age <= 29)).then("25-29"),
+    when((age >= 30) & (age <= 34)).then("30-34"),
+    when((age >= 35) & (age <= 39)).then("35-39"),
+    when((age >= 40) & (age <= 44)).then("40-44"),
+    when((age >= 45) & (age <= 49)).then("45-49"),
+    when((age >= 50) & (age <= 54)).then("50-54"),
+    when((age >= 55) & (age <= 59)).then("55-59"),
+    when((age >= 60) & (age <= 64)).then("60-64"),
+    when((age >= 65) & (age <= 69)).then("65-69"),
+    when((age >= 70) & (age <= 74)).then("70-74"),
+    when((age >= 75) & (age <= 79)).then("75-79"),
+    when((age >= 80) & (age <= 84)).then("80-84"),
+    when((age >= 85) & (age <= 89)).then("85-89"),
+    when(age >= 90).then("90plus"),
+    default="missing",
+)
+
+
+# DENOMINATOR
+#
+
+population = (
+    practice.exists_for_patient()
+    & ~has_died
+    & patients.sex.is_in(["male", "female"])
+    & (age_band != "missing")
+)
+
+
+# NUMERATOR
+#
+# Patients who have had a matching event in the interval
+
+# https://www.opencodelists.org/codelist/primis-covid19-vacc-uptake/cov1decl/v1.1/
+codelist = [
+    "1324721000000108",  # Severe acute respiratory syndrome coronavirus 2 vaccination dose declined
+    "1324741000000101",  # Severe acute respiratory syndrome coronavirus 2 vaccination first dose declined
+    "1324811000000107",  # Severe acute respiratory syndrome coronavirus 2 immunisation course declined
+]
+
+e = clinical_events
+event = (
+    e.where(e.snomedct_code.is_in(codelist))
+    .where(e.date.is_on_or_between(INTERVAL_START_DATE, INTERVAL_END_DATE))
+    .sort_by(e.date)
+    .first_for_patient()
+)
+had_matching_event = event.exists_for_patient()
+
+
+# DATE RANGE
+#
+# The `Intervals` methods are helper functions which return a list of date pairs, being
+# the start and ends (inclusive) of the specified intervals e.g.
+#
+#     Intervals.weeks_between("2020-01-01", "2020-01-15") == [
+#         (date(2020,1,1), date(2020,1,7)),
+#         (date(2020,1,8), date(2020,1,14)),
+#         (date(2020,1,15), date(2020,1,21)),
+#     ]
+#
+# `Intervals` is just acting as a namespace here; it felt cleaner to me to keep these
+# together rather than having them as free floating functions. But I'm open to other
+# suggestions.
+
+intervals = Intervals.months_between("2020-12-01", "2021-04-01")
+
+
+measures = [
+    Measure(
+        id="total",
+        # Numerator can be any boolean or integer PatientSeries
+        numerator=had_matching_event,
+        # Denominator can also be any boolean or integer PatientSeries. The denominator
+        # functions like `Dataset.define_population()` so only patients appearing in the
+        # denominator can appear in the numerator.
+        denominator=population,
+        # I'm not wild about the use of `dict` here but I can't think of a better
+        # syntactic solution.
+        group_by=dict(
+            age_band=age_band,
+        ),
+        # This can be any list of start/end date pairs – they don't have to be regular
+        # or contiguous
+        intervals=intervals,
+    ),
+    Measure(
+        id="event_code",
+        numerator=had_matching_event,
+        # All these measures use the same denominator but they don't have to
+        denominator=population,
+        # The only restriction on `group_by` is that where multiple measures use the
+        # same column name they must also share the same column definition. This allows
+        # us to combine all the measures in a single output file, and I don't think is
+        # too onerous a condition.
+        group_by=dict(
+            age_band=age_band,
+            event_code=event.snomedct_code,
+        ),
+        # Likewise, all these measures use the same intervals, but they don't have to
+        intervals=intervals,
+    ),
+    Measure(
+        id="practice",
+        numerator=had_matching_event,
+        denominator=population,
+        group_by=dict(
+            age_band=age_band,
+            practice=practice.practice_pseudo_id,
+        ),
+        intervals=intervals,
+    ),
+    Measure(
+        id="practice",
+        numerator=had_matching_event,
+        denominator=population,
+        group_by=dict(
+            age_band=age_band,
+            region=practice.nuts1_region_name,
+        ),
+        intervals=intervals,
+    ),
+]


### PR DESCRIPTION
Included is a sketch of what I think an ehrQL [measures API](https://github.com/opensafely-core/databuilder/issues/816) could look like. It's a translation of the [vaccine-declined measures](https://github.com/opensafely/covid-vaccine-declined-variation/blob/46281b8a01cfec375fb49a3a9dfd9e7cab14bcf2/analysis/study_definition.py) which happened to be the first simple example I stumbled across.

I've done enough proof-of-concept hacking to convince myself that we can implement this. And I've got some ideas of varying levels of complexity and sophistication as to how we could implement it [efficiently](https://github.com/opensafely-core/databuilder/issues/42) (at least, more efficiently than we currently do – which isn't hard).

You'd invoke this using something like:
```
databuilder generate-measures measure_definitions.py --output measures.arrow
```

Notice that there's only a single output file here. I think it would be quite sensible to have some way of outputting multiple files, one per measure, by specifying an output file pattern or something. But I'm very keen for that not to be _required_. Indeed, I'd like to follow `generate-dataset` here and just write CSV to stdout if no output file is specified at all.

I think reducing to the bare minimum the ceremony required to get _something_ out of a command is an important part of minimising the learning curve.

This does mean the resulting output file structure is a little odd in that it may have group-by columns which aren't relevant for some of the measures (because they are not grouped by that value). But these can just take NULL values and I don't think there's any practical problem here.

For example, a small part of the output for these measures might look like:

measure_id | interval_start | interval_end | value | numerator | denominator | age_band | practice | event_code | region
-- | -- | -- | -- | -- | -- | -- | -- | -- | --
total | 2020-12-01 | 2020-12-31 | 0.05 | 50 | 1000 | 50-55 |   |   |  
total | 2021-01-01 | 2021-01-31 | 0.075 | 60 | 800 | 50-55 |   |   |  
total | 2020-12-01 | 2020-12-31 | 0.025 | 40 | 1600 | 55-60 |   |   |  
total | 2021-01-01 | 2021-01-31 | 0.08 | 80 | 1000 | 55-60 |   |   |  
practice | 2020-12-01 | 2020-12-31 | 0.05 | 50 | 1000 | 40-45 | 123456 |   |  
practice | 2020-12-01 | 2020-12-31 | 0.075 | 60 | 800 | 40-45 | 789101 |   |  
... |   |   |   |   |   |   |   |   |  


I haven't thought about small number suppression at this stage.