### PR TITLE
Update TPP schema to include OpenPROMPT tables

### DIFF
--- a/tests/lib/tpp_schema.csv
+++ b/tests/lib/tpp_schema.csv
@@ -1,4 +1,11 @@
 DataSource,TableName,ColumnName,ColumnType,Precision,Scale,MaxLength,IsNullable
+Airmid,OpenPROMPT,CodedEvent_ID,varchar,0,0,50,False
+Airmid,OpenPROMPT,CodeSystemId,int,10,0,4,False
+Airmid,OpenPROMPT,ConceptId,varchar,0,0,50,True
+Airmid,OpenPROMPT,Consultation_ID,bigint,19,0,8,False
+Airmid,OpenPROMPT,ConsultationDate,datetime,23,3,8,False
+Airmid,OpenPROMPT,NumericValue,real,24,0,4,False
+Airmid,OpenPROMPT,Patient_ID,int,10,0,4,False
 ICNARC,ICNARC,AdvancedDays_CardiovascularSupport,int,10,0,4,True
 ICNARC,ICNARC,AdvancedDays_RespiratorySupport,int,10,0,4,True
 ICNARC,ICNARC,ahsurv,int,10,0,4,True

--- a/tests/lib/tpp_schema.py
+++ b/tests/lib/tpp_schema.py
@@ -2892,6 +2892,19 @@ class OPA_Proc(Base):
     Procedure_Code_2_Read = mapped_column(t.VARCHAR(5))
 
 
+class OpenPROMPT(Base):
+    __tablename__ = "OpenPROMPT"
+    _pk = mapped_column(t.Integer, primary_key=True)
+
+    Patient_ID = mapped_column(t.Integer)
+    CodeSystemId = mapped_column(t.Integer)
+    CodedEvent_ID = mapped_column(t.VARCHAR(50))
+    ConceptId = mapped_column(t.VARCHAR(50))
+    ConsultationDate = mapped_column(t.DateTime)
+    Consultation_ID = mapped_column(t.BIGINT)
+    NumericValue = mapped_column(t.REAL)
+
+
 class Organisation(Base):
     __tablename__ = "Organisation"
     _pk = mapped_column(t.Integer, primary_key=True)


### PR DESCRIPTION
This would normally be handled automatically by the scheduled action, but [an issue][1] with Job Server means that the latest published version isn't showing to logged out users so we have to download it manually.

This involved downloading the CSV file from:
https://jobs.opensafely.org/datalab/opensafely-internal/tpp-database-schema/outputs/43/

Copying it to `tests/lib/tpp_schema.csv` and then running:

    python -m tests.lib.update_tpp_schema build

[1]: https://github.com/opensafely-core/job-server/issues/3136