### PR TITLE
Author automated commits as GitHub Actions bot

### DIFF
--- a/.github/workflows/update-external-studies.yml
+++ b/.github/workflows/update-external-studies.yml
@@ -33,6 +33,8 @@ jobs:
           add-paths: tests/acceptance/external_studies/*
           branch: bot/update-external-studies
           base: main
+          author: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
+          committer: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
           commit-message: "chore: Update `external_studies` test code"
           title: "Update `external_studies` test code"
           body: |

--- a/.github/workflows/update-external-studies.yml
+++ b/.github/workflows/update-external-studies.yml
@@ -33,8 +33,8 @@ jobs:
           add-paths: tests/acceptance/external_studies/*
           branch: bot/update-external-studies
           base: main
-          author: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
-          committer: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
+          author: "opensafely-github-bot <opensafely-github-bot@users.noreply.github.com>"
+          committer: "opensafely-github-bot <opensafely-github-bot@users.noreply.github.com>"
           commit-message: "chore: Update `external_studies` test code"
           title: "Update `external_studies` test code"
           body: |

--- a/.github/workflows/update-tpp-schema.yml
+++ b/.github/workflows/update-tpp-schema.yml
@@ -33,6 +33,8 @@ jobs:
           add-paths: tests/lib/tpp_schema.*
           branch: bot/update-tpp-schema
           base: main
+          author: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
+          committer: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
           commit-message: "Update `test/lib/tpp_schema.py`"
           title: "Update `test/lib/tpp_schema.py`"
           body: |

--- a/.github/workflows/update-tpp-schema.yml
+++ b/.github/workflows/update-tpp-schema.yml
@@ -33,8 +33,8 @@ jobs:
           add-paths: tests/lib/tpp_schema.*
           branch: bot/update-tpp-schema
           base: main
-          author: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
-          committer: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
+          author: "opensafely-github-bot <opensafely-github-bot@users.noreply.github.com>"
+          committer: "opensafely-github-bot <opensafely-github-bot@users.noreply.github.com>"
           commit-message: "Update `test/lib/tpp_schema.py`"
           title: "Update `test/lib/tpp_schema.py`"
           body: |

--- a/.github/workflows/update-tutorial-ehrql-version.yml
+++ b/.github/workflows/update-tutorial-ehrql-version.yml
@@ -43,6 +43,8 @@ jobs:
             docs/ehrql-tutorial-examples/outputs/*
           branch: bot/update-tutorial-version
           base: main
+          author: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
+          committer: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
           commit-message: "chore: Update ehrql version in tutorial project.yaml"
           title: "Update ehrql version in tutorial project.yaml"
           body: |

--- a/.github/workflows/update-tutorial-ehrql-version.yml
+++ b/.github/workflows/update-tutorial-ehrql-version.yml
@@ -43,8 +43,8 @@ jobs:
             docs/ehrql-tutorial-examples/outputs/*
           branch: bot/update-tutorial-version
           base: main
-          author: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
-          committer: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
+          author: "opensafely-github-bot <opensafely-github-bot@users.noreply.github.com>"
+          committer: "opensafely-github-bot <opensafely-github-bot@users.noreply.github.com>"
           commit-message: "chore: Update ehrql version in tutorial project.yaml"
           title: "Update ehrql version in tutorial project.yaml"
           body: |


### PR DESCRIPTION
This uses the name and email as shown in the create-pull-request update guide for an old version:

https://github.com/peter-evans/create-pull-request/blob/efbb6ba75d718110dc7d3bd08cb98ebd247adc68/docs/updating.md
  
By default, the create-pull-request action specifies the person who triggered the workflow as the author.

If this is an automated scheduled run, then the person who is counted as triggering the workflow is the last person who edited the workflow file.

With #1274, it means that individual authors, may have unsigned and therefore unverified commits showing up in their commit history.

(I am perhaps fussier about this than other people.)

This is not very obvious behaviour.

By using the GitHub Actions name and email address, we can ascribe the
commits to that, which seems reasonable, as it's entirely automated.