### PR TITLE
Add placeholder EMIS backend

### DIFF
--- a/docs/includes/generated_docs/EMISBackend.md
+++ b/docs/includes/generated_docs/EMISBackend.md
@@ -1,0 +1,1 @@
+Contracts implemented:

--- a/ehrql/__main__.py
+++ b/ehrql/__main__.py
@@ -27,6 +27,7 @@ QUERY_ENGINE_ALIASES = {
 
 
 BACKEND_ALIASES = {
+    "emis": "ehrql.backends.emis.EMISBackend",
     "tpp": "ehrql.backends.tpp.TPPBackend",
 }
 

--- a/ehrql/backends/emis.py
+++ b/ehrql/backends/emis.py
@@ -1,0 +1,56 @@
+import ehrql.tables.beta.core
+import ehrql.tables.beta.smoketest
+from ehrql.backends.base import BaseBackend, MappedTable
+from ehrql.query_engines.sqlite import SQLiteQueryEngine
+
+
+class EMISBackend(BaseBackend):
+    """
+    NOTE: This is a PLACEHOLDER in advance of completing work on the EMISBackend
+    """
+
+    # Obviously the completed backend will use a TrinoQueryEngine not SQLite
+    query_engine_class = SQLiteQueryEngine
+    patient_join_column = "patient_id"
+    implements = [
+        ehrql.tables.beta.core,
+        ehrql.tables.beta.smoketest,
+    ]
+
+    patients = MappedTable(
+        source="patients",
+        columns=dict(
+            sex="sex",
+            date_of_birth="date_of_birth",
+            date_of_death="date_of_death",
+        ),
+    )
+
+    clinical_events = MappedTable(
+        source="clinical_events",
+        columns=dict(
+            date="date",
+            snomedct_code="snomedct_code",
+            numeric_value="numeric_value",
+        ),
+    )
+
+    medications = MappedTable(
+        source="medications",
+        columns=dict(
+            date="date",
+            dmd_code="dmd_code",
+        ),
+    )
+
+    ons_deaths = MappedTable(
+        source="ons_deaths",
+        columns=dict(
+            date="date",
+            place="place",
+            **{
+                f"cause_of_death_{i:02d}": f"cause_of_death_{i:02d}"
+                for i in range(1, 16)
+            },
+        ),
+    )

--- a/ehrql/backends/tpp.py
+++ b/ehrql/backends/tpp.py
@@ -100,8 +100,7 @@ class TPPBackend(BaseBackend):
             SELECT
                 meds.Patient_ID AS patient_id,
                 CAST(meds.ConsultationDate AS date) AS date,
-                dict.DMD_ID AS dmd_code,
-                meds.MultilexDrug_ID AS multilex_code
+                dict.DMD_ID AS dmd_code
             FROM MedicationIssue AS meds
             LEFT JOIN MedicationDictionary AS dict
             ON meds.MultilexDrug_ID = dict.MultilexDrug_ID

--- a/ehrql/tables/beta/core.py
+++ b/ehrql/tables/beta/core.py
@@ -1,6 +1,6 @@
 import datetime
 
-from ehrql.codes import CTV3Code, DMDCode, ICD10Code, SNOMEDCTCode
+from ehrql.codes import DMDCode, ICD10Code, SNOMEDCTCode
 from ehrql.tables import Constraint, EventFrame, PatientFrame, Series, table
 
 
@@ -79,7 +79,6 @@ class ons_deaths(EventFrame):
 class clinical_events(EventFrame):
     date = Series(datetime.date)
     snomedct_code = Series(SNOMEDCTCode)
-    ctv3_code = Series(CTV3Code)
     numeric_value = Series(float)
 
 

--- a/ehrql/tables/beta/tpp.py
+++ b/ehrql/tables/beta/tpp.py
@@ -1,9 +1,9 @@
 import datetime
 
 from ehrql import case, when
-from ehrql.codes import SNOMEDCTCode
+from ehrql.codes import CTV3Code, SNOMEDCTCode
 from ehrql.tables import Constraint, EventFrame, PatientFrame, Series, table
-from ehrql.tables.beta.core import clinical_events, medications, ons_deaths, patients
+from ehrql.tables.beta.core import medications, ons_deaths, patients
 
 
 __all__ = [
@@ -22,6 +22,14 @@ __all__ = [
     "ons_cis",
     "isaric_raw",
 ]
+
+
+@table
+class clinical_events(EventFrame):
+    date = Series(datetime.date)
+    snomedct_code = Series(SNOMEDCTCode)
+    ctv3_code = Series(CTV3Code)
+    numeric_value = Series(float)
 
 
 @table

--- a/tests/unit/test_docs.py
+++ b/tests/unit/test_docs.py
@@ -74,6 +74,7 @@ def test_render(tmp_path):
         "specs.md",
         "contracts.md",
         "TPPBackend.md",
+        "EMISBackend.md",
     }
 
 


### PR DESCRIPTION
This required a bit of tweaking of the core `clinical_events` table to remove the `ctv3_code` column and make this a TPP-only feature.