### PR TITLE
Add measures support

### DIFF
--- a/docs/includes/generated_docs/specs.md
+++ b/docs/includes/generated_docs/specs.md
@@ -2338,7 +2338,36 @@ returns the following patient series:
 
 
 
-#### 11.2.9 Is between backwards
+#### 11.2.9 Is during
+
+This example makes use of a patient-level table named `p` containing the following data:
+
+| patient|d1 |
+| - | - |
+| 1|2010-01-01 |
+| 2|2010-01-02 |
+| 3|2010-01-03 |
+| 4|2010-01-04 |
+| 5|2010-01-05 |
+| 6| |
+
+```
+p.d1.is_during(interval)
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1|F |
+| 2|T |
+| 3|T |
+| 4|T |
+| 5|F |
+| 6| |
+
+
+
+#### 11.2.10 Is between backwards
 
 This example makes use of a patient-level table named `p` containing the following data:
 
@@ -2367,7 +2396,7 @@ returns the following patient series:
 
 
 
-#### 11.2.10 Is on or between backwards
+#### 11.2.11 Is on or between backwards
 
 This example makes use of a patient-level table named `p` containing the following data:
 

--- a/ehrql/__init__.py
+++ b/ehrql/__init__.py
@@ -2,6 +2,7 @@ import os
 from pathlib import Path
 
 from ehrql.codes import codelist_from_csv
+from ehrql.measures import INTERVAL, Measures
 from ehrql.query_language import Dataset, case, days, months, when, years
 from ehrql.utils.log_utils import init_logging
 
@@ -18,6 +19,8 @@ __version__ = Path(__file__).parent.joinpath("VERSION").read_text().strip()
 
 __all__ = [
     "codelist_from_csv",
+    "INTERVAL",
+    "Measures",
     "Dataset",
     "case",
     "days",

--- a/ehrql/__main__.py
+++ b/ehrql/__main__.py
@@ -184,29 +184,48 @@ def add_create_dummy_tables(subparsers, environ, user_args):
 
 
 def add_generate_measures(subparsers, environ, user_args):
-    parser = subparsers.add_parser(
-        "generate-measures", help="Generate measures from a dataset"
-    )
+    parser = subparsers.add_parser("generate-measures", help="Generate measures")
     parser.set_defaults(function=generate_measures)
     parser.set_defaults(user_args=user_args)
-    parser.add_argument(
-        "--input",
-        help="Path and filename (or pattern) of the input file(s)",
-        type=Path,
-        dest="input_file",
-    )
+    parser.set_defaults(user_args=user_args)
     parser.add_argument(
         "--output",
-        help="Path and filename (or pattern) of the file(s) where the dataset will be written",
-        type=Path,
+        help=(
+            f"Path of the file where the measures will be written (console by default),"
+            f" supported formats: {', '.join(FILE_FORMATS)}"
+        ),
+        type=valid_output_path,
         dest="output_file",
     )
     parser.add_argument(
-        "definition_file",
-        help="The path of the file where the dataset is defined",
-        type=existing_python_file,
-        metavar="dataset_definition",
+        "--dsn",
+        help="Data Source Name: URL of remote database, or path to data on disk",
+        type=str,
+        default=environ.get("DATABASE_URL"),
     )
+    parser.add_argument(
+        "--dummy-tables",
+        help=(
+            "Path to directory of CSV files (one per table) to use when generating "
+            "dummy data"
+        ),
+        type=Path,
+        dest="dummy_tables_path",
+    )
+    parser.add_argument(
+        "--dummy-data-file",
+        help=(
+            "Provide dummy data from a file to be validated and used as the "
+            "measures output"
+        ),
+        type=Path,
+    )
+    parser.add_argument(
+        "definition_file",
+        help="Path of the file where measures are defined",
+        type=existing_python_file,
+    )
+    add_common_backend_arguments(parser, environ)
 
 
 def add_run_sandbox(subparsers, environ, user_args):

--- a/ehrql/__main__.py
+++ b/ehrql/__main__.py
@@ -111,7 +111,13 @@ def add_generate_dataset(subparsers, environ, user_args):
         type=Path,
         dest="dummy_tables_path",
     )
-    add_common_dataset_arguments(parser, environ)
+    parser.add_argument(
+        "definition_file",
+        help="The path of the file where the dataset is defined",
+        type=existing_python_file,
+        metavar="dataset_definition",
+    )
+    add_common_backend_arguments(parser, environ)
 
 
 def add_dump_dataset_sql(subparsers, environ, user_args):
@@ -131,16 +137,16 @@ def add_dump_dataset_sql(subparsers, environ, user_args):
         type=Path,
         dest="output_file",
     )
-    add_common_dataset_arguments(parser, environ)
-
-
-def add_common_dataset_arguments(parser, environ):
     parser.add_argument(
         "definition_file",
         help="The path of the file where the dataset is defined",
         type=existing_python_file,
         metavar="dataset_definition",
     )
+    add_common_backend_arguments(parser, environ)
+
+
+def add_common_backend_arguments(parser, environ):
     parser.add_argument(
         "--query-engine",
         type=query_engine_from_id,

--- a/ehrql/main.py
+++ b/ehrql/main.py
@@ -148,7 +148,11 @@ def get_sql_strings(query_engine, variable_definitions):
     sql = clause_as_str(results_query, dialect)
     sql_strings.append(f"-- Results query\n{sql}")
 
-    assert not cleanup_queries, "Support these once tests exercise them"
+    for i, query in enumerate(cleanup_queries, start=1):
+        sql = clause_as_str(query, dialect)
+        sql_strings.append(
+            f"-- Cleanup query {i:03} / {len(cleanup_queries):03}\n{sql}"
+        )
 
     return sql_strings
 

--- a/ehrql/main.py
+++ b/ehrql/main.py
@@ -285,7 +285,7 @@ def load_dataset_definition(definition_file, user_args):
             "Did not find a variable called 'dataset' in dataset definition file"
         )
     if not isinstance(dataset, Dataset):
-        raise CommandError("'dataset' must be an instance of ehrql.Dataset()")
+        raise CommandError("'dataset' must be an instance of ehrql.Dataset")
     if not hasattr(dataset, "population"):
         raise CommandError(
             "A population has not been defined; define one with define_population()"

--- a/ehrql/measures/__init__.py
+++ b/ehrql/measures/__init__.py
@@ -1,6 +1,8 @@
+from ehrql.measures.calculate import get_measure_results
 from ehrql.measures.measures import Measures, interval
 
 
 __all__ = [
+    "get_measure_results",
     "Measures",
 ]

--- a/ehrql/measures/__init__.py
+++ b/ehrql/measures/__init__.py
@@ -1,9 +1,13 @@
-from ehrql.measures.calculate import get_measure_results
+from ehrql.measures.calculate import (
+    get_column_specs_for_measures,
+    get_measure_results,
+)
 from ehrql.measures.dummy_data import DummyMeasuresDataGenerator
 from ehrql.measures.measures import INTERVAL, Measures
 
 
 __all__ = [
+    "get_column_specs_for_measures",
     "get_measure_results",
     "DummyMeasuresDataGenerator",
     "INTERVAL",

--- a/ehrql/measures/__init__.py
+++ b/ehrql/measures/__init__.py
@@ -1,0 +1,6 @@
+from ehrql.measures.measures import Measures, interval
+
+
+__all__ = [
+    "Measures",
+]

--- a/ehrql/measures/__init__.py
+++ b/ehrql/measures/__init__.py
@@ -1,8 +1,11 @@
 from ehrql.measures.calculate import get_measure_results
-from ehrql.measures.measures import Measures, interval
+from ehrql.measures.dummy_data import DummyMeasuresDataGenerator
+from ehrql.measures.measures import INTERVAL, Measures
 
 
 __all__ = [
     "get_measure_results",
+    "DummyMeasuresDataGenerator",
+    "INTERVAL",
     "Measures",
 ]

--- a/ehrql/measures/calculate.py
+++ b/ehrql/measures/calculate.py
@@ -1,0 +1,156 @@
+from collections import defaultdict
+
+from ehrql.measures.measures import get_all_group_by_columns
+from ehrql.query_model.nodes import Case, Function, Value, get_series_type
+from ehrql.query_model.transforms import substitute_parameters
+
+
+def get_measure_results(query_engine, measures):
+    # Group measures by denominator and intervals as we'll handle them together
+    grouped = defaultdict(list)
+    for measure in measures:
+        group_id = (measure.denominator, measure.intervals)
+        grouped[group_id].append(measure)
+
+    all_group_by_columns = get_all_group_by_columns(measures).keys()
+
+    for measure_group in grouped.values():
+        calculator = MeasureCalculator(measure_group)
+        results = calculator.get_results(query_engine)
+        for measure, interval, numerator, denominator, group_dict in results:
+            ratio = numerator / denominator if denominator else None
+            yield (
+                measure.name,
+                interval[0],
+                interval[1],
+                ratio,
+                numerator,
+                denominator,
+                # Return a column for every group used across all measures, even if this
+                # particular measure doesn't use that group
+                *(group_dict.get(name) for name in all_group_by_columns),
+            )
+
+
+class MeasureCalculator:
+    def __init__(self, measures):
+        self.denominator = None
+        self.intervals = None
+        self.variables = {}
+        self.measures = []
+        self.fetchers = []
+        for measure in measures:
+            self.add_measure(measure)
+
+    def get_results(self, query_engine):
+        for interval in self.intervals:
+            results = self.get_results_for_interval(query_engine, interval)
+            for measure, numerator, denominator, group in results:
+                group_dict = dict(zip(measure.group_by.keys(), group))
+                yield measure, interval, numerator, denominator, group_dict
+
+    def get_results_for_interval(self, query_engine, interval):
+        # Build the query for this interval by replacing the interval start/end
+        # placeholders with actual dates
+        query = substitute_interval_parameters(self.variables, interval)
+
+        # "fetchers" are functions which take a row and return the values relevant to a
+        # given measure (numerator, denominator and groups); "accumulators" are dicts
+        # storing the cumulative numerator and denominator totals for each group in the
+        # measure
+        fetcher_accumulator_pairs = [
+            (fetcher, defaultdict(lambda: [0, 0])) for fetcher in self.fetchers
+        ]
+
+        for row in query_engine.get_results(query):
+            for fetcher, accumulator in fetcher_accumulator_pairs:
+                numerator, denominator, group = fetcher(row)
+                totals = accumulator[group]
+                totals[0] += numerator
+                totals[1] += denominator
+
+        for measure, (_, accumulator) in zip(self.measures, fetcher_accumulator_pairs):
+            for group, (numerator, denominator) in accumulator.items():
+                yield measure, numerator, denominator, group
+
+    def add_measure(self, measure):
+        # Record denominator and intervals from first measure
+        if self.denominator is None:
+            self.denominator = measure.denominator
+            self.intervals = measure.intervals
+            self.variables["population"] = series_as_bool(self.denominator)
+        else:
+            assert measure.denominator == self.denominator
+            assert measure.intervals == self.intervals
+
+        numerator_index = self.add_variable(series_as_int(measure.numerator))
+        denominator_index = self.add_variable(series_as_int(measure.denominator))
+        group_indexes = [
+            self.add_variable(column) for column in measure.group_by.values()
+        ]
+
+        # Create a function which takes a results row and returns a numerator,
+        # denominator, and tuple of group values, based on their indices
+        fetcher = self.create_fetcher(numerator_index, denominator_index, group_indexes)
+
+        self.measures.append(measure)
+        self.fetchers.append(fetcher)
+
+    def add_variable(self, variable):
+        # Return the position of `variable` in the variables dict, adding it if not
+        # already present
+        try:
+            return list(self.variables.values()).index(variable)
+        except ValueError:
+            index = len(self.variables)
+            self.variables[f"column_{index}"] = variable
+            return index
+
+    @staticmethod
+    def create_fetcher(numerator_index, denominator_index, group_indexes):
+        # Given a bunch of indices we want a function which extracts just those indices
+        # from a tuple. This is going to be called frequently, so the fastest way to do
+        # this is to build a function definition and then eval it.
+        group_items = [f"row[{i}]" for i in group_indexes]
+        items = [
+            f"row[{numerator_index}]",
+            f"row[{denominator_index}]",
+            f"({', '.join(group_items)},)",
+        ]
+        code = f"lambda row: ({', '.join(items)})"
+        return eval(code)
+
+
+def series_as_bool(series):
+    series_type = get_series_type(series)
+    if series_type is bool:
+        return series
+    elif series_type is int:
+        return Function.GT(series, Value(0))
+    else:
+        assert False
+
+
+def series_as_int(series):
+    series_type = get_series_type(series)
+    if series_type is int:
+        return series
+    elif series_type is bool:
+        # TODO: This is definitely not the most efficient way to do this. We should
+        # extend the `CastToInt` operation to apply to boolean as well.
+        return Case(
+            {
+                Function.EQ(series, Value(True)): Value(1),
+                Function.EQ(series, Value(False)): Value(0),
+            }
+        )
+    else:
+        assert False
+
+
+def substitute_interval_parameters(variable_definitions, interval):
+    return substitute_parameters(
+        variable_definitions,
+        interval_start_date=interval[0],
+        interval_end_date=interval[1],
+    )

--- a/ehrql/measures/calculate.py
+++ b/ehrql/measures/calculate.py
@@ -1,6 +1,8 @@
+import datetime
 from collections import defaultdict
 
 from ehrql.measures.measures import get_all_group_by_columns
+from ehrql.query_model.column_specs import ColumnSpec, get_column_spec_from_series
 from ehrql.query_model.nodes import Case, Function, Value, get_series_type
 from ehrql.query_model.transforms import substitute_parameters
 
@@ -30,6 +32,25 @@ def get_measure_results(query_engine, measures):
                 # particular measure doesn't use that group
                 *(group_dict.get(name) for name in all_group_by_columns),
             )
+
+
+def get_column_specs_for_measures(measures):
+    return {
+        "measure": ColumnSpec(
+            str,
+            categories=tuple(measure.name for measure in measures),
+            nullable=False,
+        ),
+        "interval_start": ColumnSpec(datetime.date, nullable=False),
+        "interval_end": ColumnSpec(datetime.date, nullable=False),
+        "ratio": ColumnSpec(float),
+        "numerator": ColumnSpec(int),
+        "denominator": ColumnSpec(int),
+        **{
+            name: get_column_spec_from_series(column)
+            for name, column in get_all_group_by_columns(measures).items()
+        },
+    }
 
 
 class MeasureCalculator:

--- a/ehrql/measures/dummy_data.py
+++ b/ehrql/measures/dummy_data.py
@@ -1,0 +1,60 @@
+from functools import reduce
+
+from ehrql.dummy_data import DummyDataGenerator
+from ehrql.measures.calculate import (
+    get_all_group_by_columns,
+    get_measure_results,
+    series_as_bool,
+    substitute_interval_parameters,
+)
+from ehrql.query_engines.in_memory import InMemoryQueryEngine
+from ehrql.query_engines.in_memory_database import InMemoryDatabase
+from ehrql.query_model.nodes import Function
+
+
+class DummyMeasuresDataGenerator:
+    def __init__(self, measures):
+        self.measures = measures
+        variables, population_size = self._variables_and_population_size(measures)
+        self.generator = DummyDataGenerator(variables, population_size=population_size)
+
+    def _variables_and_population_size(self, measures):
+        # Collect all variables used in all measures
+        all_denominators = {series_as_bool(m.denominator) for m in measures}
+        all_numerators = {m.numerator for m in measures}
+        all_groups = get_all_group_by_columns(measures).values()
+
+        variable_placeholders = {
+            # Use the union of all denominators as the population
+            "population": reduce(Function.Or, all_denominators),
+            **{
+                f"column_{i}": column
+                for i, column in enumerate([*all_numerators, *all_groups])
+            },
+        }
+
+        # Use the maximum range over all intervals as a date range
+        all_intervals = {interval for m in measures for interval in m.intervals}
+        min_interval_start = min(interval[0] for interval in all_intervals)
+        max_interval_end = max(interval[1] for interval in all_intervals)
+
+        variables = substitute_interval_parameters(
+            variable_placeholders, (min_interval_start, max_interval_end)
+        )
+
+        # Totally unscientific heuristic for producing a "big enough" population to
+        # generate a "reasonable" amount of non-zero measures
+        population_size = (
+            10 * len(all_denominators) * len(all_intervals) * len(all_groups)
+        )
+
+        return variables, population_size
+
+    def get_data(self):
+        return self.generator.get_data()
+
+    def get_results(self):
+        database = InMemoryDatabase()
+        database.setup(self.get_data())
+        engine = InMemoryQueryEngine(database)
+        return get_measure_results(engine, self.measures)

--- a/ehrql/measures/measures.py
+++ b/ehrql/measures/measures.py
@@ -4,6 +4,7 @@ from collections import namedtuple
 
 from ehrql.query_language import (
     BoolPatientSeries,
+    Duration,
     IntPatientSeries,
     Parameter,
     PatientSeries,
@@ -146,6 +147,11 @@ class Measures:
     def _validate_intervals(self, intervals):
         if intervals is None:
             return
+        if isinstance(intervals, Duration):
+            raise ValidationError(
+                f"You must supply a date using `{intervals!r}.starting_on('<DATE>')`"
+                f" or `{intervals!r}.ending_on('<DATE>')`"
+            )
         if not isinstance(intervals, list):
             raise ValidationError(
                 f"`intervals` must be a list, got '{type(intervals)}': {intervals!r}"

--- a/ehrql/measures/measures.py
+++ b/ehrql/measures/measures.py
@@ -1,0 +1,196 @@
+import dataclasses
+import datetime
+from collections import namedtuple
+
+from ehrql.query_language import (
+    BoolPatientSeries,
+    IntPatientSeries,
+    Parameter,
+    PatientSeries,
+)
+from ehrql.query_model.nodes import Series
+
+
+class ValidationError(Exception):
+    pass
+
+
+# Parameters to be used in place of date values when constructing the ehrQL queries
+# which define the measures. For ergonomic's sake, we wrap the pair of dates up in a
+# namedtuple.
+INTERVAL = namedtuple("INTERVAL", ["start_date", "end_date"])(
+    start_date=Parameter("interval_start_date", datetime.date),
+    end_date=Parameter("interval_end_date", datetime.date),
+)
+
+
+@dataclasses.dataclass
+class Measure:
+    name: str
+    numerator: Series[bool] | Series[int]
+    denominator: Series[bool] | Series[int]
+    group_by: dict[str, Series]
+    intervals: tuple[tuple[datetime.date, datetime.date]]
+
+
+class Measures:
+    # These names are used in the measures output table and so can't be used as group_by
+    # column names
+    RESERVED_NAMES = {
+        "measure",
+        "numerator",
+        "denominator",
+        "ratio",
+        "interval_start",
+        "interval_end",
+    }
+
+    def __init__(self):
+        self._measures = {}
+        self._defaults = {}
+
+    def define_defaults(
+        self,
+        numerator: BoolPatientSeries | IntPatientSeries | None = None,
+        denominator: BoolPatientSeries | IntPatientSeries | None = None,
+        group_by: dict[str, PatientSeries] | None = None,
+        intervals: list[tuple[datetime.date, datetime.date]] | None = None,
+    ):
+        kwargs = {
+            "numerator": numerator,
+            "denominator": denominator,
+            "group_by": group_by,
+            "intervals": intervals,
+        }
+        if self._defaults:
+            raise ValidationError(
+                "Defaults already set; cannot call `define_defaults()` more than once"
+            )
+        self._validate_kwargs(kwargs)
+        self._defaults = kwargs
+
+    def define_measure(
+        self,
+        name,
+        numerator: BoolPatientSeries | IntPatientSeries | None = None,
+        denominator: BoolPatientSeries | IntPatientSeries | None = None,
+        group_by: dict[str, PatientSeries] | None = None,
+        intervals: list[tuple[datetime.date, datetime.date]] | None = None,
+    ):
+        # Merge supplied kwargs with defaults and validate
+        supplied_kwargs = {
+            "numerator": numerator,
+            "denominator": denominator,
+            "group_by": group_by,
+            "intervals": intervals,
+        }
+        kwargs = {
+            key: value if value is not None else self._defaults.get(key)
+            for key, value in supplied_kwargs.items()
+        }
+        self._validate_kwargs(kwargs)
+
+        # Ensure all arguments are provided (either directly or by defaults)
+        for key, value in kwargs.items():
+            if value is None:
+                raise ValidationError(
+                    f"No value supplied for '{key}' and no default defined"
+                )
+
+        # Ensure measure names are unique
+        if name in self._measures:
+            raise ValidationError(f"Measure already defined with name: {name}")
+
+        # Ensure group_by column definitions are consistent across measures
+        for group_name, definition in get_all_group_by_columns(
+            self._measures.values()
+        ).items():
+            if group_name not in group_by:
+                continue
+            if group_by[group_name].qm_node != definition:
+                raise ValidationError(
+                    f"Inconsistent definition for `group_by` column: {group_name}"
+                )
+
+        # Add measure
+        self._measures[name] = Measure(
+            name=name,
+            numerator=kwargs["numerator"].qm_node,
+            denominator=kwargs["denominator"].qm_node,
+            group_by={
+                group_name: series.qm_node
+                for group_name, series in kwargs["group_by"].items()
+            },
+            intervals=tuple(sorted(set(kwargs["intervals"]))),
+        )
+
+    def _validate_kwargs(self, kwargs):
+        self._validate_num_denom(kwargs["numerator"], "numerator")
+        self._validate_num_denom(kwargs["denominator"], "denominator")
+        self._validate_intervals(kwargs["intervals"])
+        self._validate_group_by(kwargs["group_by"])
+
+    def _validate_num_denom(self, value, name):
+        if value is None:
+            return
+        if not isinstance(value, PatientSeries):
+            raise ValidationError(
+                f"`{name}` must be a one row per patient series,"
+                f" got '{type(value)}': {value!r}"
+            )
+        if value._type not in (bool, int):
+            raise ValidationError(
+                f"`{name}` must be a boolean or integer series, got '{value._type}'"
+            )
+
+    def _validate_intervals(self, intervals):
+        if intervals is None:
+            return
+        if not isinstance(intervals, list):
+            raise ValidationError(
+                f"`intervals` must be a list, got '{type(intervals)}': {intervals!r}"
+            )
+        for interval in intervals:
+            self._validate_interval(interval)
+
+    def _validate_interval(self, interval):
+        if (
+            not isinstance(interval, tuple)
+            or len(interval) != 2
+            or not all(isinstance(i, datetime.date) for i in interval)
+        ):
+            raise ValidationError(
+                f"`intervals` must contain pairs of dates, got: {interval!r}"
+            )
+        if interval[0] > interval[1]:
+            raise ValidationError(
+                f"Interval start date must be before end date, got: {interval!r}"
+            )
+
+    def _validate_group_by(self, group_by):
+        if group_by is None:
+            return
+        disallowed = self.RESERVED_NAMES.intersection(group_by)
+        if disallowed:
+            raise ValidationError(
+                f"disallowed `group_by` column name: {', '.join(disallowed)}"
+            )
+
+    def __iter__(self):
+        return iter(self._measures.values())
+
+    def __len__(self):
+        return len(self._measures)
+
+
+def get_all_group_by_columns(measures):
+    """
+    Merge all `group_by` dictionaries into a single, flat dictionary
+    """
+    # We don't need to worry about collisions here because we enforce during measure
+    # construction that each name refers consistently to a single column definition
+    return {
+        name: column
+        for measure in measures
+        for name, column in measure.group_by.items()
+    }

--- a/ehrql/query_engines/mssql.py
+++ b/ehrql/query_engines/mssql.py
@@ -242,12 +242,8 @@ def temporary_table_from_query(table_name, query, index_col=0, schema=None):
         # SQLAlchemy generate one for us.)
         CreateIndex(sqlalchemy.Index(None, table.c[index_col], mssql_clustered=True)),
     ]
-    # The "#" prefix indicates a session-scoped temporary table which doesn't need
-    # explict cleanup
-    if table_name.startswith("#"):
-        table.is_persistent = False
-        table.cleanup_queries = []
-    else:
-        table.is_persistent = True
-        table.cleanup_queries = [DropTable(table)]
+    table.cleanup_queries = [DropTable(table, if_exists=True)]
+    # The "#" prefix indicates a session-scoped temporary table which won't persist if
+    # we open a new connection to the database
+    table.is_persistent = table_name.startswith("#")
     return table

--- a/ehrql/query_language.py
+++ b/ehrql/query_language.py
@@ -386,6 +386,10 @@ class DateFunctions(ComparableFunctions):
     def is_on_or_between(self, start, end):
         return (self >= start) & (self <= end)
 
+    def is_during(self, interval):
+        start, end = interval
+        return self.is_on_or_between(start, end)
+
     def __sub__(self, other):
         other = self._cast(other)
         if isinstance(other, datetime.date | DateEventSeries | DatePatientSeries):

--- a/ehrql/query_language.py
+++ b/ehrql/query_language.py
@@ -338,7 +338,10 @@ class FloatPatientSeries(FloatFunctions, PatientSeries):
 
 def parse_date_if_str(value):
     if isinstance(value, str):
-        return datetime.date.fromisoformat(value)
+        try:
+            return datetime.date.fromisoformat(value)
+        except ValueError as e:
+            raise ValueError(f"{e} in {value!r}")
     else:
         return value
 

--- a/ehrql/query_language.py
+++ b/ehrql/query_language.py
@@ -600,6 +600,15 @@ def _to_series(value):
     return _wrap(_convert(value))
 
 
+def Parameter(name, type_):
+    """
+    Return a parameter or placeholder series which can be used to construct a query
+    "template": a structure which can be turned into a query by substituing in concrete
+    values for any parameters it contains
+    """
+    return _wrap(qm.Parameter(name, type_))
+
+
 # FRAME TYPES
 #
 

--- a/ehrql/query_model/column_specs.py
+++ b/ehrql/query_model/column_specs.py
@@ -36,20 +36,7 @@ def get_column_specs(variable_definitions):
     for name, series in variable_definitions.items():
         if name == "population":
             continue
-        type_ = get_series_type(series)
-        categories = get_categories(series)
-        min_value, max_value = get_range(series)
-        if hasattr(type_, "_primitive_type"):
-            type_ = type_._primitive_type()
-            if categories:
-                categories = tuple(c._to_primitive_type() for c in categories)
-        column_specs[name] = ColumnSpec(
-            type_,
-            nullable=True,
-            categories=categories,
-            min_value=min_value,
-            max_value=max_value,
-        )
+        column_specs[name] = get_column_spec_from_series(series)
     return column_specs
 
 
@@ -62,6 +49,23 @@ def get_column_specs_from_schema(schema):
         for name, col_type in dict(schema.column_types).items()
     }
     return column_specs
+
+
+def get_column_spec_from_series(series):
+    type_ = get_series_type(series)
+    categories = get_categories(series)
+    min_value, max_value = get_range(series)
+    if hasattr(type_, "_primitive_type"):
+        type_ = type_._primitive_type()
+        if categories:
+            categories = tuple(c._to_primitive_type() for c in categories)
+    return ColumnSpec(
+        type_,
+        nullable=True,
+        categories=categories,
+        min_value=min_value,
+        max_value=max_value,
+    )
 
 
 @singledispatch

--- a/ehrql/query_model/nodes.py
+++ b/ehrql/query_model/nodes.py
@@ -18,6 +18,7 @@ __all__ = [
     "Node",
     "Series",
     "Value",
+    "Parameter",
     "SelectTable",
     "SelectPatientTable",
     "InlinePatientTable",
@@ -183,6 +184,13 @@ class Value(OneRowPerPatientSeries[T]):
                 return False
             return self.value == other.value
         return NotImplemented
+
+
+# `Parameter` is a placeholder for a value: it allows us to construct query "templates"
+# which can later be turned into queries by substituting in concrete values.
+class Parameter(OneRowPerPatientSeries[T]):
+    name: str
+    type: type[T]  # NOQA: A003
 
 
 class SelectTable(ManyRowsPerPatientFrame):

--- a/ehrql/query_model/transforms.py
+++ b/ehrql/query_model/transforms.py
@@ -19,6 +19,7 @@ from typing import Any
 from ehrql.query_model.nodes import (
     Case,
     Function,
+    Parameter,
     PickOneRowPerPatient,
     SelectColumn,
     Sort,
@@ -189,3 +190,12 @@ def build_reverse_index(nodes):
         for i in get_input_nodes(n):
             reverse_index[i].add(n)
     return reverse_index
+
+
+def substitute_parameters(variable_definitions, **parameter_values):
+    rewriter = QueryGraphRewriter()
+    for name, value in parameter_values.items():
+        value_type = type(value)
+        parameter = Parameter(name, value_type)
+        rewriter.replace(parameter, Value(value))
+    return rewriter.rewrite(variable_definitions)

--- a/ehrql/utils/date_utils.py
+++ b/ehrql/utils/date_utils.py
@@ -39,6 +39,10 @@ def date_add_days(date, num_days):
     return date + datetime.timedelta(days=num_days)
 
 
+def date_add_weeks(date, num_weeks):
+    return date_add_days(date, num_weeks * 7)
+
+
 def assert_valid_num_days(num_days):
     if abs(num_days) > 999999999:
         raise ValueError(f"Number of days {num_days} is out of range")
@@ -90,3 +94,13 @@ def to_first_of_year(date):
 
 def to_first_of_month(date):
     return date.replace(day=1)
+
+
+def generate_intervals(date_add_fn, base_date, count):
+    return [
+        (
+            date_add_fn(base_date, offset),
+            date_add_fn(base_date, offset + 1) - datetime.timedelta(days=1),
+        )
+        for offset in (range(count) if count >= 0 else range(1 + count, 1))
+    ]

--- a/tests/acceptance/test_embedded_study.py
+++ b/tests/acceptance/test_embedded_study.py
@@ -87,7 +87,7 @@ def test_dump_dataset_sql_attribute_invalid(study, mssql_database, capsys):
     study.setup_from_string(invalid_dataset_attribute_dataset_definition)
     with pytest.raises(SystemExit):
         study.dump_dataset_sql()
-    assert "'dataset' must be an instance of ehrql.Dataset()" in capsys.readouterr().err
+    assert "'dataset' must be an instance of ehrql.Dataset" in capsys.readouterr().err
 
 
 def test_dump_dataset_sql_query_model_error(study, mssql_database, capsys):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -166,14 +166,17 @@ class QueryEngineFixture:
     def populate(self, *args):
         return self.setup(make_orm_models(*args))
 
+    def query_engine(self, dsn=False, **engine_kwargs):
+        if dsn is False:
+            dsn = self.database.host_url()
+        return self.query_engine_class(dsn, **engine_kwargs)
+
     def extract(self, dataset, **engine_kwargs):
         variables = compile(dataset)
         return self.extract_qm(variables, **engine_kwargs)
 
     def extract_qm(self, variables, **engine_kwargs):
-        query_engine = self.query_engine_class(
-            self.database.host_url(), **engine_kwargs
-        )
+        query_engine = self.query_engine(**engine_kwargs)
         results = query_engine.get_results(variables)
         # We don't explicitly order the results and not all databases naturally
         # return in the same order
@@ -181,11 +184,11 @@ class QueryEngineFixture:
 
     def dump_dataset_sql(self, dataset, **engine_kwargs):
         variables = compile(dataset)
-        query_engine = self.query_engine_class(dsn=None, **engine_kwargs)
+        query_engine = self.query_engine(dsn=None, **engine_kwargs)
         return get_sql_strings(query_engine, variables)
 
     def sqlalchemy_engine(self):
-        return self.query_engine_class(self.database.host_url()).engine
+        return self.query_engine().engine
 
 
 QUERY_ENGINE_NAMES = ("in_memory", "sqlite", "mssql")

--- a/tests/fixtures/bad_dataset_definitions/empty_measures.py
+++ b/tests/fixtures/bad_dataset_definitions/empty_measures.py
@@ -1,0 +1,3 @@
+from ehrql import Measures
+
+measures = Measures()

--- a/tests/fixtures/bad_dataset_definitions/no_measures.py
+++ b/tests/fixtures/bad_dataset_definitions/no_measures.py
@@ -1,0 +1,1 @@
+measuuuuures = []

--- a/tests/fixtures/bad_dataset_definitions/not_measures_instance.py
+++ b/tests/fixtures/bad_dataset_definitions/not_measures_instance.py
@@ -1,0 +1,1 @@
+measures = object()

--- a/tests/generative/variable_strategies.py
+++ b/tests/generative/variable_strategies.py
@@ -11,6 +11,7 @@ from ehrql.query_model.nodes import (
     Function,
     InlinePatientTable,
     IterWrapper,
+    Parameter,
     PickOneRowPerPatient,
     Position,
     SelectColumn,
@@ -494,6 +495,9 @@ def variable(patient_tables, event_tables, schema, value_strategies):
 
 known_missing_operations = {
     AggregateByPatient.CombineAsSet,
+    # Parameters don't themselves form part of valid queries: they are placeholders
+    # which must all be replaced with Values before the query can be executed.
+    Parameter,
 }
 
 

--- a/tests/integration/measures/test_calculate.py
+++ b/tests/integration/measures/test_calculate.py
@@ -1,0 +1,167 @@
+import random
+from collections import defaultdict
+from datetime import date, timedelta
+
+from ehrql import years
+from ehrql.measures import INTERVAL, Measures, get_measure_results
+from ehrql.tables import EventFrame, PatientFrame, Series, table
+
+
+@table
+class patients(PatientFrame):
+    sex = Series(str)
+    region = Series(str)
+
+
+@table
+class events(EventFrame):
+    date = Series(date)
+    code = Series(str)
+
+
+def test_get_measure_results(engine):
+    events_in_interval = events.where(events.date.is_during(INTERVAL))
+    event_count = events_in_interval.count_for_patient()
+    foo_event_count = events_in_interval.where(events.code == "foo").count_for_patient()
+    had_event = events_in_interval.exists_for_patient()
+
+    intervals = years(3).starting_on("2020-01-01")
+    measures = Measures()
+
+    measures.define_measure(
+        "foo_events_by_sex",
+        numerator=foo_event_count,
+        denominator=event_count,
+        group_by=dict(sex=patients.sex),
+        intervals=intervals,
+    )
+    measures.define_measure(
+        "foo_events_by_region",
+        numerator=foo_event_count,
+        denominator=event_count,
+        group_by=dict(region=patients.region),
+        intervals=intervals,
+    )
+    measures.define_measure(
+        "had_event_by_sex",
+        numerator=had_event,
+        denominator=patients.exists_for_patient(),
+        group_by=dict(sex=patients.sex),
+        intervals=intervals,
+    )
+    measures.define_measure(
+        "had_event_by_region",
+        numerator=had_event,
+        denominator=patients.exists_for_patient(),
+        group_by=dict(region=patients.region),
+        intervals=intervals,
+    )
+    measures.define_measure(
+        "had_event_by_sex_and_region",
+        numerator=had_event,
+        denominator=patients.exists_for_patient(),
+        group_by=dict(
+            sex=patients.sex,
+            region=patients.region,
+        ),
+        intervals=intervals,
+    )
+
+    patient_data, event_data = generate_data(intervals)
+    engine.populate({patients: patient_data, events: event_data})
+
+    results = get_measure_results(engine.query_engine(), measures)
+    results = list(results)
+
+    expected = calculate_measure_results(intervals, patient_data, event_data)
+    expected = list(expected)
+
+    # We don't care about the order of the results
+    assert set(results) == set(expected)
+
+
+def generate_data(intervals):
+    rnd = random.Random(20230518)
+    # Generate some random patients
+    patient_data = [
+        dict(
+            patient_id=patient_id,
+            sex=rnd.choice(["male", "female"]),
+            region=rnd.choice(["London", "The North", "The Countryside"]),
+        )
+        for patient_id in range(1, 50)
+    ]
+    # For each interval and patient, generate some events (possibly zero)
+    event_data = []
+    for interval in intervals:
+        for patient in patient_data:
+            # Choose a number of events, biased towards zero
+            event_count = max(rnd.randint(-10, 10), 0)
+            event_data.extend(
+                dict(
+                    patient_id=patient["patient_id"],
+                    code=rnd.choice(["abc", "def", "foo"]),
+                    date=random_date_in_interval(rnd, interval),
+                )
+                for _ in range(event_count)
+            )
+    return patient_data, event_data
+
+
+def random_date_in_interval(rnd, interval):
+    days_in_interval = (interval[1] - interval[0]).days
+    offset = rnd.randint(0, days_in_interval)
+    return interval[0] + timedelta(days=offset)
+
+
+def calculate_measure_results(intervals, patient_data, event_data):
+    nums = defaultdict(int)
+    dens = defaultdict(int)
+
+    for interval, patient, events in group_events(intervals, patient_data, event_data):
+        event_count = len(events)
+        foo_count = len([e for e in events if e["code"] == "foo"])
+        had_event = 1 if events else 0
+
+        nums[("foo_events_by_sex", interval, patient["sex"], None)] += foo_count
+        dens[("foo_events_by_sex", interval, patient["sex"], None)] += event_count
+        nums[("foo_events_by_region", interval, None, patient["region"])] += foo_count
+        dens[("foo_events_by_region", interval, None, patient["region"])] += event_count
+        nums[("had_event_by_sex", interval, patient["sex"], None)] += had_event
+        dens[("had_event_by_sex", interval, patient["sex"], None)] += 1
+        nums[("had_event_by_region", interval, None, patient["region"])] += had_event
+        dens[("had_event_by_region", interval, None, patient["region"])] += 1
+        nums[
+            ("had_event_by_sex_and_region", interval, patient["sex"], patient["region"])
+        ] += had_event
+        dens[
+            ("had_event_by_sex_and_region", interval, patient["sex"], patient["region"])
+        ] += 1
+
+    for key, numerator in nums.items():
+        measure, interval, sex, region = key
+        denominator = dens[key]
+        ratio = numerator / denominator
+        yield (
+            measure,
+            interval[0],
+            interval[1],
+            ratio,
+            numerator,
+            denominator,
+            sex,
+            region,
+        )
+
+
+def group_events(intervals, patient_data, event_data):
+    "Group events by interval and patient"
+    for patient in patient_data:
+        patient_events = [
+            e for e in event_data if e["patient_id"] == patient["patient_id"]
+        ]
+        for interval in intervals:
+            interval_events = [
+                e for e in patient_events if interval[0] <= e["date"] <= interval[1]
+            ]
+            yield interval, patient, interval_events

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -1,0 +1,126 @@
+import textwrap
+from datetime import date
+
+from ehrql.main import generate_measures
+from ehrql.query_engines.sqlite import SQLiteQueryEngine
+from ehrql.tables.beta.core import patients
+from ehrql.utils.orm_utils import make_orm_models
+
+
+MEASURE_DEFINITIONS = """
+from ehrql import INTERVAL, Measures, years
+from ehrql.tables.beta.core import patients
+
+
+measures = Measures()
+
+measures.define_measure(
+    "births",
+    numerator=patients.date_of_birth.is_during(INTERVAL),
+    denominator=patients.exists_for_patient(),
+    group_by={"sex": patients.sex},
+    intervals=years(2).starting_on("2020-01-01"),
+)
+"""
+
+
+def test_generate_measures(in_memory_sqlite_database, tmp_path):
+    in_memory_sqlite_database.setup(
+        make_orm_models(
+            {
+                patients: [
+                    dict(patient_id=1, date_of_birth=date(2020, 6, 1), sex="male"),
+                    dict(patient_id=2, date_of_birth=date(2021, 6, 1), sex="female"),
+                ]
+            }
+        )
+    )
+
+    measure_definitions = tmp_path / "measures.py"
+    measure_definitions.write_text(MEASURE_DEFINITIONS)
+    output_file = tmp_path / "output.csv"
+
+    generate_measures(
+        measure_definitions,
+        output_file,
+        dsn=in_memory_sqlite_database.host_url(),
+        query_engine_class=SQLiteQueryEngine,
+    )
+    assert output_file.read_text() == textwrap.dedent(
+        """\
+        measure,interval_start,interval_end,ratio,numerator,denominator,sex
+        births,2020-01-01,2020-12-31,1.0,1,1,male
+        births,2020-01-01,2020-12-31,0.0,0,1,female
+        births,2021-01-01,2021-12-31,0.0,0,1,male
+        births,2021-01-01,2021-12-31,1.0,1,1,female
+        """
+    )
+
+
+def test_generate_measures_dummy_data_generated(tmp_path):
+    measure_definitions = tmp_path / "measures.py"
+    measure_definitions.write_text(MEASURE_DEFINITIONS)
+    output_file = tmp_path / "output.csv"
+
+    generate_measures(
+        measure_definitions,
+        output_file,
+    )
+    assert output_file.read_text().startswith(
+        "measure,interval_start,interval_end,ratio,numerator,denominator,sex"
+    )
+
+
+def test_generate_measures_dummy_data_supplied(tmp_path):
+    measure_definitions = tmp_path / "measures.py"
+    measure_definitions.write_text(MEASURE_DEFINITIONS)
+    output_file = tmp_path / "output.csv"
+    DUMMY_DATA = textwrap.dedent(
+        """\
+        measure,interval_start,interval_end,ratio,numerator,denominator,sex
+        births,2020-01-01,2020-12-31,0.4,4,10,male
+        births,2020-01-01,2020-12-31,0.3,6,20,female
+        births,2021-01-01,2021-12-31,0.6,6,10,male
+        births,2021-01-01,2021-12-31,0.7,14,20,female
+        """
+    )
+    dummy_data_file = tmp_path / "dummy.csv"
+    dummy_data_file.write_text(DUMMY_DATA)
+
+    generate_measures(
+        measure_definitions,
+        output_file,
+        dummy_data_file=dummy_data_file,
+    )
+    assert output_file.read_text() == DUMMY_DATA
+
+
+def test_generate_measures_dummy_tables(tmp_path):
+    measure_definitions = tmp_path / "measures.py"
+    measure_definitions.write_text(MEASURE_DEFINITIONS)
+    output_file = tmp_path / "output.csv"
+    DUMMY_DATA = textwrap.dedent(
+        """\
+        patient_id,date_of_birth,sex
+        1,2020-06-01,male
+        2,2021-06-01,female
+        """
+    )
+    dummy_tables_path = tmp_path / "dummy_tables"
+    dummy_tables_path.mkdir()
+    dummy_tables_path.joinpath("patients.csv").write_text(DUMMY_DATA)
+
+    generate_measures(
+        measure_definitions,
+        output_file,
+        dummy_tables_path=dummy_tables_path,
+    )
+    assert output_file.read_text() == textwrap.dedent(
+        """\
+        measure,interval_start,interval_end,ratio,numerator,denominator,sex
+        births,2020-01-01,2020-12-31,1.0,1,1,male
+        births,2020-01-01,2020-12-31,0.0,0,1,female
+        births,2021-01-01,2021-12-31,0.0,0,1,male
+        births,2021-01-01,2021-12-31,1.0,1,1,female
+        """
+    )

--- a/tests/spec/date_series_ops/test_date_comparisons.py
+++ b/tests/spec/date_series_ops/test_date_comparisons.py
@@ -141,6 +141,26 @@ def test_is_on_or_between(spec_test):
     )
 
 
+def test_is_during(spec_test):
+    table_data = table_data_for_between_tests
+    interval = (
+        date(2010, 1, 2),
+        date(2010, 1, 4),
+    )
+    spec_test(
+        table_data,
+        p.d1.is_during(interval),
+        {
+            1: False,
+            2: True,
+            3: True,
+            4: True,
+            5: False,
+            6: None,
+        },
+    )
+
+
 def test_is_between_backwards(spec_test):
     table_data = table_data_for_between_tests
     spec_test(

--- a/tests/unit/measures/test_dummy_data.py
+++ b/tests/unit/measures/test_dummy_data.py
@@ -1,0 +1,71 @@
+from datetime import date
+
+from ehrql import years
+from ehrql.measures import INTERVAL, DummyMeasuresDataGenerator, Measures
+from ehrql.tables import Constraint, EventFrame, PatientFrame, Series, table
+
+
+@table
+class patients(PatientFrame):
+    sex = Series(
+        str,
+        constraints=[Constraint.Categorical(["male", "female"])],
+    )
+    region = Series(
+        str,
+        constraints=[
+            Constraint.Categorical(["London", "The North", "The Countryside"])
+        ],
+    )
+
+
+@table
+class events(EventFrame):
+    date = Series(date)
+    code = Series(
+        str,
+        constraints=[Constraint.Categorical(["abc", "def", "foo"])],
+    )
+
+
+def test_dummy_measures_data_generator():
+    events_in_interval = events.where(events.date.is_during(INTERVAL))
+    event_count = events_in_interval.count_for_patient()
+    foo_event_count = events_in_interval.where(events.code == "foo").count_for_patient()
+    had_event = events_in_interval.exists_for_patient()
+
+    intervals = years(2).starting_on("2020-01-01")
+    measures = Measures()
+
+    measures.define_measure(
+        "foo_events_by_sex",
+        numerator=foo_event_count,
+        denominator=event_count,
+        group_by=dict(sex=patients.sex),
+        intervals=intervals,
+    )
+    measures.define_measure(
+        "had_event_by_region",
+        numerator=had_event,
+        denominator=patients.exists_for_patient(),
+        group_by=dict(region=patients.region),
+        intervals=intervals,
+    )
+
+    results = DummyMeasuresDataGenerator(measures).get_results()
+    results = list(results)
+
+    # Check we generated the right number of rows: 2 rows for each breakdown by sex, 3
+    # for each breakdown by region
+    assert len(results) == (len(intervals) * 2) + (len(intervals) * 3)
+
+    # The dummy data results go through the same code path as the real thing, so we
+    # don't need to worry about them being correct; rather than challenge is making sure
+    # we generate enough dummy data that matches the numerator/denominator conditions
+    # that the results are not empty. So below we assert that, for every numerator and
+    # denominator in every interval, something matched i.e. the count was above zero.
+    numerators = [row[4] for row in results]
+    denominators = [row[5] for row in results]
+
+    assert all(v > 0 for v in numerators)
+    assert all(v > 0 for v in denominators)

--- a/tests/unit/measures/test_measures.py
+++ b/tests/unit/measures/test_measures.py
@@ -1,0 +1,192 @@
+from datetime import date
+
+import pytest
+
+from ehrql import Measures
+from ehrql.measures.measures import Measure, ValidationError
+from ehrql.tables import PatientFrame, Series, table
+
+
+@table
+class patients(PatientFrame):
+    is_interesting = Series(bool)
+    score = Series(int)
+    category = Series(str)
+    style = Series(str)
+
+
+def test_define_measures():
+    intervals = [
+        (date(2021, 1, 1), date(2021, 1, 31)),
+        (date(2021, 2, 1), date(2021, 2, 28)),
+    ]
+
+    measures = Measures()
+
+    measures.define_defaults(
+        numerator=patients.score,
+        denominator=patients.is_interesting,
+        intervals=intervals,
+    )
+
+    measures.define_measure(
+        name="test_1",
+        group_by={"category": patients.category},
+    )
+    measures.define_measure(
+        name="test_2",
+        group_by={"style": patients.style},
+    )
+
+    assert len(measures) == 2
+
+    assert list(measures) == [
+        Measure(
+            name="test_1",
+            numerator=patients.score.qm_node,
+            denominator=patients.is_interesting.qm_node,
+            group_by={
+                "category": patients.category.qm_node,
+            },
+            intervals=tuple(intervals),
+        ),
+        Measure(
+            name="test_2",
+            numerator=patients.score.qm_node,
+            denominator=patients.is_interesting.qm_node,
+            group_by={
+                "style": patients.style.qm_node,
+            },
+            intervals=tuple(intervals),
+        ),
+    ]
+
+
+def test_cannot_redefine_defaults():
+    measures = Measures()
+    measures.define_defaults(numerator=patients.score)
+    with pytest.raises(ValidationError, match="Defaults already set"):
+        measures.define_defaults(numerator=patients.is_interesting)
+
+
+def test_must_define_all_attributes():
+    measures = Measures()
+    measures.define_defaults(numerator=patients.score)
+    with pytest.raises(
+        ValidationError, match="No value supplied for 'group_by' and no default defined"
+    ):
+        measures.define_measure(
+            name="test",
+            denominator=patients.is_interesting,
+        )
+
+
+def test_names_must_be_unique():
+    measures = Measures()
+
+    measures.define_defaults(
+        denominator=patients.is_interesting,
+        intervals=[(date(2021, 1, 1), date(2021, 1, 31))],
+        group_by={"category": patients.category},
+    )
+
+    measures.define_measure(name="test", numerator=patients.score)
+    with pytest.raises(
+        ValidationError, match="Measure already defined with name: test"
+    ):
+        measures.define_measure(name="test", numerator=patients.is_interesting)
+
+
+def test_group_by_columns_must_be_consistent():
+    measures = Measures()
+
+    measures.define_defaults(
+        numerator=patients.score,
+        denominator=patients.is_interesting,
+        intervals=[(date(2021, 1, 1), date(2021, 1, 31))],
+    )
+
+    measures.define_measure(
+        name="test_1",
+        group_by={
+            "style": patients.style,
+            "category": patients.category,
+        },
+    )
+    with pytest.raises(
+        ValidationError, match="Inconsistent definition for `group_by` column: category"
+    ):
+        measures.define_measure(
+            name="test_2",
+            group_by={
+                "style": patients.style,
+                "category": patients.is_interesting,
+            },
+        )
+
+
+def test_numerator_must_be_patient_series():
+    measures = Measures()
+
+    with pytest.raises(
+        ValidationError, match="`numerator` must be a one row per patient series"
+    ):
+        measures.define_measure(
+            name="test",
+            numerator=object(),
+            denominator=patients.is_interesting,
+            intervals=[(date(2021, 1, 1), date(2021, 1, 31))],
+            group_by={"category": patients.category},
+        )
+
+
+def test_denominator_must_be_int_or_bool_series():
+    measures = Measures()
+
+    with pytest.raises(
+        ValidationError, match="`denominator` must be a boolean or integer series"
+    ):
+        measures.define_measure(
+            name="test",
+            numerator=patients.score,
+            denominator=patients.style,
+            intervals=[(date(2021, 1, 1), date(2021, 1, 31))],
+            group_by={"category": patients.category},
+        )
+
+
+def test_reserved_column_names_are_rejected():
+    measures = Measures()
+
+    with pytest.raises(
+        ValidationError, match="disallowed `group_by` column name: measure"
+    ):
+        measures.define_measure(
+            name="test",
+            numerator=patients.score,
+            denominator=patients.is_interesting,
+            intervals=[(date(2021, 1, 1), date(2021, 1, 31))],
+            group_by={"measure": patients.category},
+        )
+
+
+@pytest.mark.parametrize(
+    "intervals,error",
+    [
+        (object(), "`intervals` must be a list"),
+        ([(1, 2)], "`intervals` must contain pairs of dates"),
+        ([(date(2020, 1, 1),)], "`intervals` must contain pairs of dates"),
+        ([(date(2021, 1, 1), date(2020, 1, 1))], "start date must be before end date"),
+    ],
+)
+def test_invalid_intervals_are_rejected(intervals, error):
+    measures = Measures()
+
+    with pytest.raises(ValidationError, match=error):
+        measures.define_measure(
+            name="test",
+            numerator=patients.score,
+            denominator=patients.is_interesting,
+            intervals=intervals,
+            group_by={"category": patients.category},
+        )

--- a/tests/unit/measures/test_measures.py
+++ b/tests/unit/measures/test_measures.py
@@ -1,8 +1,9 @@
+import re
 from datetime import date
 
 import pytest
 
-from ehrql import Measures
+from ehrql import Measures, months
 from ehrql.measures.measures import Measure, ValidationError
 from ehrql.tables import PatientFrame, Series, table
 
@@ -177,6 +178,13 @@ def test_reserved_column_names_are_rejected():
         ([(1, 2)], "`intervals` must contain pairs of dates"),
         ([(date(2020, 1, 1),)], "`intervals` must contain pairs of dates"),
         ([(date(2021, 1, 1), date(2020, 1, 1))], "start date must be before end date"),
+        (
+            months(12),
+            re.escape(
+                "You must supply a date using `months(value=12).starting_on('<DATE>')`"
+                " or `months(value=12).ending_on('<DATE>')`"
+            ),
+        ),
     ],
 )
 def test_invalid_intervals_are_rejected(intervals, error):

--- a/tests/unit/query_model/test_transforms.py
+++ b/tests/unit/query_model/test_transforms.py
@@ -5,6 +5,7 @@ from ehrql.query_model.nodes import (
     Column,
     Filter,
     Function,
+    Parameter,
     PickOneRowPerPatient,
     Position,
     SelectColumn,
@@ -16,6 +17,7 @@ from ehrql.query_model.nodes import (
 from ehrql.query_model.transforms import (
     PickOneRowPerPatientWithColumns,
     apply_transforms,
+    substitute_parameters,
 )
 
 
@@ -352,3 +354,9 @@ def test_identical_operations_are_not_transformed_differently():
 
 def transform(variable):
     return apply_transforms({"v": variable})["v"]
+
+
+def test_substitute_parameters():
+    graph = {"value": Function.Add(Value(10), Parameter("i", int))}
+    transformed = substitute_parameters(graph, i=20)
+    assert transformed == {"value": Function.Add(Value(10), Value(20))}

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -143,7 +143,7 @@ def test_load_dataset_definition_no_dataset():
 def test_load_dataset_definition_not_a_dataset():
     filename = FIXTURES / "not_a_dataset.py"
     with pytest.raises(
-        CommandError, match=r"'dataset' must be an instance of .*\.Dataset()"
+        CommandError, match=r"'dataset' must be an instance of .*\.Dataset"
     ):
         load_dataset_definition(filename, user_args=())
 

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -9,6 +9,7 @@ from ehrql.main import (
     generate_dataset,
     get_query_engine,
     load_dataset_definition,
+    load_measure_definitions,
     open_output_file,
 )
 
@@ -151,3 +152,23 @@ def test_load_dataset_definition_no_population():
     filename = FIXTURES / "no_population.py"
     with pytest.raises(CommandError, match="A population has not been defined"):
         load_dataset_definition(filename, user_args=())
+
+
+def test_load_measure_definitions_no_measures():
+    filename = FIXTURES / "no_measures.py"
+    with pytest.raises(CommandError, match="Did not find a variable called 'measures'"):
+        load_measure_definitions(filename, user_args=())
+
+
+def test_load_measure_definitions_not_measures_instance():
+    filename = FIXTURES / "not_measures_instance.py"
+    with pytest.raises(
+        CommandError, match=r"'measures' must be an instance of .*\.Measures"
+    ):
+        load_measure_definitions(filename, user_args=())
+
+
+def test_load_measure_definitions_empty_measures():
+    filename = FIXTURES / "empty_measures.py"
+    with pytest.raises(CommandError, match="No measures defined"):
+        load_measure_definitions(filename, user_args=())

--- a/tests/unit/test_query_language.py
+++ b/tests/unit/test_query_language.py
@@ -571,6 +571,9 @@ def test_ehrql_date_string_equivalence(fn_name):
     if fn_name in ["is_in", "is_not_in", "map_values"]:
         date_args = [date_args]
         str_args = [str_args]
+    if fn_name == "is_during":
+        date_args = [(date_args[0], date_args[0])]
+        str_args = [(str_args[0], str_args[0])]
 
     assert f(*date_args).qm_node == f(*str_args).qm_node
 

--- a/tests/unit/test_query_language.py
+++ b/tests/unit/test_query_language.py
@@ -28,6 +28,7 @@ from ehrql.query_language import (
     compile,
     days,
     months,
+    parse_date_if_str,
     table,
     table_from_file,
     table_from_rows,
@@ -633,3 +634,29 @@ def test_frame_classes_are_preserved():
     # suggestion. Using `hasattr()` wouldn't tell us whether the attribute was only
     # available via a magic `__getattr__` method.
     assert "start_date" in dir(latest_event)
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        # Strings are parsed as dates
+        ("2021-03-04", date(2021, 3, 4)),
+        # Other types are passed through
+        (1.23, 1.23),
+        (b"abc", b"abc"),
+    ],
+)
+def test_parse_date_if_str(value, expected):
+    assert parse_date_if_str(value) == expected
+
+
+@pytest.mark.parametrize(
+    "value,error",
+    [
+        ("1st March 2020", "Invalid isoformat string: '1st March 2020'"),
+        ("2021-02-29", "day is out of range for month in '2021-02-29'"),
+    ],
+)
+def test_parse_date_if_str_errors(value, error):
+    with pytest.raises(ValueError, match=error):
+        parse_date_if_str(value)

--- a/tests/unit/test_query_language.py
+++ b/tests/unit/test_query_language.py
@@ -20,6 +20,7 @@ from ehrql.query_language import (
     FloatPatientSeries,
     IntEventSeries,
     IntPatientSeries,
+    Parameter,
     PatientFrame,
     SchemaError,
     Series,
@@ -660,3 +661,8 @@ def test_parse_date_if_str(value, expected):
 def test_parse_date_if_str_errors(value, error):
     with pytest.raises(ValueError, match=error):
         parse_date_if_str(value)
+
+
+def test_parameter():
+    series = Parameter("test_param", date)
+    assert isinstance(series, DatePatientSeries)

--- a/tests/unit/utils/test_date_utils.py
+++ b/tests/unit/utils/test_date_utils.py
@@ -1,0 +1,91 @@
+from datetime import date
+
+import pytest
+
+from ehrql.utils.date_utils import (
+    date_add_months,
+    date_add_weeks,
+    date_add_years,
+    generate_intervals,
+)
+
+
+@pytest.mark.parametrize(
+    "start_date,n,expected",
+    [
+        (
+            date(2020, 2, 20),
+            3,
+            [
+                (date(2020, 2, 20), date(2020, 2, 26)),
+                (date(2020, 2, 27), date(2020, 3, 4)),
+                (date(2020, 3, 5), date(2020, 3, 11)),
+            ],
+        ),
+        (
+            date(2020, 3, 5),
+            -3,
+            [
+                (date(2020, 2, 20), date(2020, 2, 26)),
+                (date(2020, 2, 27), date(2020, 3, 4)),
+                (date(2020, 3, 5), date(2020, 3, 11)),
+            ],
+        ),
+    ],
+)
+def test_generate_intervals_weeks(start_date, n, expected):
+    assert generate_intervals(date_add_weeks, start_date, n) == expected
+
+
+@pytest.mark.parametrize(
+    "start_date,n,expected",
+    [
+        (
+            date(2020, 11, 1),
+            3,
+            [
+                (date(2020, 11, 1), date(2020, 11, 30)),
+                (date(2020, 12, 1), date(2020, 12, 31)),
+                (date(2021, 1, 1), date(2021, 1, 31)),
+            ],
+        ),
+        (
+            date(2021, 1, 1),
+            -3,
+            [
+                (date(2020, 11, 1), date(2020, 11, 30)),
+                (date(2020, 12, 1), date(2020, 12, 31)),
+                (date(2021, 1, 1), date(2021, 1, 31)),
+            ],
+        ),
+    ],
+)
+def test_generate_intervals_months(start_date, n, expected):
+    assert generate_intervals(date_add_months, start_date, n) == expected
+
+
+@pytest.mark.parametrize(
+    "start_date,n,expected",
+    [
+        (
+            date(2020, 11, 1),
+            3,
+            [
+                (date(2020, 11, 1), date(2021, 10, 31)),
+                (date(2021, 11, 1), date(2022, 10, 31)),
+                (date(2022, 11, 1), date(2023, 10, 31)),
+            ],
+        ),
+        (
+            date(2022, 11, 1),
+            -3,
+            [
+                (date(2020, 11, 1), date(2021, 10, 31)),
+                (date(2021, 11, 1), date(2022, 10, 31)),
+                (date(2022, 11, 1), date(2023, 10, 31)),
+            ],
+        ),
+    ],
+)
+def test_generate_intervals_years(start_date, n, expected):
+    assert generate_intervals(date_add_years, start_date, n) == expected


### PR DESCRIPTION
This adds measures support to ehrQL. Specifically it adds a new command `generate-measures`:
```
usage: ehrql generate-measures [-h] [--output OUTPUT_FILE] [--dsn DSN] [--dummy-tables DUMMY_TABLES_PATH]
                               [--dummy-data-file DUMMY_DATA_FILE] [--query-engine QUERY_ENGINE_CLASS]
                               [--backend BACKEND_CLASS]
                               definition_file

positional arguments:
  definition_file       Path of the file where measures are defined
```

This has identical arguments to `generate-dataset` except that it takes a measures definition file rather than a dataset definition.

Below is a toy example measure definition. It defines a single measure which counts the proportion of registered patients who received a vaccination in each month in 2021, broken down by sex and age band:
```py
from ehrql import INTERVAL, Measures, case, months, when
from ehrql.tables.beta.tpp import (
    patients,
    practice_registrations,
    vaccinations,
)


has_vaxx_during_interval = (
    vaccinations.where(vaccinations.date.is_during(INTERVAL))
    .exists_for_patient()
)
is_registered_during_interval = (
    practice_registrations.for_patient_on(INTERVAL.start_date)
    .exists_for_patient()
)

age = patients.age_on(INTERVAL.start_date)
age_band = case(
    when(age < 30).then("0-30"),
    when(age < 60).then("30-60"),
    when(age >= 60).then("60+"),
)

measures = Measures()

measures.define_measure(
    name="vaccinations",
    numerator=has_vaxx_during_interval,
    denominator=is_registered_during_interval,
    group_by={
        "sex": patients.sex,
        "age_band": age_band,
    },
    intervals=months(12).starting_on("2021-01-01"),
)
```

This produces output with the following structure:
measure | interval_start | interval_end | ratio | numerator | denominator | sex | age_band
-- | -- | -- | -- | -- | -- | -- | --
vaccinations | 2021-01-01 | 2021-01-31 | 0.0008 | 10 | 12345 | male | 0-30
vaccinations | 2021-01-01 | 2021-01-31 | 0.0013 | 20 | 15432 | male | 30-60
vaccinations | 2021-01-01 | 2021-01-31 | 0.0018 | 30 | 16789 | male | 60+
vaccinations | 2021-01-01 | 2021-01-31 | 0.0015 | 15 | 10123 | female | 0-30
vaccinations | 2021-01-01 | 2021-01-31 | 0.0023 | 25 | 10987 | female | 30-60
vaccinations | 2021-01-01 | 2021-01-31 | 0.0019 | 35 | 18765 | female | 60+




## Implementation

The current implementation is not any cleverer than the old Cohort Extractor implementation in that it still involves running a separate query for each interval and pulling down the full set of patient level results each time.

However, despite this there should still be some significant efficiency gains because we no longer need to write each full cohort to disk, copy it out of the volume, copy it back to _different_ volume, read it all into memory and finally calculate the measures. Instead we calculate the measures in a streaming fashion without ever needing to hold the full patient-level results in memory or write them to disk.

Longer term, the API is designed so that we can improve the [efficiency](https://github.com/opensafely-core/ehrql/issues/42) of the implementation incrementally without requiring any changes from users.

Closes #816