### PR TITLE
Upgrade to github-tag-action v6.1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: hadolint/hadolint-action@54c9adbab1582c2ef04b2016b760714a4bfde3cf
+      - uses: hadolint/hadolint-action@54c9adbab1582c2ef04b2016b760714a4bfde3cf #v3.1.0
         with:
           failure-threshold: error
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,7 +62,7 @@ jobs:
           fetch-depth: 0
       - name: Bump version and push tag
         id: tag
-        uses: mathieudutour/github-tag-action@981ffb2cc3f2b684b2bfd8ee17bc8d781368ba60
+        uses: mathieudutour/github-tag-action@fcfbdceb3093f6d85a3b194740f8c6cec632f4e2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           default_bump: false

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,7 +62,7 @@ jobs:
           fetch-depth: 0
       - name: Bump version and push tag
         id: tag
-        uses: mathieudutour/github-tag-action@fcfbdceb3093f6d85a3b194740f8c6cec632f4e2
+        uses: mathieudutour/github-tag-action@fcfbdceb3093f6d85a3b194740f8c6cec632f4e2 #v6.1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           default_bump: false

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,6 +52,7 @@ jobs:
     # BREAKING CHANGE in footer -> major release
     #
     # anything else (docs, refactor, etc) does not create a release
+    if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
     needs: [check, test]
     runs-on: ubuntu-latest
     outputs:


### PR DESCRIPTION
Fixes #716.
Fixes #976.
Supersedes #851.

This was previously updated in #689 and reverted in #714, due to it breaking tagging.

Having looked around the code, issues and PRs for the action, it looks as if the README is not in line with the current behaviour (mathieudutour/github-tag-action#150).

The author's suggestion there is to just not run the action of PRs, which is a reasonable fix for now. If the tagging behaviour is more controllable as we need in the future, we could revisit this to remove the conditional check in our workflow.