### PR TITLE
Fix: support first_/last_for_patient in sandbox

### DIFF
--- a/ehrql/query_engines/in_memory.py
+++ b/ehrql/query_engines/in_memory.py
@@ -111,12 +111,15 @@ class InMemoryQueryEngine(BaseQueryEngine):
         sort_index = self.visit(node.sort_by).sort_index()
         return source.sort(sort_index)
 
-    def visit_PickOneRowPerPatientWithColumns(self, node):
+    def visit_PickOneRowPerPatient(self, node):
         ix = {
             qm.Position.FIRST: 0,
             qm.Position.LAST: -1,
         }[node.position]
         return self.visit(node.source).pick_at_index(ix)
+
+    def visit_PickOneRowPerPatientWithColumns(self, node):
+        return self.visit_PickOneRowPerPatient(node)
 
     def visit_Exists(self, node):
         return self.visit(node.source).exists()

--- a/tests/unit/query_engines/test_in_memory.py
+++ b/tests/unit/query_engines/test_in_memory.py
@@ -13,7 +13,7 @@ class events(EventFrame):
 
 def test_pick_one_row_per_patient():
     # This test verifies that picking one row per patient works without first having
-    # applied QM transformations to all variables ina dataset.
+    # applied QM transformations to all variables in a dataset.
     database = InMemoryDatabase()
     database.setup(make_orm_models({events: [{"patient_id": 1, "date": "2023-01-01"}]}))
     engine = InMemoryQueryEngine(database)

--- a/tests/unit/query_engines/test_in_memory.py
+++ b/tests/unit/query_engines/test_in_memory.py
@@ -1,0 +1,22 @@
+from datetime import date
+
+from ehrql.query_engines.in_memory import InMemoryQueryEngine
+from ehrql.query_engines.in_memory_database import InMemoryDatabase
+from ehrql.query_language import EventFrame, Series, table
+from ehrql.utils.orm_utils import make_orm_models
+
+
+@table
+class events(EventFrame):
+    date = Series(date)
+
+
+def test_pick_one_row_per_patient():
+    # This test verifies that picking one row per patient works without first having
+    # applied QM transformations to all variables ina dataset.
+    database = InMemoryDatabase()
+    database.setup(make_orm_models({events: [{"patient_id": 1, "date": "2023-01-01"}]}))
+    engine = InMemoryQueryEngine(database)
+    engine.cache = {}
+    frame = events.sort_by(events.date).first_for_patient()
+    engine.visit(frame.qm_node)


### PR DESCRIPTION
Most sandbox queries exercise code that is already well tested. However, because sandbox queries aren't always attached to a dataset, QM transformations are not applied.  In the case of picking one row per patient, this means that a PickOneRowPerPatient node won't have been transformed to a PickOneRowPerPatientWithColumns node.