### PR TITLE
Expose OpenPROMPT

### DIFF
--- a/ehrql/backends/tpp.py
+++ b/ehrql/backends/tpp.py
@@ -360,3 +360,18 @@ class TPPBackend(BaseBackend):
             FROM ISARIC_New
         """
     )
+
+    open_prompt = QueryTable(
+        """
+        SELECT
+            Patient_ID AS patient_id,
+            CodedEvent_ID AS ctv3_code,
+            CASE
+                WHEN CodeSystemId = 0 THEN ConceptId
+            END AS snomedct_code,
+            CAST(ConsultationDate AS date) AS consultation_date,
+            Consultation_ID AS consultation_id,
+            NumericValue AS numeric_value
+        FROM OpenPROMPT
+    """
+    )

--- a/ehrql/tables/beta/tpp.py
+++ b/ehrql/tables/beta/tpp.py
@@ -1,7 +1,7 @@
 import datetime
 
 from ehrql import case, when
-from ehrql.codes import SNOMEDCTCode
+from ehrql.codes import CTV3Code, SNOMEDCTCode
 from ehrql.tables import Constraint, EventFrame, PatientFrame, Series, table
 from ehrql.tables.beta.core import clinical_events, medications, ons_deaths, patients
 
@@ -21,6 +21,7 @@ __all__ = [
     "appointments",
     "ons_cis",
     "isaric_raw",
+    "open_prompt",
 ]
 
 
@@ -458,4 +459,28 @@ class isaric_raw(EventFrame):
     dsstdtc = Series(
         datetime.date,
         description="Outcome date.",
+    )
+
+
+@table
+class open_prompt(EventFrame):
+    ctv3_code = Series(
+        CTV3Code,
+        description="The question, as a CTV3 code",
+    )
+    snomedct_code = Series(
+        SNOMEDCTCode,
+        description="The question, as a SNOMED CT code or None",
+    )
+    consultation_date = Series(
+        datetime.date,
+        description="The date the survey was administered",
+    )
+    consultation_id = Series(
+        int,
+        description="The ID of the survey",
+    )
+    numeric_value = Series(
+        float,
+        description="The response to the question",
     )

--- a/tests/integration/backends/test_tpp.py
+++ b/tests/integration/backends/test_tpp.py
@@ -22,6 +22,7 @@ from tests.lib.tpp_schema import (
     MedicationIssue,
     ONS_CIS_New,
     ONS_Deaths,
+    OpenPROMPT,
     Organisation,
     Patient,
     PatientAddress,
@@ -940,6 +941,48 @@ def test_isaric_raw_clinical_variables(select_all):
         patient_7_results,
         patient_8_results,
         patient_9_results,
+    ]
+
+
+@register_test_for(tpp.open_prompt)
+def test_open_prompt(select_all):
+    results = select_all(
+        OpenPROMPT(
+            Patient_ID=1,
+            CodedEvent_ID="00000",
+            CodeSystemId=0,  # SNOMED CT
+            ConceptId="100000",
+            ConsultationDate="2023-01-01",
+            Consultation_ID=1,
+            NumericValue=1.0,
+        ),
+        OpenPROMPT(
+            Patient_ID=2,
+            CodedEvent_ID="Y0000",
+            CodeSystemId=2,  # CTV3 "Y"
+            ConceptId="Y0000",
+            ConsultationDate="2023-01-01",
+            Consultation_ID=2,
+            NumericValue=1.0,
+        ),
+    )
+    assert results == [
+        {
+            "patient_id": 1,
+            "ctv3_code": "00000",
+            "snomedct_code": "100000",
+            "consultation_date": date(2023, 1, 1),
+            "consultation_id": 1,
+            "numeric_value": 1.0,
+        },
+        {
+            "patient_id": 2,
+            "ctv3_code": "Y0000",
+            "snomedct_code": None,
+            "consultation_date": date(2023, 1, 1),
+            "consultation_id": 2,
+            "numeric_value": 1.0,
+        },
     ]
 
 


### PR DESCRIPTION
This PR exposes [the `OpenPROMPT` table][1].

First, some terminology. Participants answer questions in questionnaires. Their answers are responses. We expect one questionnaire to be administered once, on day 0:

1. Baseline questionnaire

We expect five questionnaires to be administered four times, on days 0, 30, 60, and 90:

1. Covid and vaccination questionnaire
1. Eq-5D questionnaire
1. Productivity questionnaire
1. Fatigue questionnaire
1. Breathing problems questionnaire

A survey comprises the responses to the questions in between five and six questionnaires on one day. There are four days, so we expect each participant to take part in four surveys.

Based on [airmid-short-data-report][2], I'm confident that:

* Participants are mostly TPP patients. However, there are some non-TPP patients (see the `patient_id` action)
* Each row represents one response (see the `consultation_id_num_rows` action)
* Each row has a valid CTV3 code (`CodedEvent_ID`). We know these codes are valid, because they have corresponding entries in the `CTV3Dictionary` table.
* For those CTV3 codes that are "Y" codes, then for each row `CodeSystemId = 2` and `ConceptId` repeats the CTV3 code (the "Y" code)
* For those CTV3 codes that aren't "Y" codes, then for each row `CodeSystemId = 0` and `ConceptId` is a SNOMED CT code. We don't know these codes are valid, because there isn't a `SNOMEDCTDictionary` table

There are some data quality issues, but these shouldn't prevent us from exposing the `OpenPROMPT` table. For example, several values of `ConsultationDate` pre-date the OpenPROMPT project (see the `consultation_date` action); many participants took part in more than four surveys and many participants took part in less than four surveys (see the `consultation_id` action).

Closes #1246 

[1]: https://reports.opensafely.org/reports/opensafely-tpp-database-schema/#OpenPROMPT
[2]: https://github.com/opensafely/airmid-short-data-report