### PR TITLE
fix: Validate that a population has been defined

### DIFF
--- a/databuilder/query_language.py
+++ b/databuilder/query_language.py
@@ -75,7 +75,12 @@ class Dataset:
 
 
 def compile(dataset):  # noqa A003
-    return {k: v.qm_node for k, v in dataset.variables.items()}
+    compiled = {k: v.qm_node for k, v in dataset.variables.items()}
+    if "population" not in compiled:
+        raise AttributeError(
+            "A population has not been defined; define one with define_population()"
+        )
+    return compiled
 
 
 # BASIC SERIES TYPES

--- a/tests/unit/test_query_language.py
+++ b/tests/unit/test_query_language.py
@@ -107,6 +107,13 @@ def test_dataset_preserves_variable_order():
     assert variables == ["population", "foo", "baz", "bar"]
 
 
+def test_population_must_be_defined():
+    dataset = Dataset()
+    dataset.foo = patients.date_of_birth.year
+    with pytest.raises(AttributeError, match="population has not been defined"):
+        compile(dataset)
+
+
 def test_assign_population_variable():
     with pytest.raises(AttributeError, match="Cannot set variable 'population'"):
         Dataset().population = patients.exists_for_patient()


### PR DESCRIPTION
Fixes #1216 