### PR TITLE
Fix auto-merge command

### DIFF
--- a/.github/workflows/update-external-studies.yml
+++ b/.github/workflows/update-external-studies.yml
@@ -51,6 +51,6 @@ jobs:
       # The PR will still require manual approval, this just reduces it to a one-click process
       - name: Enable automerge
         if: steps.create_pr.outputs.pull-request-operation == 'created'
-        run: gh pr merge --merge --auto --squash ${{ steps.create_pr.outputs.pull-request-number }}
+        run: gh pr merge --auto --squash ${{ steps.create_pr.outputs.pull-request-number }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update-tpp-schema.yml
+++ b/.github/workflows/update-tpp-schema.yml
@@ -51,6 +51,6 @@ jobs:
       # The PR will still require manual approval, this just reduces it to a one-click process
       - name: Enable automerge
         if: steps.create_pr.outputs.pull-request-operation == 'created'
-        run: gh pr merge --merge --auto --squash ${{ steps.create_pr.outputs.pull-request-number }}
+        run: gh pr merge --auto --squash ${{ steps.create_pr.outputs.pull-request-number }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update-tutorial-ehrql-version.yml
+++ b/.github/workflows/update-tutorial-ehrql-version.yml
@@ -61,6 +61,6 @@ jobs:
       # The PR will still require manual approval, this just reduces it to a one-click process
       - name: Enable automerge
         if: steps.create_pr.outputs.pull-request-operation == 'created'
-        run: gh pr merge --merge --auto --squash ${{ steps.create_pr.outputs.pull-request-number }}
+        run: gh pr merge --auto --squash ${{ steps.create_pr.outputs.pull-request-number }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
You can't use `--merge` and `--squash` together (obviously, in retrospect) because they denote different merge strategies. I don't know if I mis-copied this from the documentation or if the documentation was incorrect.