### PR TITLE
Reduce example count for long-running generative tests

### DIFF
--- a/.github/workflows/generative-tests.yml
+++ b/.github/workflows/generative-tests.yml
@@ -17,7 +17,7 @@ jobs:
           install-just: true
           python-version: "3.11"
       - run: |
-          GENTEST_EXAMPLES=40000 \
+          GENTEST_EXAMPLES=20000 \
           GENTEST_COMPREHENSIVE=t \
           GENTEST_DEBUG=t \
           GENTEST_CHECK_IGNORED_ERRORS=t \


### PR DESCRIPTION
Until we have time to dig into #1242 properly we're hoping that reducing the number of examples will avoid triggering the issue while still getting us value from the generative tests.

If this doesn't work we'll try halving them again (to 10,000) but it's probably not worth going much further than that.