### PR TITLE
feat: Tag newly built images as ehrql as well as databuilder

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -16,6 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       image: ghcr.io/opensafely-core/databuilder
+      aliased_image: ghcr.io/opensafely-core/ehrql
     steps:
       - uses: actions/checkout@v3
         with:
@@ -104,7 +105,10 @@ jobs:
             --target databuilder \
             --tag ${{ env.image }}:$MAJOR \
             --tag ${{ env.image }}:$MINOR \
-            --tag ${{ env.image }}:$PATCH
+            --tag ${{ env.image }}:$PATCH \
+            --tag ${{ env.aliased_image }}:$MAJOR \
+            --tag ${{ env.aliased_image }}:$MINOR \
+            --tag ${{ env.aliased_image }}:$PATCH
 
       - name: Log into GitHub Container Registry
         if: ${{ startsWith(steps.taggedcommit.outputs.tag, 'y') }}


### PR DESCRIPTION
This means that we can use `ehrql:v0` in project.yaml and `opensafely exec` in advance of the full renaming work.

Will also require (in this order): 
- update to job-runner: https://github.com/opensafely-core/job-runner/pull/606
- update to the vendored jobrunner in https://github.com/opensafely-core/opensafely-cli 