### PR TITLE
fix: Move `patient_id` check to TableSchema

### DIFF
--- a/databuilder/query_model/nodes.py
+++ b/databuilder/query_model/nodes.py
@@ -203,12 +203,6 @@ class InlinePatientTable(OneRowPerPatientFrame):
     rows: Iterable[tuple]
     schema: TableSchema
 
-    def __post_init__(self):
-        assert (
-            "patient_id" not in self.schema.column_names
-        ), "patient_id is implicitly included and must not be explicitly specified"
-        return super().__post_init__()
-
 
 class SelectColumn(Series):
     source: Frame

--- a/databuilder/query_model/table_schema.py
+++ b/databuilder/query_model/table_schema.py
@@ -92,6 +92,11 @@ class TableSchema:
         return cls(**{name: Column(type_) for name, type_ in kwargs.items()})
 
     def __init__(self, **kwargs):
+        if "patient_id" in kwargs:
+            raise ValueError(
+                "`patient_id` is an implicitly included column on every table "
+                "and must not be explicitly specified"
+            )
         self.schema = kwargs
 
     def __eq__(self, other):

--- a/tests/unit/query_model/test_nodes.py
+++ b/tests/unit/query_model/test_nodes.py
@@ -153,17 +153,6 @@ def test_inline_patient_table():
     i = SelectColumn(inline_table, "i")
     assert get_series_type(i) == int
 
-    # Check that attempting to construct an InlinePatientTable with an explicit definition
-    # for patient_id throws an error
-    with pytest.raises(
-        AssertionError,
-        match="patient_id is implicitly included and must not be explicitly specified",
-    ):
-        InlinePatientTable(
-            rows=IterWrapper([(1)]),
-            schema=TableSchema(patient_id=int),
-        )
-
 
 def test_iterwrapper_rejects_iterators():
     rows = [(1, 2), (3, 4)]

--- a/tests/unit/query_model/test_table_schema.py
+++ b/tests/unit/query_model/test_table_schema.py
@@ -44,6 +44,17 @@ def test_from_primitives():
     assert t1 == t2
 
 
+def test_table_schema_rejects_patient_id_column():
+    with pytest.raises(
+        ValueError,
+        match=(
+            "`patient_id` is an implicitly included column on every table and"
+            " must not be explicitly specified"
+        ),
+    ):
+        TableSchema(patient_id=Column(int))
+
+
 def test_get_column():
     schema = TableSchema(i=Column(int))
     assert schema.get_column("i") == Column(int)


### PR DESCRIPTION
It's not valid to use `patient_id` as a column on any sort of table, so it makes sense to validate it at the TableSchema level rather than on a particular node type.

And given that this is potentially a user-facing, rather than just a devloper-facing, error we should raise an exception rather than using `assert`.