### PR TITLE
Rework `read_dataset` functions

### DIFF
--- a/databuilder/file_formats/__init__.py
+++ b/databuilder/file_formats/__init__.py
@@ -55,6 +55,10 @@ def validate_dataset(filename, column_specs):
 
 def read_dataset(filename, column_specs):
     extension = get_file_extension(filename)
+    if extension not in FILE_FORMATS:
+        raise ValidationError(f"Unsupported file type: {extension}")
+    if not os.path.isfile(filename):
+        raise ValidationError(f"Missing file: {filename}")
     reader = FILE_FORMATS[extension][2]
     return reader(filename, column_specs)
 

--- a/databuilder/file_formats/__init__.py
+++ b/databuilder/file_formats/__init__.py
@@ -2,13 +2,10 @@ import os
 
 from databuilder.file_formats.arrow import (
     ArrowDatasetReader,
-    validate_dataset_arrow,
     write_dataset_arrow,
 )
 from databuilder.file_formats.csv import (
     CSVDatasetReader,
-    validate_dataset_csv,
-    validate_dataset_csv_gz,
     write_dataset_csv,
     write_dataset_csv_gz,
 )
@@ -16,21 +13,9 @@ from databuilder.file_formats.validation import ValidationError
 
 
 FILE_FORMATS = {
-    ".arrow": (
-        write_dataset_arrow,
-        validate_dataset_arrow,
-        ArrowDatasetReader,
-    ),
-    ".csv": (
-        write_dataset_csv,
-        validate_dataset_csv,
-        CSVDatasetReader.from_csv,
-    ),
-    ".csv.gz": (
-        write_dataset_csv_gz,
-        validate_dataset_csv_gz,
-        CSVDatasetReader.from_csv_gz,
-    ),
+    ".arrow": (write_dataset_arrow, ArrowDatasetReader),
+    ".csv": (write_dataset_csv, CSVDatasetReader.from_csv),
+    ".csv.gz": (write_dataset_csv_gz, CSVDatasetReader.from_csv_gz),
 }
 
 
@@ -43,34 +28,14 @@ def write_dataset(filename, results, column_specs):
     writer(filename, results, column_specs)
 
 
-def validate_dataset(filename, column_specs):
-    if not os.path.isfile(filename):
-        raise FileNotFoundError(f"{filename} not found")
-    extension = get_file_extension(filename)
-    if extension not in FILE_FORMATS:
-        raise ValueError(f"Loading from {extension} files not supported")
-    validator = FILE_FORMATS[extension][1]
-    validator(filename, column_specs)
-
-
 def read_dataset(filename, column_specs):
     extension = get_file_extension(filename)
     if extension not in FILE_FORMATS:
         raise ValidationError(f"Unsupported file type: {extension}")
     if not os.path.isfile(filename):
         raise ValidationError(f"Missing file: {filename}")
-    reader = FILE_FORMATS[extension][2]
+    reader = FILE_FORMATS[extension][1]
     return reader(filename, column_specs)
-
-
-def validate_file_types_match(dummy_filename, output_filename):
-    if get_file_extension(dummy_filename) != get_file_extension(output_filename):
-        raise ValidationError(
-            f"Dummy data file does not have the same file extension as the output "
-            f"filename:\n"
-            f"Dummy data file: {dummy_filename}\n"
-            f"Output file: {output_filename}"
-        )
 
 
 def get_file_extension(filename):

--- a/databuilder/file_formats/__init__.py
+++ b/databuilder/file_formats/__init__.py
@@ -1,13 +1,12 @@
 import os
 
 from databuilder.file_formats.arrow import (
-    read_dataset_arrow,
+    ArrowDatasetReader,
     validate_dataset_arrow,
     write_dataset_arrow,
 )
 from databuilder.file_formats.csv import (
-    read_dataset_csv,
-    read_dataset_csv_gz,
+    CSVDatasetReader,
     validate_dataset_csv,
     validate_dataset_csv_gz,
     write_dataset_csv,
@@ -17,9 +16,21 @@ from databuilder.file_formats.validation import ValidationError
 
 
 FILE_FORMATS = {
-    ".arrow": (write_dataset_arrow, validate_dataset_arrow, read_dataset_arrow),
-    ".csv": (write_dataset_csv, validate_dataset_csv, read_dataset_csv),
-    ".csv.gz": (write_dataset_csv_gz, validate_dataset_csv_gz, read_dataset_csv_gz),
+    ".arrow": (
+        write_dataset_arrow,
+        validate_dataset_arrow,
+        ArrowDatasetReader,
+    ),
+    ".csv": (
+        write_dataset_csv,
+        validate_dataset_csv,
+        CSVDatasetReader.from_csv,
+    ),
+    ".csv.gz": (
+        write_dataset_csv_gz,
+        validate_dataset_csv_gz,
+        CSVDatasetReader.from_csv_gz,
+    ),
 }
 
 

--- a/databuilder/file_formats/arrow.py
+++ b/databuilder/file_formats/arrow.py
@@ -3,7 +3,11 @@ from itertools import islice
 
 import pyarrow
 
-from databuilder.file_formats.validation import ValidationError, validate_headers
+from databuilder.file_formats.validation import (
+    ValidationError,
+    validate_columns,
+    validate_headers,
+)
 
 
 PYARROW_TYPE_MAP = {
@@ -12,6 +16,14 @@ PYARROW_TYPE_MAP = {
     float: pyarrow.float64,
     str: pyarrow.string,
     datetime.date: pyarrow.date32,
+}
+
+PYARROW_TYPE_TEST_MAP = {
+    bool: pyarrow.types.is_boolean,
+    int: pyarrow.types.is_integer,
+    float: pyarrow.types.is_floating,
+    str: pyarrow.types.is_string,
+    datetime.date: pyarrow.types.is_date,
 }
 
 # When dumping a `pyarrow.Table` or `pandas.DataFrame` to disk, pyarrow takes care of
@@ -199,10 +211,65 @@ def get_first_record_batch_from_file(filename):
             return reader.get_batch(0)
 
 
-def read_dataset_arrow(filename, column_specs=None):
-    with pyarrow.memory_map(str(filename), "rb") as f:
-        with pyarrow.ipc.open_file(f) as reader:
-            for i in range(0, reader.num_record_batches):
-                rb = reader.get_record_batch(i)
-                for j in range(0, rb.num_rows):
-                    yield tuple(rb.take([j]).to_pylist()[0].values())
+class ArrowDatasetReader:
+    def __init__(self, filename, column_specs):
+        self.fileobj = pyarrow.memory_map(str(filename), "rb")
+        self.reader = pyarrow.ipc.open_file(self.fileobj)
+        self.column_specs = column_specs
+        self.columns = list(column_specs.keys())
+        try:
+            self._validate_basic()
+        except ValidationError:
+            self.close()
+            raise
+
+    def _validate_basic(self):
+        # Arrow enforces that all record batches have a consistent schema and that any
+        # categorical columns use the same dictionary, so we only need to get the first
+        # batch in order to validate
+        batch = self.reader.get_record_batch(0)
+        validate_columns(batch.schema.names, self.columns)
+        errors = []
+        for name, spec in self.column_specs.items():
+            column = batch.column(name)
+            if error := self._validate_column(name, column, spec):
+                errors.append(error)
+        if errors:
+            raise ValidationError("\n".join(errors))
+
+    def _validate_column(self, name, column, spec):
+        type_test = PYARROW_TYPE_TEST_MAP[spec.type]
+        column_type = column.type
+        if pyarrow.types.is_dictionary(column_type):
+            column_type = column_type.value_type
+        if not type_test(column_type):
+            return (
+                f"Type mismatch in column '{name}': "
+                f"expected {spec.type}, got {column.type}"
+            )
+        if pyarrow.types.is_dictionary(column.type) and spec.categories is not None:
+            column_categories = column.dictionary.to_pylist()
+            if column_categories != list(spec.categories):
+                return (
+                    f"Unexpected categories in column '{name}'\n"
+                    f"  Categories: {', '.join(column_categories)}\n"
+                    f"  Expected: {', '.join(spec.categories)}\n"
+                )
+
+    def __iter__(self):
+        for i in range(self.reader.num_record_batches):
+            batch = self.reader.get_record_batch(i)
+            # Use `zip(*...)` to transpose from column-wise to row-wise
+            yield from zip(*(batch.column(name).to_pylist() for name in self.columns))
+
+    def close(self):
+        # `self.reader` does not need closing: it acts as a contextmanager, but its exit
+        # method is a no-op, see:
+        # https://github.com/apache/arrow/blob/1706b095/python/pyarrow/ipc.pxi#L1032-L1036
+        self.fileobj.close()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc_args):
+        self.close()

--- a/databuilder/file_formats/csv.py
+++ b/databuilder/file_formats/csv.py
@@ -4,11 +4,7 @@ import gzip
 import sys
 from contextlib import nullcontext
 
-from databuilder.file_formats.validation import (
-    ValidationError,
-    validate_columns,
-    validate_headers,
-)
+from databuilder.file_formats.validation import ValidationError, validate_columns
 
 
 def write_dataset_csv(filename, results, column_specs):
@@ -62,20 +58,6 @@ def format_bool(value):
     return "T" if value else "F"
 
 
-def validate_dataset_csv(filename, column_specs):
-    with open(filename, newline="") as f:
-        # Consume the generator to raise any errors
-        for _ in read_dataset_csv_lines(f, column_specs):
-            pass
-
-
-def validate_dataset_csv_gz(filename, column_specs):
-    with gzip.open(filename, "rt", newline="") as f:
-        # Consume the generator to raise any errors
-        for _ in read_dataset_csv_lines(f, column_specs):
-            pass
-
-
 class CSVDatasetReader:
     @classmethod
     def from_csv(cls, filename, column_specs):
@@ -121,18 +103,6 @@ class CSVDatasetReader:
 
     def __exit__(self, *exc_args):
         self.close()
-
-
-def read_dataset_csv_lines(lines, column_specs):
-    reader = csv.reader(lines)
-    headers = next(reader)
-    validate_headers(headers, list(column_specs.keys()))
-    row_parser = create_row_parser(headers, column_specs)
-    for n, row in enumerate(reader, start=1):
-        try:
-            yield row_parser(row)
-        except ValueError as e:
-            raise ValidationError(f"row {n}: {e}")
 
 
 def create_row_parser(headers, column_specs):

--- a/databuilder/file_formats/csv.py
+++ b/databuilder/file_formats/csv.py
@@ -4,7 +4,11 @@ import gzip
 import sys
 from contextlib import nullcontext
 
-from databuilder.file_formats.validation import ValidationError, validate_headers
+from databuilder.file_formats.validation import (
+    ValidationError,
+    validate_columns,
+    validate_headers,
+)
 
 
 def write_dataset_csv(filename, results, column_specs):
@@ -72,14 +76,51 @@ def validate_dataset_csv_gz(filename, column_specs):
             pass
 
 
-def read_dataset_csv(filename, column_specs):
-    with filename.open(newline="") as f:
-        yield from read_dataset_csv_lines(f, column_specs)
+class CSVDatasetReader:
+    @classmethod
+    def from_csv(cls, filename, column_specs):
+        return cls(open(filename, newline=""), column_specs)
 
+    @classmethod
+    def from_csv_gz(cls, filename, column_specs):
+        return cls(gzip.open(filename, "rt", newline=""), column_specs)
 
-def read_dataset_csv_gz(filename, column_specs):
-    with gzip.open(filename, "rt", newline="") as f:
-        yield from read_dataset_csv_lines(f, column_specs)
+    def __init__(self, fileobj, column_specs):
+        self.fileobj = fileobj
+        self.column_specs = column_specs
+        try:
+            self._validate_basic()
+        except ValidationError:
+            self.close()
+            raise
+
+    def _validate_basic(self):
+        # CSV being what it is we can't properly validate the types it contains without
+        # reading the entire thing, which we don't want do. So we read the first 10 rows
+        # in the hope that if there's a type mistmach it will show up here.
+        for _ in zip(self, range(10)):
+            pass
+
+    def __iter__(self):
+        self.fileobj.seek(0)
+        reader = csv.reader(self.fileobj)
+        headers = next(reader)
+        validate_columns(headers, self.column_specs.keys())
+        row_parser = create_row_parser(headers, self.column_specs)
+        for n, row in enumerate(reader, start=1):
+            try:
+                yield row_parser(row)
+            except ValueError as e:
+                raise ValidationError(f"row {n}: {e}")
+
+    def close(self):
+        self.fileobj.close()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc_args):
+        self.close()
 
 
 def read_dataset_csv_lines(lines, column_specs):

--- a/databuilder/file_formats/validation.py
+++ b/databuilder/file_formats/validation.py
@@ -23,3 +23,9 @@ def validate_headers(headers, expected_headers):
             f"  expected: {', '.join(expected_headers)}\n"
             f"  found: {', '.join(headers)}"
         )
+
+
+def validate_columns(columns, required_columns):
+    missing = [c for c in required_columns if c not in columns]
+    if missing:
+        raise ValidationError(f"Missing columns: {', '.join(missing)}")

--- a/databuilder/file_formats/validation.py
+++ b/databuilder/file_formats/validation.py
@@ -2,29 +2,6 @@ class ValidationError(Exception):
     pass
 
 
-def validate_headers(headers, expected_headers):
-    headers_set = set(headers)
-    expected_set = set(expected_headers)
-    if headers_set != expected_set:
-        errors = []
-        missing = expected_set - headers_set
-        if missing:
-            errors.append(f"Missing columns: {', '.join(missing)}")
-        extra = headers_set - expected_set
-        if extra:
-            errors.append(f"Unexpected columns: {', '.join(extra)}")
-        raise ValidationError("\n".join(errors))
-    elif headers != expected_headers:
-        # We could be more relaxed about things here, but I think it's worth insisting
-        # that columns be in the same order. We've seen analysis code before which is
-        # sensitive to column ordering.
-        raise ValidationError(
-            f"Headers not in expected order:\n"
-            f"  expected: {', '.join(expected_headers)}\n"
-            f"  found: {', '.join(headers)}"
-        )
-
-
 def validate_columns(columns, required_columns):
     missing = [c for c in required_columns if c not in columns]
     if missing:

--- a/databuilder/main.py
+++ b/databuilder/main.py
@@ -7,6 +7,7 @@ import structlog
 
 from databuilder.dummy_data import DummyDataGenerator
 from databuilder.file_formats import (
+    read_dataset,
     validate_dataset,
     validate_file_types_match,
     write_dataset,
@@ -55,11 +56,9 @@ def generate_dataset(
             query_engine_class=query_engine_class,
             environ=environ or {},
         )
-    elif dummy_data_file:
-        pass_dummy_data(variable_definitions, dataset_file, dummy_data_file)
     else:
         generate_dataset_with_dummy_data(
-            variable_definitions, dataset_file, dummy_tables_path
+            variable_definitions, dataset_file, dummy_data_file, dummy_tables_path
         )
 
 
@@ -86,12 +85,16 @@ def generate_dataset_with_dsn(
 
 
 def generate_dataset_with_dummy_data(
-    variable_definitions, dataset_file, dummy_tables_path=None
+    variable_definitions, dataset_file, dummy_data_file=None, dummy_tables_path=None
 ):
     log.info("Generating dummy dataset")
     column_specs = get_column_specs(variable_definitions)
 
-    if dummy_tables_path:
+    if dummy_data_file:
+        log.info(f"Reading dummy data from {dummy_data_file}")
+        reader = read_dataset(dummy_data_file, column_specs)
+        results = iter(reader)
+    elif dummy_tables_path:
         log.info(f"Reading CSV data from {dummy_tables_path}")
         query_engine = CSVQueryEngine(dummy_tables_path)
         results = query_engine.get_results(variable_definitions)

--- a/databuilder/main.py
+++ b/databuilder/main.py
@@ -1,17 +1,11 @@
 import importlib.util
-import shutil
 import sys
 from contextlib import nullcontext
 
 import structlog
 
 from databuilder.dummy_data import DummyDataGenerator
-from databuilder.file_formats import (
-    read_dataset,
-    validate_dataset,
-    validate_file_types_match,
-    write_dataset,
-)
+from databuilder.file_formats import read_dataset, write_dataset
 from databuilder.query_engines.csv import CSVQueryEngine
 from databuilder.query_engines.sqlite import SQLiteQueryEngine
 from databuilder.query_language import Dataset, compile
@@ -115,18 +109,6 @@ def create_dummy_tables(definition_file, dummy_tables_path, user_args):
     dummy_tables_path.parent.mkdir(parents=True, exist_ok=True)
     log.info(f"Writing CSV files to {dummy_tables_path}")
     write_orm_models_to_csv_directory(dummy_tables_path, dummy_tables)
-
-
-def pass_dummy_data(variable_definitions, dataset_file, dummy_data_file):
-    log.info(f"Propagating dummy data from {dummy_data_file}")
-
-    column_specs = get_column_specs(variable_definitions)
-
-    validate_file_types_match(dummy_data_file, dataset_file)
-    validate_dataset(dummy_data_file, column_specs)
-
-    dataset_file.parent.mkdir(parents=True, exist_ok=True)
-    shutil.copyfile(dummy_data_file, dataset_file)
 
 
 def dump_dataset_sql(

--- a/databuilder/query_language.py
+++ b/databuilder/query_language.py
@@ -6,7 +6,7 @@ from collections import ChainMap
 from pathlib import Path
 
 from databuilder.codes import BaseCode
-from databuilder.file_formats import read_dataset, validate_dataset
+from databuilder.file_formats import read_dataset
 from databuilder.query_model import nodes as qm
 from databuilder.query_model.column_specs import get_column_specs_from_schema
 from databuilder.query_model.nodes import get_series_type, has_one_row_per_patient
@@ -772,7 +772,6 @@ def table_from_file(path):
         schema = get_table_schema_from_class(cls)
         column_specs = get_column_specs_from_schema(schema)
 
-        validate_dataset(path, column_specs)
         rows = read_dataset(path, column_specs)
 
         qm_node = qm.InlinePatientTable(

--- a/databuilder/query_model/nodes.py
+++ b/databuilder/query_model/nodes.py
@@ -1,6 +1,6 @@
 import dataclasses
 import typing
-from collections.abc import Iterable, Mapping, Set
+from collections.abc import Iterable, Iterator, Mapping, Set
 from datetime import date
 from enum import Enum
 from functools import cache, singledispatch
@@ -75,6 +75,10 @@ class Position(Enum):
 # iterable of tuples which prevents the query model attempting to reach in any further.
 class IterWrapper(Iterable):
     def __init__(self, iterable: Iterable[tuple]):
+        # Ensure the wrapped object is iterable (i.e. has an `__iter__` method) but is
+        # not an iterator (i.e. has a `__next___` method). It's important that we're
+        # able to iterate over the object multiple times without consuming it.
+        assert isinstance(iterable, Iterable) and not isinstance(iterable, Iterator)
         self.iterable = iterable
 
     def __iter__(self):

--- a/tests/integration/test_file_formats.py
+++ b/tests/integration/test_file_formats.py
@@ -1,12 +1,146 @@
+import datetime
+
 import pytest
 
 from databuilder.file_formats import (
     FILE_FORMATS,
     ValidationError,
+    read_dataset,
     validate_dataset,
     write_dataset,
 )
 from databuilder.query_model.column_specs import ColumnSpec
+from databuilder.sqlalchemy_types import TYPE_MAP
+
+
+TEST_FILE_SPECS = {
+    "patient_id": ColumnSpec(int),
+    "b": ColumnSpec(bool),
+    "i": ColumnSpec(int),
+    "f": ColumnSpec(float),
+    "s": ColumnSpec(str),
+    "c": ColumnSpec(str, categories=("A", "B")),
+    "d": ColumnSpec(datetime.date),
+}
+
+TEST_FILE_DATA = [
+    (123, True, 1, 2.3, "a", "A", datetime.date(2020, 1, 1)),
+    (456, False, -5, -0.4, "b", "B", datetime.date(2022, 12, 31)),
+    (789, None, None, None, None, None, None),
+]
+
+
+def test_all_types_are_covered_in_test():
+    types = [spec.type for spec in TEST_FILE_SPECS.values()]
+    assert set(types) == set(TYPE_MAP)
+
+
+# Generate a test file for each of the file formats we support. This is a session-scoped
+# fixture so we generate each file once and then use it across multiple tests.
+@pytest.fixture(params=list(FILE_FORMATS.keys()), scope="session")
+def test_file(request, tmp_path_factory):
+    # We have to use `tmp_path_factory` rather than the usual `tmp_path` because the latter
+    # is function-scoped and we need a session-scoped fixture
+    tmp_path = tmp_path_factory.mktemp("test_file_formats")
+    extension = request.param
+    filename = tmp_path / f"dataset{extension}"
+    write_dataset(filename, TEST_FILE_DATA, TEST_FILE_SPECS)
+    yield filename
+
+
+def test_read_and_write_dataset_roundtrip(test_file):
+    # Basic test that we can read what we've written
+    with read_dataset(test_file, TEST_FILE_SPECS) as reader:
+        results = list(reader)
+    assert results == TEST_FILE_DATA
+
+
+def test_read_dataset_with_a_subset_of_columns(test_file):
+    # Read a subset of the original columns and in a different order
+    column_specs = {
+        "patient_id": ColumnSpec(int),
+        "s": ColumnSpec(str),
+        "i": ColumnSpec(int),
+    }
+    with read_dataset(test_file, column_specs) as reader:
+        results = list(reader)
+
+    original_columns = list(TEST_FILE_SPECS.keys())
+    patient_id_index = original_columns.index("patient_id")
+    s_index = original_columns.index("s")
+    i_index = original_columns.index("i")
+    expected = [
+        (row[patient_id_index], row[s_index], row[i_index]) for row in TEST_FILE_DATA
+    ]
+
+    assert results == expected
+
+
+def test_read_dataset_can_be_iterated_multiple_times(test_file):
+    with read_dataset(test_file, TEST_FILE_SPECS) as reader:
+        # Each time we iterate `reader` we should get the full contents of the file
+        results_1 = list(reader)
+        results_2 = list(reader)
+    assert results_1 == TEST_FILE_DATA
+    assert results_2 == TEST_FILE_DATA
+
+
+def test_read_dataset_validates_on_open(test_file):
+    # We should get a ValidationEror (because the columns don't match) immediately on
+    # opening the file, even if we don't try to read any rows from it
+    with pytest.raises(ValidationError):
+        read_dataset(test_file, {"wrong_column": ColumnSpec(int)})
+
+
+def test_read_dataset_validates_columns(test_file):
+    # Create a copy of the column specs with extra columns
+    column_specs = TEST_FILE_SPECS.copy()
+    column_specs["extra_column_1"] = ColumnSpec(int)
+    column_specs["extra_column_2"] = ColumnSpec(int)
+
+    with pytest.raises(
+        ValidationError,
+        match=("Missing columns: extra_column_1, extra_column_2"),
+    ):
+        read_dataset(test_file, column_specs)
+
+
+def test_read_dataset_validates_types(test_file):
+    # Create a copy of the column specs with a modified column type
+    column_specs = TEST_FILE_SPECS.copy()
+    column_specs["s"] = ColumnSpec(int)
+
+    # The errors are different here because with Arrow we can validate the schema but
+    # with CSV we can only validate individual values
+    errors = {
+        "dataset.arrow": "expected <class 'int'>, got string",
+        "dataset.csv": "invalid literal for int",
+        "dataset.csv.gz": "invalid literal for int",
+    }
+
+    with pytest.raises(ValidationError, match=errors[test_file.name]):
+        read_dataset(test_file, column_specs)
+
+
+def test_read_dataset_validates_categories(test_file):
+    # Create a copy of the column specs with modified column categories
+    column_specs = TEST_FILE_SPECS.copy()
+    column_specs["c"] = ColumnSpec(str, categories=("X", "Y"))
+
+    # The errors are different here because with Arrow we can validate the categories in
+    # the schema but with CSV we can only validate individual values
+    errors = {
+        "dataset.arrow": (
+            "Unexpected categories in column 'c'\n"
+            "  Categories: A, B\n"
+            "  Expected: X, Y"
+        ),
+        "dataset.csv": "'A' not in valid categories: 'X', 'Y'",
+        "dataset.csv.gz": "'A' not in valid categories: 'X', 'Y'",
+    }
+
+    with pytest.raises(ValidationError, match=errors[test_file.name]):
+        read_dataset(test_file, column_specs)
 
 
 @pytest.mark.parametrize("extension", list(FILE_FORMATS.keys()))

--- a/tests/integration/test_file_formats.py
+++ b/tests/integration/test_file_formats.py
@@ -6,7 +6,6 @@ from databuilder.file_formats import (
     FILE_FORMATS,
     ValidationError,
     read_dataset,
-    validate_dataset,
     write_dataset,
 )
 from databuilder.query_model.column_specs import ColumnSpec
@@ -141,78 +140,3 @@ def test_read_dataset_validates_categories(test_file):
 
     with pytest.raises(ValidationError, match=errors[test_file.name]):
         read_dataset(test_file, column_specs)
-
-
-@pytest.mark.parametrize("extension", list(FILE_FORMATS.keys()))
-def test_write_and_validate_dataset_happy_path(tmp_path, extension):
-    filename = tmp_path / f"dataset{extension}"
-    column_specs = {
-        "patient_id": ColumnSpec(int),
-        "year_of_birth": ColumnSpec(int),
-        "category": ColumnSpec(str, categories=("a", "b")),
-    }
-    results = [
-        (123, 1980, "a"),
-        (456, 1999, "b"),
-    ]
-    write_dataset(filename, results, column_specs)
-
-    validate_dataset(filename, column_specs)
-
-
-@pytest.mark.parametrize("extension", list(FILE_FORMATS.keys()))
-def test_validate_dataset_type_mismatch(tmp_path, extension):
-    filename = tmp_path / f"dataset{extension}"
-    column_specs_1 = {
-        "patient_id": ColumnSpec(int),
-        "sex": ColumnSpec(str),
-    }
-    results = [
-        (123, "F"),
-        (456, "M"),
-    ]
-    write_dataset(filename, results, column_specs_1)
-
-    # Create another set of columns with the same names but different types, and check
-    # that the file *doesn't* validate against this
-    column_specs_2 = {
-        "patient_id": ColumnSpec(int),
-        "sex": ColumnSpec(int),
-    }
-
-    errors = {
-        ".arrow": "File does not have expected schema",
-        ".csv": "invalid literal for int",
-        ".csv.gz": "invalid literal for int",
-    }
-
-    with pytest.raises(ValidationError, match=errors[extension]):
-        validate_dataset(filename, column_specs_2)
-
-
-@pytest.mark.parametrize("extension", list(FILE_FORMATS.keys()))
-def test_validate_dataset_category_mismatch(tmp_path, extension):
-    filename = tmp_path / f"dataset{extension}"
-    column_specs_1 = {
-        "patient_id": ColumnSpec(int),
-        "category": ColumnSpec(str, categories=("a", "b")),
-    }
-    results = [
-        (123, "a"),
-        (456, "b"),
-    ]
-    write_dataset(filename, results, column_specs_1)
-
-    column_specs_2 = {
-        "patient_id": ColumnSpec(int),
-        "category": ColumnSpec(str, categories=("x", "y")),
-    }
-
-    errors = {
-        ".arrow": "Unexpected categories in column 'category'",
-        ".csv": "'a' not in valid categories: 'x', 'y'",
-        ".csv.gz": "'a' not in valid categories: 'x', 'y'",
-    }
-
-    with pytest.raises(ValidationError, match=errors[extension]):
-        validate_dataset(filename, column_specs_2)

--- a/tests/unit/file_formats/test_arrow.py
+++ b/tests/unit/file_formats/test_arrow.py
@@ -2,9 +2,9 @@ import pyarrow
 import pytest
 
 from databuilder.file_formats.arrow import (
+    ArrowDatasetReader,
     batch_and_transpose,
     get_schema_and_convertor,
-    read_dataset_arrow,
     smallest_int_type_for_range,
 )
 from databuilder.query_model.column_specs import ColumnSpec
@@ -84,6 +84,8 @@ def test_read_dataset_arrow(tmp_path):
     input_table = pyarrow.Table.from_pylist([dict(zip(columns, f)) for f in file_data])
     pyarrow.feather.write_feather(input_table, str(path), compression="zstd")
 
-    lines = list(read_dataset_arrow(path))
+    column_specs = {"patient_id": ColumnSpec(int), "n": ColumnSpec(int)}
+    with ArrowDatasetReader(path, column_specs) as reader:
+        lines = list(reader)
 
     assert lines == file_data

--- a/tests/unit/file_formats/test_csv.py
+++ b/tests/unit/file_formats/test_csv.py
@@ -1,5 +1,4 @@
 import datetime
-import gzip
 from io import StringIO
 
 import pytest
@@ -7,55 +6,11 @@ import pytest
 from databuilder.file_formats.csv import (
     ValidationError,
     create_column_parser,
-    read_dataset_csv,
-    read_dataset_csv_gz,
     read_dataset_csv_lines,
     write_dataset_csv_lines,
 )
 from databuilder.query_model.column_specs import ColumnSpec
 from databuilder.sqlalchemy_types import TYPE_MAP
-
-
-CSV_READ_PARAMS = (
-    "csv,error",
-    [
-        # Happy path (with allowed null)
-        (
-            "patient_id,age\n1,65\n2,",
-            None,
-        ),
-        # Null in non-nullable colum
-        (
-            "patient_id,age\n1,65\n,25",
-            "row 2: NULL value in non-nullable column 'patient_id'",
-        ),
-        # Wrong headers
-        (
-            "patient_id,oldness_score\n1,65",
-            "Missing columns",
-        ),
-        # Invalid type
-        (
-            "patient_id,age\n1,sixty",
-            "row 1: column 'age': invalid literal for int",
-        ),
-        # Too many columns
-        (
-            "patient_id,age\n1,65,0",
-            "row 1: expected 2 columns but got 3",
-        ),
-        # Too few columns
-        (
-            "patient_id,age\n1",
-            "row 1: expected 2 columns but got 1",
-        ),
-    ],
-)
-
-COLUMN_SPECS = {
-    "patient_id": ColumnSpec(int, nullable=False),
-    "age": ColumnSpec(int, nullable=True),
-}
 
 
 @pytest.mark.parametrize(
@@ -93,49 +48,56 @@ def test_write_dataset_csv_lines_params_are_exhaustive():
     assert set(types) == set(TYPE_MAP)
 
 
-def validate_test_csv(lines, error):
+@pytest.mark.parametrize(
+    "csv,error",
+    [
+        # Happy path (with allowed null)
+        (
+            "patient_id,age\n1,65\n2,",
+            None,
+        ),
+        # Null in non-nullable colum
+        (
+            "patient_id,age\n1,65\n,25",
+            "row 2: NULL value in non-nullable column 'patient_id'",
+        ),
+        # Wrong headers
+        (
+            "patient_id,oldness_score\n1,65",
+            "Missing columns",
+        ),
+        # Invalid type
+        (
+            "patient_id,age\n1,sixty",
+            "row 1: column 'age': invalid literal for int",
+        ),
+        # Too many columns
+        (
+            "patient_id,age\n1,65,0",
+            "row 1: expected 2 columns but got 3",
+        ),
+        # Too few columns
+        (
+            "patient_id,age\n1",
+            "row 1: expected 2 columns but got 1",
+        ),
+    ],
+)
+def test_read_dataset_csv_lines(csv, error):
+    specs = {
+        "patient_id": ColumnSpec(int, nullable=False),
+        "age": ColumnSpec(int, nullable=True),
+    }
+    csv_file = iter(csv.splitlines(keepends=True))
+
+    # ValidationErrors won't be raised until we consume the iterator
+    lines = read_dataset_csv_lines(csv_file, specs)
+
     if error is None:
         list(lines)
     else:
         with pytest.raises(ValidationError, match=error):
             list(lines)
-
-
-@pytest.mark.parametrize(*CSV_READ_PARAMS)
-def test_read_dataset_csv_lines(csv, error):
-    csv_file = iter(csv.splitlines(keepends=True))
-
-    # ValidationErrors won't be raised until we consume the iterator
-    lines = read_dataset_csv_lines(csv_file, COLUMN_SPECS)
-
-    validate_test_csv(lines, error)
-
-
-@pytest.mark.parametrize(*CSV_READ_PARAMS)
-def test_read_dataset_csv(csv, error, tmp_path):
-    # Use same test parameters and expectations as test_read_dataset_csv_lines()
-    # to ensure same results regardless of whether data read from string or file
-    csv_path = tmp_path / "input.csv"
-    with csv_path.open("w") as f:
-        f.write(csv)
-    # ValidationErrors won't be raised until we consume the iterator
-    lines = read_dataset_csv(csv_path, COLUMN_SPECS)
-
-    validate_test_csv(lines, error)
-
-
-@pytest.mark.parametrize(*CSV_READ_PARAMS)
-def test_read_dataset_csv_gz(csv, error, tmp_path):
-    # Use same test parameters and expectations as test_read_dataset_csv_lines()
-    # to ensure same results regardless of whether data read from string or file
-    csv_gz_path = tmp_path / "input.csv.gz"
-    with gzip.open(csv_gz_path, "wt", newline="", compresslevel=6) as f:
-        f.write(csv)
-
-    # ValidationErrors won't be raised until we consume the iterator
-    lines = read_dataset_csv_gz(csv_gz_path, COLUMN_SPECS)
-
-    validate_test_csv(lines, error)
 
 
 @pytest.mark.parametrize(
@@ -175,7 +137,12 @@ def test_read_dataset_csv_gz(csv, error, tmp_path):
         ),
         ("2021-2-2", ColumnSpec(datetime.date), None, "Invalid isoformat string"),
         # Categoricals
-        ("foo", ColumnSpec(str, categories=("foo", "bar")), "foo", None),
+        (
+            "foo",
+            ColumnSpec(str, categories=("foo", "bar")),
+            "foo",
+            None,
+        ),
         (
             "baz",
             ColumnSpec(str, categories=("foo", "bar")),

--- a/tests/unit/file_formats/test_csv.py
+++ b/tests/unit/file_formats/test_csv.py
@@ -4,9 +4,9 @@ from io import StringIO
 import pytest
 
 from databuilder.file_formats.csv import (
+    CSVDatasetReader,
     ValidationError,
     create_column_parser,
-    read_dataset_csv_lines,
     write_dataset_csv_lines,
 )
 from databuilder.query_model.column_specs import ColumnSpec
@@ -88,16 +88,13 @@ def test_read_dataset_csv_lines(csv, error):
         "patient_id": ColumnSpec(int, nullable=False),
         "age": ColumnSpec(int, nullable=True),
     }
-    csv_file = iter(csv.splitlines(keepends=True))
-
-    # ValidationErrors won't be raised until we consume the iterator
-    lines = read_dataset_csv_lines(csv_file, specs)
+    csv_file = StringIO(csv)
 
     if error is None:
-        list(lines)
+        CSVDatasetReader(csv_file, specs).close()
     else:
         with pytest.raises(ValidationError, match=error):
-            list(lines)
+            CSVDatasetReader(csv_file, specs)
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/file_formats/test_validation.py
+++ b/tests/unit/file_formats/test_validation.py
@@ -1,29 +1,6 @@
 import pytest
 
-from databuilder.file_formats.validation import (
-    ValidationError,
-    validate_columns,
-    validate_headers,
-)
-
-
-@pytest.mark.parametrize(
-    "headers,error",
-    [
-        (["foo", "bar", "baz"], None),
-        (["foo", "baz"], r"Missing columns"),
-        (["foo", "bar", "baz", "boo"], r"Unexpected columns"),
-        (["bar", "baz", "boo"], r"Missing columns[\s\S]*Unexpected columns"),
-        (["foo", "baz", "bar"], r"Headers not in expected order"),
-    ],
-)
-def test_validate_headers(headers, error):
-    expected = ["foo", "bar", "baz"]
-    if error is None:
-        validate_headers(headers, expected)
-    else:
-        with pytest.raises(ValidationError, match=error):
-            validate_headers(headers, expected)
+from databuilder.file_formats.validation import ValidationError, validate_columns
 
 
 def test_validate_columns():

--- a/tests/unit/file_formats/test_validation.py
+++ b/tests/unit/file_formats/test_validation.py
@@ -1,6 +1,10 @@
 import pytest
 
-from databuilder.file_formats.validation import ValidationError, validate_headers
+from databuilder.file_formats.validation import (
+    ValidationError,
+    validate_columns,
+    validate_headers,
+)
 
 
 @pytest.mark.parametrize(
@@ -20,3 +24,11 @@ def test_validate_headers(headers, error):
     else:
         with pytest.raises(ValidationError, match=error):
             validate_headers(headers, expected)
+
+
+def test_validate_columns():
+    # Column order is not significant, neither is the presence of additional columns so
+    # long as all required columns are present
+    validate_columns(["a", "b", "c", "d"], ["c", "b", "a"])
+    with pytest.raises(ValidationError, match="Missing columns: b, d"):
+        validate_columns(["c", "a"], ["a", "b", "c", "d"])

--- a/tests/unit/query_model/test_nodes.py
+++ b/tests/unit/query_model/test_nodes.py
@@ -143,7 +143,7 @@ def test_inline_patient_table():
     assert hash(inline_table)
 
     # Check that the repr still round-trips. To do this we have to compare the
-    # _contents_ of the iterators, rather than the identity of the wrappers.
+    # _contents_ of the iterables, rather than the identity of the wrappers.
     round_tripped = eval(repr(inline_table))
     assert list(round_tripped.rows) == list(inline_table.rows)
     assert round_tripped.schema == inline_table.schema
@@ -163,6 +163,15 @@ def test_inline_patient_table():
             rows=IterWrapper([(1)]),
             schema=TableSchema(patient_id=int),
         )
+
+
+def test_iterwrapper_rejects_iterators():
+    rows = [(1, 2), (3, 4)]
+    # IterWrapper accepts an iterable
+    assert IterWrapper(rows)
+    with pytest.raises(AssertionError):
+        # But rejects an iterator
+        IterWrapper(iter(rows))
 
 
 # TEST DOMAIN VALIDATION

--- a/tests/unit/test_file_formats.py
+++ b/tests/unit/test_file_formats.py
@@ -2,35 +2,7 @@ from pathlib import Path
 
 import pytest
 
-from databuilder.file_formats import (
-    ValidationError,
-    get_file_extension,
-    read_dataset,
-    validate_dataset,
-    validate_file_types_match,
-)
-
-
-@pytest.mark.parametrize(
-    "a,b,matches",
-    [
-        ("testfile.feather", "other.feather", True),
-        ("testfile.csv.gz", "other.csv.gz", True),
-        ("testfile.dta", "testfile.dta.gz", False),
-        ("testfile.csv", "testfile.tsv", False),
-    ],
-)
-def test_validate_file_types_match(a, b, matches):
-    path_a = Path(a)
-    path_b = Path(b)
-    if matches:
-        validate_file_types_match(path_a, path_b)
-    else:
-        with pytest.raises(
-            ValidationError,
-            match="Dummy data file does not have the same file extension",
-        ):
-            validate_file_types_match(path_a, path_b)
+from databuilder.file_formats import ValidationError, get_file_extension, read_dataset
 
 
 @pytest.mark.parametrize(
@@ -56,19 +28,3 @@ def test_read_dataset_raises_error_for_missing_files():
     missing_file = Path(__file__).parent / "no_such_file.csv"
     with pytest.raises(ValidationError, match=f"Missing file: {missing_file}"):
         read_dataset(missing_file, {})
-
-
-def test_validate_dataset_rejects_unknown_filetypes(tmp_path):
-    # create empty file with unrecognised extension
-    bad_file_extension_path = tmp_path / "foo.xyz"
-    with bad_file_extension_path.open("w") as f:
-        f.write("")
-    with pytest.raises(ValueError, match="Loading from .xyz files not supported"):
-        validate_dataset(bad_file_extension_path, None)
-
-
-def test_validate_dataset_raises_error_on_unknown_path(tmp_path):
-    # file has acceptable extension but does not exist
-    nonexistent_path = tmp_path / "file.csv"
-    with pytest.raises(FileNotFoundError, match=f"{nonexistent_path} not found"):
-        validate_dataset(nonexistent_path, None)

--- a/tests/unit/test_file_formats.py
+++ b/tests/unit/test_file_formats.py
@@ -5,6 +5,7 @@ import pytest
 from databuilder.file_formats import (
     ValidationError,
     get_file_extension,
+    read_dataset,
     validate_dataset,
     validate_file_types_match,
 )
@@ -44,6 +45,17 @@ def test_validate_file_types_match(a, b, matches):
 )
 def test_get_file_extension(filename, extension):
     assert get_file_extension(filename) == extension
+
+
+def test_read_dataset_rejects_unsupported_file_types():
+    with pytest.raises(ValidationError, match="Unsupported file type: .xyz"):
+        read_dataset(Path("some_file.xyz"), {})
+
+
+def test_read_dataset_raises_error_for_missing_files():
+    missing_file = Path(__file__).parent / "no_such_file.csv"
+    with pytest.raises(ValidationError, match=f"Missing file: {missing_file}"):
+        read_dataset(missing_file, {})
 
 
 def test_validate_dataset_rejects_unknown_filetypes(tmp_path):

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -46,7 +46,7 @@ def test_generate_dataset_dsn_arg(mock_load_and_compile):
 
 
 def test_generate_dataset_dummy_data_file_arg(mock_load_and_compile):
-    with mock.patch("databuilder.main.pass_dummy_data") as p:
+    with mock.patch("databuilder.main.generate_dataset_with_dummy_data") as p:
         generate_dataset(
             Path("dataset_definition.py"),
             Path("results.csv"),


### PR DESCRIPTION
The primary motivation here was to allow `InlinePatientTable` nodes to work with the forthcoming measures system, which requires that queries be executable multiple times. The previous `read_dataset_X` functions returned iterators which were exhausted on the first read.

However, the reworked code gives us the opportunity to take a different approach with user-supplied dummy data. Instead of validating this data and then copying it across unmodified, we now read it in and then write it out again using the same code paths as used in production. This gives us better parity with production while simultaneously allowing us to be more relaxed about the data we accept and throw away various bits of validation code.