### PR TITLE
fix: User-friendly error message for variables with leading underscore

### DIFF
--- a/databuilder/query_language.py
+++ b/databuilder/query_language.py
@@ -2,6 +2,7 @@ import dataclasses
 import datetime
 import enum
 import functools
+import re
 from collections import ChainMap
 from pathlib import Path
 
@@ -13,6 +14,8 @@ from databuilder.query_model.nodes import get_series_type, has_one_row_per_patie
 from databuilder.query_model.population_validation import validate_population_definition
 from databuilder.utils import date_utils
 
+
+VALID_VARIABLE_NAME_RE = re.compile(r"^[A-Za-z0-9_]+$")
 
 # This gets populated by the `__init_subclass__` methods of EventSeries and
 # PatientSeries. Its structure is:
@@ -54,6 +57,10 @@ class Dataset:
         if name.startswith("_"):
             raise AttributeError(
                 f"Variable names must not start with underscores (you defined a variable '{name}')"
+            )
+        if not VALID_VARIABLE_NAME_RE.match(name):
+            raise AttributeError(
+                f"Variable names must only contain alphanumeric characters and underscores (you defined a variable '{name}')"
             )
         if not isinstance(value, BaseSeries):
             raise TypeError(

--- a/databuilder/query_language.py
+++ b/databuilder/query_language.py
@@ -51,7 +51,7 @@ class Dataset:
             raise AttributeError(f"'{name}' is already set and cannot be reassigned")
         if name == "variables":
             raise AttributeError("'variables' is not an allowed variable name")
-        if name.startswith("__"):
+        if name.startswith("_"):
             raise AttributeError(
                 f"Variable names must not start with underscores (you defined a variable '{name}')"
             )

--- a/databuilder/query_language.py
+++ b/databuilder/query_language.py
@@ -15,7 +15,7 @@ from databuilder.query_model.population_validation import validate_population_de
 from databuilder.utils import date_utils
 
 
-VALID_VARIABLE_NAME_RE = re.compile(r"^[A-Za-z0-9_]+$")
+VALID_VARIABLE_NAME_RE = re.compile(r"^[A-Za-z]+[A-Za-z0-9_]*$")
 
 # This gets populated by the `__init_subclass__` methods of EventSeries and
 # PatientSeries. Its structure is:
@@ -54,13 +54,9 @@ class Dataset:
             raise AttributeError(f"'{name}' is already set and cannot be reassigned")
         if name == "variables":
             raise AttributeError("'variables' is not an allowed variable name")
-        if name.startswith("_"):
-            raise AttributeError(
-                f"Variable names must not start with underscores (you defined a variable '{name}')"
-            )
         if not VALID_VARIABLE_NAME_RE.match(name):
             raise AttributeError(
-                f"Variable names must only contain alphanumeric characters and underscores (you defined a variable '{name}')"
+                f"Variable names must start with a letter, and contain only alphanumeric characters and underscores (you defined a variable '{name}')"
             )
         if not isinstance(value, BaseSeries):
             raise TypeError(

--- a/tests/unit/test_query_language.py
+++ b/tests/unit/test_query_language.py
@@ -149,7 +149,12 @@ def test_cannot_define_variable_names_with_invalid_characters():
         setattr(Dataset(), "something!", patients.exists_for_patient())
 
 
-@pytest.mark.parametrize("name", ["foo", "Foo", "f", "f_oo", "1f", "f1"])
+def test_cannot_define_variable_names_starting_with_numbers():
+    with pytest.raises(AttributeError, match="alphanumeric"):
+        setattr(Dataset(), "1f", patients.exists_for_patient())
+
+
+@pytest.mark.parametrize("name", ["foo", "Foo", "f", "f_oo", "f1"])
 def test_allowed_variable_names(name):
     setattr(Dataset(), name, patients.exists_for_patient())
 

--- a/tests/unit/test_query_language.py
+++ b/tests/unit/test_query_language.py
@@ -144,6 +144,16 @@ def test_cannot_define_variable_names_starting_with_double_underscores():
         Dataset().__something = patients.exists_for_patient()
 
 
+def test_cannot_define_variable_names_with_invalid_characters():
+    with pytest.raises(AttributeError, match="alphanumeric"):
+        setattr(Dataset(), "something!", patients.exists_for_patient())
+
+
+@pytest.mark.parametrize("name", ["foo", "Foo", "f", "f_oo", "1f", "f1"])
+def test_allowed_variable_names(name):
+    setattr(Dataset(), name, patients.exists_for_patient())
+
+
 def test_accessing_unassigned_variable_gives_helpful_error():
     with pytest.raises(AttributeError, match="'foo' has not been defined"):
         Dataset().foo

--- a/tests/unit/test_query_language.py
+++ b/tests/unit/test_query_language.py
@@ -134,6 +134,11 @@ def test_cannot_define_variable_called_variables():
         Dataset().variables = patients.exists_for_patient()
 
 
+def test_cannot_define_variable_names_starting_with_single_underscores():
+    with pytest.raises(AttributeError, match="underscore"):
+        Dataset()._something = patients.exists_for_patient()
+
+
 def test_cannot_define_variable_names_starting_with_double_underscores():
     with pytest.raises(AttributeError, match="underscore"):
         Dataset().__something = patients.exists_for_patient()


### PR DESCRIPTION
Fixes #1217 