### PR TITLE
Try reducing generative test examples even further

### DIFF
--- a/.github/workflows/generative-tests.yml
+++ b/.github/workflows/generative-tests.yml
@@ -17,7 +17,7 @@ jobs:
           install-just: true
           python-version: "3.11"
       - run: |
-          GENTEST_EXAMPLES=20000 \
+          GENTEST_EXAMPLES=10000 \
           GENTEST_COMPREHENSIVE=t \
           GENTEST_DEBUG=t \
           GENTEST_CHECK_IGNORED_ERRORS=t \


### PR DESCRIPTION
The change in #1243 did seem to prevent the issue described in #1242 from recurring, but the tests ran for so long that they exceeded the 6 hour time limt and Github killed them. See:
https://github.com/opensafely-core/ehrql/actions/runs/4869287946

Let's try halving the number of examples again.