### PR TITLE
Add generated docs for all backends and schemas

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -290,6 +290,7 @@ docs-check-generated-docs-are-current: generate-docs
       echo "Generated docs directory is current and free of other files/directories."
     else
       echo "Generated docs directory contains files/directories not in the repository."
+      git diff ./docs/includes/generated_docs/; git clean -n ./docs/includes/generated_docs/
       exit 1
     fi
 

--- a/Justfile
+++ b/Justfile
@@ -98,16 +98,9 @@ ruff *args=".": devenv
     $BIN/ruff {{ args }}
 
 # runs the various dev checks but does not change any files
-check *args: devenv black ruff docstrings
+check *args: devenv black ruff
     docker pull hadolint/hadolint
     docker run --rm -i hadolint/hadolint < Dockerfile
-
-# ensure our public facing docstrings exist so we can build docs from them
-docstrings: devenv
-    $BIN/pydocstyle ehrql/backends/tpp.py
-
-    # only enforce classes are documented for the public facing docs
-    $BIN/pydocstyle --add-ignore=D102,D103,D105,D106 ehrql/contracts/wip.py
 
 # runs the format (black) and other code linting (ruff) checks and fixes the files
 fix: devenv

--- a/docs/backends.md
+++ b/docs/backends.md
@@ -1,0 +1,20 @@
+# Backends
+
+Dataset definitions written in ehrQL can be run inside different secure
+environments, managed by different providers of EHR data. For each such
+secure environment there is a corresponding "backend" defined in ehrQL.
+This specifies what datasets are available inside each secure
+environment and does the necessary translation work to allow the same
+dataset definition to run against data modelled in different ways and
+stored in different systems.
+
+When writing a dataset definition you don't need to explicitly reference
+any particular backend. But, as not every dataset is available in every
+backend, the [table schema](../schemas/) you use to write your dataset
+definition will determine which backends it can be run against.
+
+Below are the backends currently supported in ehrQL, together with the
+list of [table schemas](../schemas/) each one supports.
+
+
+---8<-- 'includes/generated_docs/backends.md'

--- a/docs/includes/generated_docs/backends.md
+++ b/docs/includes/generated_docs/backends.md
@@ -1,0 +1,37 @@
+## TPP
+<small class="subtitle">
+  <a href="https://github.com/opensafely-core/ehrql/blob/main/ehrql/backends/tpp.py">
+    <code>ehrql.backends.tpp.TPPBackend</code>
+  </a>
+</small>
+
+[TPP](https://tpp-uk.com/) are the developers and operators of the
+[SystmOne](https://tpp-uk.com/products/) EHR platform. The ehrQL TPP backend
+provides access to primary care data from SystmOne, plus data linked from other
+sources.
+
+This backend implements the following table schemas:
+
+ * [beta.core](../schemas/beta.core/)
+ * [beta.tpp](../schemas/beta.tpp/)
+ * [beta.smoketest](../schemas/beta.smoketest/)
+
+## EMIS
+<small class="subtitle">
+  <a href="https://github.com/opensafely-core/ehrql/blob/main/ehrql/backends/emis.py">
+    <code>ehrql.backends.emis.EMISBackend</code>
+  </a>
+</small>
+
+!!! warning
+    This is backend is still under development and is not ready for production use.
+
+[EMIS Health](https://www.emishealth.com/) are the devlopers and operators of the
+[EMIS Web](https://www.emishealth.com/products/emis-web) EHR platform. The ehrQL
+EMIS backend provides access to primary care data from EMIS Web, plus data linked
+from other sources.
+
+This backend implements the following table schemas:
+
+ * [beta.core](../schemas/beta.core/)
+ * [beta.smoketest](../schemas/beta.smoketest/)

--- a/docs/includes/generated_docs/contracts.md
+++ b/docs/includes/generated_docs/contracts.md
@@ -4,8 +4,8 @@
 
 | Column name | Description | Type | Constraints |
 | ----------- | ----------- | ---- | ----------- |
-| date_of_birth | Patient's date of birth, rounded to first of month | date | Must be the first day of a month, must have a value. |
-| sex | Patient's sex | str | Must have a value, must be one of: 'female', 'male', 'intersex', 'unknown'. |
+| date_of_birth | Patient's date of birth, rounded to first of month | date | Always the first day of a month, never `null`. |
+| sex | Patient's sex | str | Never `null`, possible values: `female`, `male`, `intersex`, `unknown`. |
 | date_of_death | Patient's date of death | date | . |
 
 

--- a/docs/includes/generated_docs/schemas.md
+++ b/docs/includes/generated_docs/schemas.md
@@ -1,0 +1,46 @@
+## [beta.tpp](./beta.tpp/)
+<small class="subtitle">
+  <a href="./beta.tpp/"> view details → </a>
+</small>
+
+Available on backends: [**TPP**](../backends#tpp)
+
+This defines all the data (both primary care and externally linked) available in the TPP
+backend.
+
+## [beta.core](./beta.core/)
+<small class="subtitle">
+  <a href="./beta.core/"> view details → </a>
+</small>
+
+Available on backends: [**TPP**](../backends#tpp), [**EMIS**](../backends#emis)
+
+This schema defines the core tables and columns which should be available in any backend
+providing primary care data, allowing dataset definitions written using this schema to
+run across multiple backends.
+
+!!! warning
+    This schema is very much still a work-in-progress while the EMIS backend remains
+    under developemnt.
+
+## [beta.smoketest](./beta.smoketest/)
+<small class="subtitle">
+  <a href="./beta.smoketest/"> view details → </a>
+</small>
+
+Available on backends: [**TPP**](../backends#tpp), [**EMIS**](../backends#emis)
+
+This tiny schema is used to write a [minimal dataset definition][smoketest_repo] that
+can function as a basic end-to-end test (or "smoke test") of the OpenSAFELY platform
+across all available backends.
+
+[smoketest_repo]: https://github.com/opensafely/test-age-distribution
+
+## [examples.tutorial](./examples.tutorial/)
+<small class="subtitle">
+  <a href="./examples.tutorial/"> view details → </a>
+</small>
+
+_This schema is for development or testing purposes and is not available on any backend._
+
+This example schema is for use in the ehrQL tutorial.

--- a/docs/includes/generated_docs/schemas/beta.core.md
+++ b/docs/includes/generated_docs/schemas/beta.core.md
@@ -1,0 +1,357 @@
+# <strong>beta.core</strong> schema
+
+Available on backends: [**TPP**](../../backends#tpp), [**EMIS**](../../backends#emis)
+
+This schema defines the core tables and columns which should be available in any backend
+providing primary care data, allowing dataset definitions written using this schema to
+run across multiple backends.
+
+!!! warning
+    This schema is very much still a work-in-progress while the EMIS backend remains
+    under developemnt.
+
+``` {.python .copy title='To use this schema in an ehrQL file:'}
+from ehrql.tables.beta.core import (
+    clinical_events,
+    medications,
+    ons_deaths,
+    patients,
+)
+```
+
+<p class="dimension-indicator"><code>many rows per patient</code></p>
+## clinical_events
+
+
+
+<dl markdown="block" class="schema-column-list">
+<div markdown="block">
+  <dt id="clinical_events.date">
+    <strong>date</strong>
+    <a class="headerlink" href="#clinical_events.date" title="Permanent link">🔗</a>
+    <code>date</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="clinical_events.snomedct_code">
+    <strong>snomedct_code</strong>
+    <a class="headerlink" href="#clinical_events.snomedct_code" title="Permanent link">🔗</a>
+    <code>SNOMED-CT code</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="clinical_events.numeric_value">
+    <strong>numeric_value</strong>
+    <a class="headerlink" href="#clinical_events.numeric_value" title="Permanent link">🔗</a>
+    <code>float</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+</dl>
+
+<p class="dimension-indicator"><code>many rows per patient</code></p>
+## medications
+
+
+
+<dl markdown="block" class="schema-column-list">
+<div markdown="block">
+  <dt id="medications.date">
+    <strong>date</strong>
+    <a class="headerlink" href="#medications.date" title="Permanent link">🔗</a>
+    <code>date</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="medications.dmd_code">
+    <strong>dmd_code</strong>
+    <a class="headerlink" href="#medications.dmd_code" title="Permanent link">🔗</a>
+    <code>dm+d code</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+</dl>
+
+<p class="dimension-indicator"><code>many rows per patient</code></p>
+## ons_deaths
+
+
+
+<dl markdown="block" class="schema-column-list">
+<div markdown="block">
+  <dt id="ons_deaths.date">
+    <strong>date</strong>
+    <a class="headerlink" href="#ons_deaths.date" title="Permanent link">🔗</a>
+    <code>date</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="ons_deaths.place">
+    <strong>place</strong>
+    <a class="headerlink" href="#ons_deaths.place" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+
+
+ * Possible values: `Care Home`, `Elsewhere`, `Home`, `Hospice`, `Hospital`, `Other communal establishment`
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="ons_deaths.cause_of_death_01">
+    <strong>cause_of_death_01</strong>
+    <a class="headerlink" href="#ons_deaths.cause_of_death_01" title="Permanent link">🔗</a>
+    <code>ICD-10 code</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="ons_deaths.cause_of_death_02">
+    <strong>cause_of_death_02</strong>
+    <a class="headerlink" href="#ons_deaths.cause_of_death_02" title="Permanent link">🔗</a>
+    <code>ICD-10 code</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="ons_deaths.cause_of_death_03">
+    <strong>cause_of_death_03</strong>
+    <a class="headerlink" href="#ons_deaths.cause_of_death_03" title="Permanent link">🔗</a>
+    <code>ICD-10 code</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="ons_deaths.cause_of_death_04">
+    <strong>cause_of_death_04</strong>
+    <a class="headerlink" href="#ons_deaths.cause_of_death_04" title="Permanent link">🔗</a>
+    <code>ICD-10 code</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="ons_deaths.cause_of_death_05">
+    <strong>cause_of_death_05</strong>
+    <a class="headerlink" href="#ons_deaths.cause_of_death_05" title="Permanent link">🔗</a>
+    <code>ICD-10 code</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="ons_deaths.cause_of_death_06">
+    <strong>cause_of_death_06</strong>
+    <a class="headerlink" href="#ons_deaths.cause_of_death_06" title="Permanent link">🔗</a>
+    <code>ICD-10 code</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="ons_deaths.cause_of_death_07">
+    <strong>cause_of_death_07</strong>
+    <a class="headerlink" href="#ons_deaths.cause_of_death_07" title="Permanent link">🔗</a>
+    <code>ICD-10 code</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="ons_deaths.cause_of_death_08">
+    <strong>cause_of_death_08</strong>
+    <a class="headerlink" href="#ons_deaths.cause_of_death_08" title="Permanent link">🔗</a>
+    <code>ICD-10 code</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="ons_deaths.cause_of_death_09">
+    <strong>cause_of_death_09</strong>
+    <a class="headerlink" href="#ons_deaths.cause_of_death_09" title="Permanent link">🔗</a>
+    <code>ICD-10 code</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="ons_deaths.cause_of_death_10">
+    <strong>cause_of_death_10</strong>
+    <a class="headerlink" href="#ons_deaths.cause_of_death_10" title="Permanent link">🔗</a>
+    <code>ICD-10 code</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="ons_deaths.cause_of_death_11">
+    <strong>cause_of_death_11</strong>
+    <a class="headerlink" href="#ons_deaths.cause_of_death_11" title="Permanent link">🔗</a>
+    <code>ICD-10 code</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="ons_deaths.cause_of_death_12">
+    <strong>cause_of_death_12</strong>
+    <a class="headerlink" href="#ons_deaths.cause_of_death_12" title="Permanent link">🔗</a>
+    <code>ICD-10 code</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="ons_deaths.cause_of_death_13">
+    <strong>cause_of_death_13</strong>
+    <a class="headerlink" href="#ons_deaths.cause_of_death_13" title="Permanent link">🔗</a>
+    <code>ICD-10 code</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="ons_deaths.cause_of_death_14">
+    <strong>cause_of_death_14</strong>
+    <a class="headerlink" href="#ons_deaths.cause_of_death_14" title="Permanent link">🔗</a>
+    <code>ICD-10 code</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="ons_deaths.cause_of_death_15">
+    <strong>cause_of_death_15</strong>
+    <a class="headerlink" href="#ons_deaths.cause_of_death_15" title="Permanent link">🔗</a>
+    <code>ICD-10 code</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+</dl>
+
+<p class="dimension-indicator"><code>one row per patient</code></p>
+## patients
+
+
+
+<dl markdown="block" class="schema-column-list">
+<div markdown="block">
+  <dt id="patients.date_of_birth">
+    <strong>date_of_birth</strong>
+    <a class="headerlink" href="#patients.date_of_birth" title="Permanent link">🔗</a>
+    <code>date</code>
+  </dt>
+  <dd markdown="block">
+Patient's date of birth, rounded to first of month.
+
+ * Always the first day of a month
+ * Never `NULL`
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="patients.sex">
+    <strong>sex</strong>
+    <a class="headerlink" href="#patients.sex" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+Patient's sex.
+
+ * Possible values: `female`, `male`, `intersex`, `unknown`
+ * Never `NULL`
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="patients.date_of_death">
+    <strong>date_of_death</strong>
+    <a class="headerlink" href="#patients.date_of_death" title="Permanent link">🔗</a>
+    <code>date</code>
+  </dt>
+  <dd markdown="block">
+Patient's date of death.
+
+  </dd>
+</div>
+
+</dl>

--- a/docs/includes/generated_docs/schemas/beta.smoketest.md
+++ b/docs/includes/generated_docs/schemas/beta.smoketest.md
@@ -1,0 +1,37 @@
+# <strong>beta.smoketest</strong> schema
+
+Available on backends: [**TPP**](../../backends#tpp), [**EMIS**](../../backends#emis)
+
+This tiny schema is used to write a [minimal dataset definition][smoketest_repo] that
+can function as a basic end-to-end test (or "smoke test") of the OpenSAFELY platform
+across all available backends.
+
+[smoketest_repo]: https://github.com/opensafely/test-age-distribution
+
+``` {.python .copy title='To use this schema in an ehrQL file:'}
+from ehrql.tables.beta.smoketest import (
+    patients,
+)
+```
+
+<p class="dimension-indicator"><code>one row per patient</code></p>
+## patients
+
+
+
+<dl markdown="block" class="schema-column-list">
+<div markdown="block">
+  <dt id="patients.date_of_birth">
+    <strong>date_of_birth</strong>
+    <a class="headerlink" href="#patients.date_of_birth" title="Permanent link">🔗</a>
+    <code>date</code>
+  </dt>
+  <dd markdown="block">
+Patient's year and month of birth, provided in format YYYY-MM-01. The day will always be the first of the month.
+
+ * Always the first day of a month
+ * Never `NULL`
+  </dd>
+</div>
+
+</dl>

--- a/docs/includes/generated_docs/schemas/beta.tpp.md
+++ b/docs/includes/generated_docs/schemas/beta.tpp.md
@@ -1,0 +1,1984 @@
+# <strong>beta.tpp</strong> schema
+
+Available on backends: [**TPP**](../../backends#tpp)
+
+This defines all the data (both primary care and externally linked) available in the TPP
+backend.
+
+``` {.python .copy title='To use this schema in an ehrQL file:'}
+from ehrql.tables.beta.tpp import (
+    addresses,
+    appointments,
+    clinical_events,
+    emergency_care_attendances,
+    hospital_admissions,
+    household_memberships_2020,
+    isaric_raw,
+    medications,
+    occupation_on_covid_vaccine_record,
+    ons_cis,
+    ons_deaths,
+    open_prompt,
+    patients,
+    practice_registrations,
+    sgss_covid_all_tests,
+    vaccinations,
+)
+```
+
+<p class="dimension-indicator"><code>many rows per patient</code></p>
+## addresses
+
+
+
+<dl markdown="block" class="schema-column-list">
+<div markdown="block">
+  <dt id="addresses.address_id">
+    <strong>address_id</strong>
+    <a class="headerlink" href="#addresses.address_id" title="Permanent link">🔗</a>
+    <code>integer</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="addresses.start_date">
+    <strong>start_date</strong>
+    <a class="headerlink" href="#addresses.start_date" title="Permanent link">🔗</a>
+    <code>date</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="addresses.end_date">
+    <strong>end_date</strong>
+    <a class="headerlink" href="#addresses.end_date" title="Permanent link">🔗</a>
+    <code>date</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="addresses.address_type">
+    <strong>address_type</strong>
+    <a class="headerlink" href="#addresses.address_type" title="Permanent link">🔗</a>
+    <code>integer</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="addresses.rural_urban_classification">
+    <strong>rural_urban_classification</strong>
+    <a class="headerlink" href="#addresses.rural_urban_classification" title="Permanent link">🔗</a>
+    <code>integer</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="addresses.imd_rounded">
+    <strong>imd_rounded</strong>
+    <a class="headerlink" href="#addresses.imd_rounded" title="Permanent link">🔗</a>
+    <code>integer</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="addresses.msoa_code">
+    <strong>msoa_code</strong>
+    <a class="headerlink" href="#addresses.msoa_code" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+
+
+ * Matches regular expression: `E020[0-9]{5}`
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="addresses.has_postcode">
+    <strong>has_postcode</strong>
+    <a class="headerlink" href="#addresses.has_postcode" title="Permanent link">🔗</a>
+    <code>boolean</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="addresses.care_home_is_potential_match">
+    <strong>care_home_is_potential_match</strong>
+    <a class="headerlink" href="#addresses.care_home_is_potential_match" title="Permanent link">🔗</a>
+    <code>boolean</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="addresses.care_home_requires_nursing">
+    <strong>care_home_requires_nursing</strong>
+    <a class="headerlink" href="#addresses.care_home_requires_nursing" title="Permanent link">🔗</a>
+    <code>boolean</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="addresses.care_home_does_not_require_nursing">
+    <strong>care_home_does_not_require_nursing</strong>
+    <a class="headerlink" href="#addresses.care_home_does_not_require_nursing" title="Permanent link">🔗</a>
+    <code>boolean</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+</dl>
+
+<p class="dimension-indicator"><code>many rows per patient</code></p>
+## appointments
+
+
+
+<dl markdown="block" class="schema-column-list">
+<div markdown="block">
+  <dt id="appointments.booked_date">
+    <strong>booked_date</strong>
+    <a class="headerlink" href="#appointments.booked_date" title="Permanent link">🔗</a>
+    <code>date</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="appointments.start_date">
+    <strong>start_date</strong>
+    <a class="headerlink" href="#appointments.start_date" title="Permanent link">🔗</a>
+    <code>date</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+</dl>
+
+<p class="dimension-indicator"><code>many rows per patient</code></p>
+## clinical_events
+
+
+
+<dl markdown="block" class="schema-column-list">
+<div markdown="block">
+  <dt id="clinical_events.date">
+    <strong>date</strong>
+    <a class="headerlink" href="#clinical_events.date" title="Permanent link">🔗</a>
+    <code>date</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="clinical_events.snomedct_code">
+    <strong>snomedct_code</strong>
+    <a class="headerlink" href="#clinical_events.snomedct_code" title="Permanent link">🔗</a>
+    <code>SNOMED-CT code</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="clinical_events.ctv3_code">
+    <strong>ctv3_code</strong>
+    <a class="headerlink" href="#clinical_events.ctv3_code" title="Permanent link">🔗</a>
+    <code>CTV3 (Read v3) code</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="clinical_events.numeric_value">
+    <strong>numeric_value</strong>
+    <a class="headerlink" href="#clinical_events.numeric_value" title="Permanent link">🔗</a>
+    <code>float</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+</dl>
+
+<p class="dimension-indicator"><code>many rows per patient</code></p>
+## emergency_care_attendances
+
+
+
+<dl markdown="block" class="schema-column-list">
+<div markdown="block">
+  <dt id="emergency_care_attendances.id">
+    <strong>id</strong>
+    <a class="headerlink" href="#emergency_care_attendances.id" title="Permanent link">🔗</a>
+    <code>integer</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="emergency_care_attendances.arrival_date">
+    <strong>arrival_date</strong>
+    <a class="headerlink" href="#emergency_care_attendances.arrival_date" title="Permanent link">🔗</a>
+    <code>date</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="emergency_care_attendances.discharge_destination">
+    <strong>discharge_destination</strong>
+    <a class="headerlink" href="#emergency_care_attendances.discharge_destination" title="Permanent link">🔗</a>
+    <code>SNOMED-CT code</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="emergency_care_attendances.diagnosis_01">
+    <strong>diagnosis_01</strong>
+    <a class="headerlink" href="#emergency_care_attendances.diagnosis_01" title="Permanent link">🔗</a>
+    <code>SNOMED-CT code</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="emergency_care_attendances.diagnosis_02">
+    <strong>diagnosis_02</strong>
+    <a class="headerlink" href="#emergency_care_attendances.diagnosis_02" title="Permanent link">🔗</a>
+    <code>SNOMED-CT code</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="emergency_care_attendances.diagnosis_03">
+    <strong>diagnosis_03</strong>
+    <a class="headerlink" href="#emergency_care_attendances.diagnosis_03" title="Permanent link">🔗</a>
+    <code>SNOMED-CT code</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="emergency_care_attendances.diagnosis_04">
+    <strong>diagnosis_04</strong>
+    <a class="headerlink" href="#emergency_care_attendances.diagnosis_04" title="Permanent link">🔗</a>
+    <code>SNOMED-CT code</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="emergency_care_attendances.diagnosis_05">
+    <strong>diagnosis_05</strong>
+    <a class="headerlink" href="#emergency_care_attendances.diagnosis_05" title="Permanent link">🔗</a>
+    <code>SNOMED-CT code</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="emergency_care_attendances.diagnosis_06">
+    <strong>diagnosis_06</strong>
+    <a class="headerlink" href="#emergency_care_attendances.diagnosis_06" title="Permanent link">🔗</a>
+    <code>SNOMED-CT code</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="emergency_care_attendances.diagnosis_07">
+    <strong>diagnosis_07</strong>
+    <a class="headerlink" href="#emergency_care_attendances.diagnosis_07" title="Permanent link">🔗</a>
+    <code>SNOMED-CT code</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="emergency_care_attendances.diagnosis_08">
+    <strong>diagnosis_08</strong>
+    <a class="headerlink" href="#emergency_care_attendances.diagnosis_08" title="Permanent link">🔗</a>
+    <code>SNOMED-CT code</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="emergency_care_attendances.diagnosis_09">
+    <strong>diagnosis_09</strong>
+    <a class="headerlink" href="#emergency_care_attendances.diagnosis_09" title="Permanent link">🔗</a>
+    <code>SNOMED-CT code</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="emergency_care_attendances.diagnosis_10">
+    <strong>diagnosis_10</strong>
+    <a class="headerlink" href="#emergency_care_attendances.diagnosis_10" title="Permanent link">🔗</a>
+    <code>SNOMED-CT code</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="emergency_care_attendances.diagnosis_11">
+    <strong>diagnosis_11</strong>
+    <a class="headerlink" href="#emergency_care_attendances.diagnosis_11" title="Permanent link">🔗</a>
+    <code>SNOMED-CT code</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="emergency_care_attendances.diagnosis_12">
+    <strong>diagnosis_12</strong>
+    <a class="headerlink" href="#emergency_care_attendances.diagnosis_12" title="Permanent link">🔗</a>
+    <code>SNOMED-CT code</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="emergency_care_attendances.diagnosis_13">
+    <strong>diagnosis_13</strong>
+    <a class="headerlink" href="#emergency_care_attendances.diagnosis_13" title="Permanent link">🔗</a>
+    <code>SNOMED-CT code</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="emergency_care_attendances.diagnosis_14">
+    <strong>diagnosis_14</strong>
+    <a class="headerlink" href="#emergency_care_attendances.diagnosis_14" title="Permanent link">🔗</a>
+    <code>SNOMED-CT code</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="emergency_care_attendances.diagnosis_15">
+    <strong>diagnosis_15</strong>
+    <a class="headerlink" href="#emergency_care_attendances.diagnosis_15" title="Permanent link">🔗</a>
+    <code>SNOMED-CT code</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="emergency_care_attendances.diagnosis_16">
+    <strong>diagnosis_16</strong>
+    <a class="headerlink" href="#emergency_care_attendances.diagnosis_16" title="Permanent link">🔗</a>
+    <code>SNOMED-CT code</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="emergency_care_attendances.diagnosis_17">
+    <strong>diagnosis_17</strong>
+    <a class="headerlink" href="#emergency_care_attendances.diagnosis_17" title="Permanent link">🔗</a>
+    <code>SNOMED-CT code</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="emergency_care_attendances.diagnosis_18">
+    <strong>diagnosis_18</strong>
+    <a class="headerlink" href="#emergency_care_attendances.diagnosis_18" title="Permanent link">🔗</a>
+    <code>SNOMED-CT code</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="emergency_care_attendances.diagnosis_19">
+    <strong>diagnosis_19</strong>
+    <a class="headerlink" href="#emergency_care_attendances.diagnosis_19" title="Permanent link">🔗</a>
+    <code>SNOMED-CT code</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="emergency_care_attendances.diagnosis_20">
+    <strong>diagnosis_20</strong>
+    <a class="headerlink" href="#emergency_care_attendances.diagnosis_20" title="Permanent link">🔗</a>
+    <code>SNOMED-CT code</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="emergency_care_attendances.diagnosis_21">
+    <strong>diagnosis_21</strong>
+    <a class="headerlink" href="#emergency_care_attendances.diagnosis_21" title="Permanent link">🔗</a>
+    <code>SNOMED-CT code</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="emergency_care_attendances.diagnosis_22">
+    <strong>diagnosis_22</strong>
+    <a class="headerlink" href="#emergency_care_attendances.diagnosis_22" title="Permanent link">🔗</a>
+    <code>SNOMED-CT code</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="emergency_care_attendances.diagnosis_23">
+    <strong>diagnosis_23</strong>
+    <a class="headerlink" href="#emergency_care_attendances.diagnosis_23" title="Permanent link">🔗</a>
+    <code>SNOMED-CT code</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="emergency_care_attendances.diagnosis_24">
+    <strong>diagnosis_24</strong>
+    <a class="headerlink" href="#emergency_care_attendances.diagnosis_24" title="Permanent link">🔗</a>
+    <code>SNOMED-CT code</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+</dl>
+
+<p class="dimension-indicator"><code>many rows per patient</code></p>
+## hospital_admissions
+
+
+
+<dl markdown="block" class="schema-column-list">
+<div markdown="block">
+  <dt id="hospital_admissions.id">
+    <strong>id</strong>
+    <a class="headerlink" href="#hospital_admissions.id" title="Permanent link">🔗</a>
+    <code>integer</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="hospital_admissions.admission_date">
+    <strong>admission_date</strong>
+    <a class="headerlink" href="#hospital_admissions.admission_date" title="Permanent link">🔗</a>
+    <code>date</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="hospital_admissions.discharge_date">
+    <strong>discharge_date</strong>
+    <a class="headerlink" href="#hospital_admissions.discharge_date" title="Permanent link">🔗</a>
+    <code>date</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="hospital_admissions.admission_method">
+    <strong>admission_method</strong>
+    <a class="headerlink" href="#hospital_admissions.admission_method" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="hospital_admissions.all_diagnoses">
+    <strong>all_diagnoses</strong>
+    <a class="headerlink" href="#hospital_admissions.all_diagnoses" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="hospital_admissions.patient_classification">
+    <strong>patient_classification</strong>
+    <a class="headerlink" href="#hospital_admissions.patient_classification" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="hospital_admissions.days_in_critical_care">
+    <strong>days_in_critical_care</strong>
+    <a class="headerlink" href="#hospital_admissions.days_in_critical_care" title="Permanent link">🔗</a>
+    <code>integer</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="hospital_admissions.primary_diagnoses">
+    <strong>primary_diagnoses</strong>
+    <a class="headerlink" href="#hospital_admissions.primary_diagnoses" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+</dl>
+
+<p class="dimension-indicator"><code>one row per patient</code></p>
+## household_memberships_2020
+
+Inferred household membership as of 2020-02-01, as determined by TPP using an as yet
+undocumented algorithm.
+
+<dl markdown="block" class="schema-column-list">
+<div markdown="block">
+  <dt id="household_memberships_2020.household_pseudo_id">
+    <strong>household_pseudo_id</strong>
+    <a class="headerlink" href="#household_memberships_2020.household_pseudo_id" title="Permanent link">🔗</a>
+    <code>integer</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="household_memberships_2020.household_size">
+    <strong>household_size</strong>
+    <a class="headerlink" href="#household_memberships_2020.household_size" title="Permanent link">🔗</a>
+    <code>integer</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+</dl>
+
+<p class="dimension-indicator"><code>many rows per patient</code></p>
+## isaric_raw
+
+A subset of the ISARIC data.
+
+These columns are deliberately all taken as strings while in a preliminary phase.
+They will later change to more appropriate data types.
+
+Descriptions taken from: [CCP_REDCap_ISARIC_data_dictionary_codebook.pdf][isaric_ddc_pdf]
+
+[isaric_ddc_pdf]: https://github.com/isaric4c/wiki/blob/d6b87d59a277cf2f6deedeb5e8c1a970dbb970a3/ISARIC/CCP_REDCap_ISARIC_data_dictionary_codebook.pdf
+
+<dl markdown="block" class="schema-column-list">
+<div markdown="block">
+  <dt id="isaric_raw.age">
+    <strong>age</strong>
+    <a class="headerlink" href="#isaric_raw.age" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+Age
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="isaric_raw.age_factor">
+    <strong>age_factor</strong>
+    <a class="headerlink" href="#isaric_raw.age_factor" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+TODO
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="isaric_raw.calc_age">
+    <strong>calc_age</strong>
+    <a class="headerlink" href="#isaric_raw.calc_age" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+Calculated age (comparing date of birth with date of enrolment). May be inaccurate if a date of February 29 is used.
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="isaric_raw.sex">
+    <strong>sex</strong>
+    <a class="headerlink" href="#isaric_raw.sex" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+Sex at birth.
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="isaric_raw.ethnic___1">
+    <strong>ethnic___1</strong>
+    <a class="headerlink" href="#isaric_raw.ethnic___1" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+Ethnic group: Arab.
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="isaric_raw.ethnic___2">
+    <strong>ethnic___2</strong>
+    <a class="headerlink" href="#isaric_raw.ethnic___2" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+Ethnic group: Black.
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="isaric_raw.ethnic___3">
+    <strong>ethnic___3</strong>
+    <a class="headerlink" href="#isaric_raw.ethnic___3" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+Ethnic group: East Asian.
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="isaric_raw.ethnic___4">
+    <strong>ethnic___4</strong>
+    <a class="headerlink" href="#isaric_raw.ethnic___4" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+Ethnic group: South Asian.
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="isaric_raw.ethnic___5">
+    <strong>ethnic___5</strong>
+    <a class="headerlink" href="#isaric_raw.ethnic___5" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+Ethnic group: West Asian.
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="isaric_raw.ethnic___6">
+    <strong>ethnic___6</strong>
+    <a class="headerlink" href="#isaric_raw.ethnic___6" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+Ethnic group: Latin American.
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="isaric_raw.ethnic___7">
+    <strong>ethnic___7</strong>
+    <a class="headerlink" href="#isaric_raw.ethnic___7" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+Ethnic group: White.
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="isaric_raw.ethnic___8">
+    <strong>ethnic___8</strong>
+    <a class="headerlink" href="#isaric_raw.ethnic___8" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+Ethnic group: Aboriginal/First Nations.
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="isaric_raw.ethnic___9">
+    <strong>ethnic___9</strong>
+    <a class="headerlink" href="#isaric_raw.ethnic___9" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+Ethnic group: Other.
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="isaric_raw.ethnic___10">
+    <strong>ethnic___10</strong>
+    <a class="headerlink" href="#isaric_raw.ethnic___10" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+Ethnic group: N/A.
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="isaric_raw.covid19_vaccine">
+    <strong>covid19_vaccine</strong>
+    <a class="headerlink" href="#isaric_raw.covid19_vaccine" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+Has the patient received a Covid-19 vaccine (open label licenced product)?
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="isaric_raw.covid19_vaccined">
+    <strong>covid19_vaccined</strong>
+    <a class="headerlink" href="#isaric_raw.covid19_vaccined" title="Permanent link">🔗</a>
+    <code>date</code>
+  </dt>
+  <dd markdown="block">
+Date first vaccine given (Covid-19) if known.
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="isaric_raw.covid19_vaccine2d">
+    <strong>covid19_vaccine2d</strong>
+    <a class="headerlink" href="#isaric_raw.covid19_vaccine2d" title="Permanent link">🔗</a>
+    <code>date</code>
+  </dt>
+  <dd markdown="block">
+Date second vaccine given (Covid-19) if known.
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="isaric_raw.covid19_vaccined_nk">
+    <strong>covid19_vaccined_nk</strong>
+    <a class="headerlink" href="#isaric_raw.covid19_vaccined_nk" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+First vaccine given (Covid-19) but date not known.
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="isaric_raw.corona_ieorres">
+    <strong>corona_ieorres</strong>
+    <a class="headerlink" href="#isaric_raw.corona_ieorres" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+Suspected or proven infection with pathogen of public health interest.
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="isaric_raw.coriona_ieorres2">
+    <strong>coriona_ieorres2</strong>
+    <a class="headerlink" href="#isaric_raw.coriona_ieorres2" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+Proven or high likelihood of infection with pathogen of public health interest.
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="isaric_raw.coriona_ieorres3">
+    <strong>coriona_ieorres3</strong>
+    <a class="headerlink" href="#isaric_raw.coriona_ieorres3" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+Proven infection with pathogen of public health interest.
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="isaric_raw.inflammatory_mss">
+    <strong>inflammatory_mss</strong>
+    <a class="headerlink" href="#isaric_raw.inflammatory_mss" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+Adult or child who meets case definition for inflammatory multi-system syndrome (MIS-C/MIS-A).
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="isaric_raw.cestdat">
+    <strong>cestdat</strong>
+    <a class="headerlink" href="#isaric_raw.cestdat" title="Permanent link">🔗</a>
+    <code>date</code>
+  </dt>
+  <dd markdown="block">
+Onset date of first/earliest symptom.
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="isaric_raw.chrincard">
+    <strong>chrincard</strong>
+    <a class="headerlink" href="#isaric_raw.chrincard" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+Chronic cardiac disease, including congenital heart disease (not hypertension).
+
+ * Possible values: `YES`, `NO`, `Unknown`
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="isaric_raw.hypertension_mhyn">
+    <strong>hypertension_mhyn</strong>
+    <a class="headerlink" href="#isaric_raw.hypertension_mhyn" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+Hypertension (physician diagnosed).
+
+ * Possible values: `YES`, `NO`, `Unknown`
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="isaric_raw.chronicpul_mhyn">
+    <strong>chronicpul_mhyn</strong>
+    <a class="headerlink" href="#isaric_raw.chronicpul_mhyn" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+Chronic pulmonary disease (not asthma).
+
+ * Possible values: `YES`, `NO`, `Unknown`
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="isaric_raw.asthma_mhyn">
+    <strong>asthma_mhyn</strong>
+    <a class="headerlink" href="#isaric_raw.asthma_mhyn" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+Asthma (physician diagnosed).
+
+ * Possible values: `YES`, `NO`, `Unknown`
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="isaric_raw.renal_mhyn">
+    <strong>renal_mhyn</strong>
+    <a class="headerlink" href="#isaric_raw.renal_mhyn" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+Chronic kidney disease.
+
+ * Possible values: `YES`, `NO`, `Unknown`
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="isaric_raw.mildliver">
+    <strong>mildliver</strong>
+    <a class="headerlink" href="#isaric_raw.mildliver" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+Mild liver disease.
+
+ * Possible values: `YES`, `NO`, `Unknown`
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="isaric_raw.modliv">
+    <strong>modliv</strong>
+    <a class="headerlink" href="#isaric_raw.modliv" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+Moderate or severe liver disease
+
+ * Possible values: `YES`, `NO`, `Unknown`
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="isaric_raw.chronicneu_mhyn">
+    <strong>chronicneu_mhyn</strong>
+    <a class="headerlink" href="#isaric_raw.chronicneu_mhyn" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+Chronic neurological disorder.
+
+ * Possible values: `YES`, `NO`, `Unknown`
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="isaric_raw.malignantneo_mhyn">
+    <strong>malignantneo_mhyn</strong>
+    <a class="headerlink" href="#isaric_raw.malignantneo_mhyn" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+Malignant neoplasm.
+
+ * Possible values: `YES`, `NO`, `Unknown`
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="isaric_raw.chronichaemo_mhyn">
+    <strong>chronichaemo_mhyn</strong>
+    <a class="headerlink" href="#isaric_raw.chronichaemo_mhyn" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+Chronic haematologic disease.
+
+ * Possible values: `YES`, `NO`, `Unknown`
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="isaric_raw.aidshiv_mhyn">
+    <strong>aidshiv_mhyn</strong>
+    <a class="headerlink" href="#isaric_raw.aidshiv_mhyn" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+AIDS/HIV.
+
+ * Possible values: `YES`, `NO`, `Unknown`
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="isaric_raw.obesity_mhyn">
+    <strong>obesity_mhyn</strong>
+    <a class="headerlink" href="#isaric_raw.obesity_mhyn" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+Obesity (as defined by clinical staff).
+
+ * Possible values: `YES`, `NO`, `Unknown`
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="isaric_raw.diabetes_type_mhyn">
+    <strong>diabetes_type_mhyn</strong>
+    <a class="headerlink" href="#isaric_raw.diabetes_type_mhyn" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+Diabetes and type.
+
+ * Possible values: `NO`, `1`, `2`, `N/K`
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="isaric_raw.diabetescom_mhyn">
+    <strong>diabetescom_mhyn</strong>
+    <a class="headerlink" href="#isaric_raw.diabetescom_mhyn" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+Diabetes with complications.
+
+ * Possible values: `YES`, `NO`, `Unknown`
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="isaric_raw.diabetes_mhyn">
+    <strong>diabetes_mhyn</strong>
+    <a class="headerlink" href="#isaric_raw.diabetes_mhyn" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+Diabetes without complications.
+
+ * Possible values: `YES`, `NO`, `Unknown`
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="isaric_raw.rheumatologic_mhyn">
+    <strong>rheumatologic_mhyn</strong>
+    <a class="headerlink" href="#isaric_raw.rheumatologic_mhyn" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+Rheumatologic disorder.
+
+ * Possible values: `YES`, `NO`, `Unknown`
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="isaric_raw.dementia_mhyn">
+    <strong>dementia_mhyn</strong>
+    <a class="headerlink" href="#isaric_raw.dementia_mhyn" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+Dementia.
+
+ * Possible values: `YES`, `NO`, `Unknown`
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="isaric_raw.malnutrition_mhyn">
+    <strong>malnutrition_mhyn</strong>
+    <a class="headerlink" href="#isaric_raw.malnutrition_mhyn" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+Malnutrition.
+
+ * Possible values: `YES`, `NO`, `Unknown`
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="isaric_raw.smoking_mhyn">
+    <strong>smoking_mhyn</strong>
+    <a class="headerlink" href="#isaric_raw.smoking_mhyn" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+Smoking.
+
+ * Possible values: `Yes`, `Never Smoked`, `Former Smoker`, `N/K`
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="isaric_raw.hostdat">
+    <strong>hostdat</strong>
+    <a class="headerlink" href="#isaric_raw.hostdat" title="Permanent link">🔗</a>
+    <code>date</code>
+  </dt>
+  <dd markdown="block">
+Admission date at this facility.
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="isaric_raw.hooccur">
+    <strong>hooccur</strong>
+    <a class="headerlink" href="#isaric_raw.hooccur" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+Transfer from other facility?
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="isaric_raw.hostdat_transfer">
+    <strong>hostdat_transfer</strong>
+    <a class="headerlink" href="#isaric_raw.hostdat_transfer" title="Permanent link">🔗</a>
+    <code>date</code>
+  </dt>
+  <dd markdown="block">
+Admission date at previous facility.
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="isaric_raw.hostdat_transfernk">
+    <strong>hostdat_transfernk</strong>
+    <a class="headerlink" href="#isaric_raw.hostdat_transfernk" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+Admission date at previous facility not known.
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="isaric_raw.readm_cov19">
+    <strong>readm_cov19</strong>
+    <a class="headerlink" href="#isaric_raw.readm_cov19" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+Is the patient being readmitted with Covid-19?
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="isaric_raw.dsstdat">
+    <strong>dsstdat</strong>
+    <a class="headerlink" href="#isaric_raw.dsstdat" title="Permanent link">🔗</a>
+    <code>date</code>
+  </dt>
+  <dd markdown="block">
+Date of enrolment.
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="isaric_raw.dsstdtc">
+    <strong>dsstdtc</strong>
+    <a class="headerlink" href="#isaric_raw.dsstdtc" title="Permanent link">🔗</a>
+    <code>date</code>
+  </dt>
+  <dd markdown="block">
+Outcome date.
+
+  </dd>
+</div>
+
+</dl>
+
+<p class="dimension-indicator"><code>many rows per patient</code></p>
+## medications
+
+
+
+<dl markdown="block" class="schema-column-list">
+<div markdown="block">
+  <dt id="medications.date">
+    <strong>date</strong>
+    <a class="headerlink" href="#medications.date" title="Permanent link">🔗</a>
+    <code>date</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="medications.dmd_code">
+    <strong>dmd_code</strong>
+    <a class="headerlink" href="#medications.dmd_code" title="Permanent link">🔗</a>
+    <code>dm+d code</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+</dl>
+
+<p class="dimension-indicator"><code>many rows per patient</code></p>
+## occupation_on_covid_vaccine_record
+
+
+
+<dl markdown="block" class="schema-column-list">
+<div markdown="block">
+  <dt id="occupation_on_covid_vaccine_record.is_healthcare_worker">
+    <strong>is_healthcare_worker</strong>
+    <a class="headerlink" href="#occupation_on_covid_vaccine_record.is_healthcare_worker" title="Permanent link">🔗</a>
+    <code>boolean</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+</dl>
+
+<p class="dimension-indicator"><code>many rows per patient</code></p>
+## ons_cis
+
+Data from the ONS Covid Infection Survey.
+
+<dl markdown="block" class="schema-column-list">
+<div markdown="block">
+  <dt id="ons_cis.visit_date">
+    <strong>visit_date</strong>
+    <a class="headerlink" href="#ons_cis.visit_date" title="Permanent link">🔗</a>
+    <code>date</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="ons_cis.visit_num">
+    <strong>visit_num</strong>
+    <a class="headerlink" href="#ons_cis.visit_num" title="Permanent link">🔗</a>
+    <code>integer</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="ons_cis.is_opted_out_of_nhs_data_share">
+    <strong>is_opted_out_of_nhs_data_share</strong>
+    <a class="headerlink" href="#ons_cis.is_opted_out_of_nhs_data_share" title="Permanent link">🔗</a>
+    <code>boolean</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="ons_cis.last_linkage_dt">
+    <strong>last_linkage_dt</strong>
+    <a class="headerlink" href="#ons_cis.last_linkage_dt" title="Permanent link">🔗</a>
+    <code>date</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="ons_cis.imd_decile_e">
+    <strong>imd_decile_e</strong>
+    <a class="headerlink" href="#ons_cis.imd_decile_e" title="Permanent link">🔗</a>
+    <code>integer</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="ons_cis.imd_quartile_e">
+    <strong>imd_quartile_e</strong>
+    <a class="headerlink" href="#ons_cis.imd_quartile_e" title="Permanent link">🔗</a>
+    <code>integer</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="ons_cis.rural_urban">
+    <strong>rural_urban</strong>
+    <a class="headerlink" href="#ons_cis.rural_urban" title="Permanent link">🔗</a>
+    <code>integer</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+</dl>
+
+<p class="dimension-indicator"><code>many rows per patient</code></p>
+## ons_deaths
+
+
+
+<dl markdown="block" class="schema-column-list">
+<div markdown="block">
+  <dt id="ons_deaths.date">
+    <strong>date</strong>
+    <a class="headerlink" href="#ons_deaths.date" title="Permanent link">🔗</a>
+    <code>date</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="ons_deaths.place">
+    <strong>place</strong>
+    <a class="headerlink" href="#ons_deaths.place" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+
+
+ * Possible values: `Care Home`, `Elsewhere`, `Home`, `Hospice`, `Hospital`, `Other communal establishment`
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="ons_deaths.cause_of_death_01">
+    <strong>cause_of_death_01</strong>
+    <a class="headerlink" href="#ons_deaths.cause_of_death_01" title="Permanent link">🔗</a>
+    <code>ICD-10 code</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="ons_deaths.cause_of_death_02">
+    <strong>cause_of_death_02</strong>
+    <a class="headerlink" href="#ons_deaths.cause_of_death_02" title="Permanent link">🔗</a>
+    <code>ICD-10 code</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="ons_deaths.cause_of_death_03">
+    <strong>cause_of_death_03</strong>
+    <a class="headerlink" href="#ons_deaths.cause_of_death_03" title="Permanent link">🔗</a>
+    <code>ICD-10 code</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="ons_deaths.cause_of_death_04">
+    <strong>cause_of_death_04</strong>
+    <a class="headerlink" href="#ons_deaths.cause_of_death_04" title="Permanent link">🔗</a>
+    <code>ICD-10 code</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="ons_deaths.cause_of_death_05">
+    <strong>cause_of_death_05</strong>
+    <a class="headerlink" href="#ons_deaths.cause_of_death_05" title="Permanent link">🔗</a>
+    <code>ICD-10 code</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="ons_deaths.cause_of_death_06">
+    <strong>cause_of_death_06</strong>
+    <a class="headerlink" href="#ons_deaths.cause_of_death_06" title="Permanent link">🔗</a>
+    <code>ICD-10 code</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="ons_deaths.cause_of_death_07">
+    <strong>cause_of_death_07</strong>
+    <a class="headerlink" href="#ons_deaths.cause_of_death_07" title="Permanent link">🔗</a>
+    <code>ICD-10 code</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="ons_deaths.cause_of_death_08">
+    <strong>cause_of_death_08</strong>
+    <a class="headerlink" href="#ons_deaths.cause_of_death_08" title="Permanent link">🔗</a>
+    <code>ICD-10 code</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="ons_deaths.cause_of_death_09">
+    <strong>cause_of_death_09</strong>
+    <a class="headerlink" href="#ons_deaths.cause_of_death_09" title="Permanent link">🔗</a>
+    <code>ICD-10 code</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="ons_deaths.cause_of_death_10">
+    <strong>cause_of_death_10</strong>
+    <a class="headerlink" href="#ons_deaths.cause_of_death_10" title="Permanent link">🔗</a>
+    <code>ICD-10 code</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="ons_deaths.cause_of_death_11">
+    <strong>cause_of_death_11</strong>
+    <a class="headerlink" href="#ons_deaths.cause_of_death_11" title="Permanent link">🔗</a>
+    <code>ICD-10 code</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="ons_deaths.cause_of_death_12">
+    <strong>cause_of_death_12</strong>
+    <a class="headerlink" href="#ons_deaths.cause_of_death_12" title="Permanent link">🔗</a>
+    <code>ICD-10 code</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="ons_deaths.cause_of_death_13">
+    <strong>cause_of_death_13</strong>
+    <a class="headerlink" href="#ons_deaths.cause_of_death_13" title="Permanent link">🔗</a>
+    <code>ICD-10 code</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="ons_deaths.cause_of_death_14">
+    <strong>cause_of_death_14</strong>
+    <a class="headerlink" href="#ons_deaths.cause_of_death_14" title="Permanent link">🔗</a>
+    <code>ICD-10 code</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="ons_deaths.cause_of_death_15">
+    <strong>cause_of_death_15</strong>
+    <a class="headerlink" href="#ons_deaths.cause_of_death_15" title="Permanent link">🔗</a>
+    <code>ICD-10 code</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+</dl>
+
+<p class="dimension-indicator"><code>many rows per patient</code></p>
+## open_prompt
+
+
+
+<dl markdown="block" class="schema-column-list">
+<div markdown="block">
+  <dt id="open_prompt.ctv3_code">
+    <strong>ctv3_code</strong>
+    <a class="headerlink" href="#open_prompt.ctv3_code" title="Permanent link">🔗</a>
+    <code>CTV3 (Read v3) code</code>
+  </dt>
+  <dd markdown="block">
+The question, as a CTV3 code
+
+ * Never `NULL`
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="open_prompt.snomedct_code">
+    <strong>snomedct_code</strong>
+    <a class="headerlink" href="#open_prompt.snomedct_code" title="Permanent link">🔗</a>
+    <code>SNOMED-CT code</code>
+  </dt>
+  <dd markdown="block">
+The question, as a SNOMED CT code or None
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="open_prompt.consultation_date">
+    <strong>consultation_date</strong>
+    <a class="headerlink" href="#open_prompt.consultation_date" title="Permanent link">🔗</a>
+    <code>date</code>
+  </dt>
+  <dd markdown="block">
+The date the survey was administered
+
+ * Never `NULL`
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="open_prompt.consultation_id">
+    <strong>consultation_id</strong>
+    <a class="headerlink" href="#open_prompt.consultation_id" title="Permanent link">🔗</a>
+    <code>integer</code>
+  </dt>
+  <dd markdown="block">
+The ID of the survey
+
+ * Never `NULL`
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="open_prompt.numeric_value">
+    <strong>numeric_value</strong>
+    <a class="headerlink" href="#open_prompt.numeric_value" title="Permanent link">🔗</a>
+    <code>float</code>
+  </dt>
+  <dd markdown="block">
+The response to the question
+
+ * Never `NULL`
+  </dd>
+</div>
+
+</dl>
+
+<p class="dimension-indicator"><code>one row per patient</code></p>
+## patients
+
+
+
+<dl markdown="block" class="schema-column-list">
+<div markdown="block">
+  <dt id="patients.date_of_birth">
+    <strong>date_of_birth</strong>
+    <a class="headerlink" href="#patients.date_of_birth" title="Permanent link">🔗</a>
+    <code>date</code>
+  </dt>
+  <dd markdown="block">
+Patient's date of birth, rounded to first of month.
+
+ * Always the first day of a month
+ * Never `NULL`
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="patients.sex">
+    <strong>sex</strong>
+    <a class="headerlink" href="#patients.sex" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+Patient's sex.
+
+ * Possible values: `female`, `male`, `intersex`, `unknown`
+ * Never `NULL`
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="patients.date_of_death">
+    <strong>date_of_death</strong>
+    <a class="headerlink" href="#patients.date_of_death" title="Permanent link">🔗</a>
+    <code>date</code>
+  </dt>
+  <dd markdown="block">
+Patient's date of death.
+
+  </dd>
+</div>
+
+</dl>
+
+<p class="dimension-indicator"><code>many rows per patient</code></p>
+## practice_registrations
+
+
+
+<dl markdown="block" class="schema-column-list">
+<div markdown="block">
+  <dt id="practice_registrations.start_date">
+    <strong>start_date</strong>
+    <a class="headerlink" href="#practice_registrations.start_date" title="Permanent link">🔗</a>
+    <code>date</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="practice_registrations.end_date">
+    <strong>end_date</strong>
+    <a class="headerlink" href="#practice_registrations.end_date" title="Permanent link">🔗</a>
+    <code>date</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="practice_registrations.practice_pseudo_id">
+    <strong>practice_pseudo_id</strong>
+    <a class="headerlink" href="#practice_registrations.practice_pseudo_id" title="Permanent link">🔗</a>
+    <code>integer</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="practice_registrations.practice_stp">
+    <strong>practice_stp</strong>
+    <a class="headerlink" href="#practice_registrations.practice_stp" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+
+
+ * Matches regular expression: `E540000[0-9]{2}`
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="practice_registrations.practice_nuts1_region_name">
+    <strong>practice_nuts1_region_name</strong>
+    <a class="headerlink" href="#practice_registrations.practice_nuts1_region_name" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+Name of the NUTS level 1 region of England to which the practice belongs.
+For more information see:
+<https://www.ons.gov.uk/methodology/geography/ukgeographies/eurostat>
+
+ * Possible values: `North East`, `North West`, `Yorkshire and The Humber`, `East Midlands`, `West Midlands`, `East`, `London`, `South East`, `South West`
+  </dd>
+</div>
+
+</dl>
+
+<p class="dimension-indicator"><code>many rows per patient</code></p>
+## sgss_covid_all_tests
+
+
+
+<dl markdown="block" class="schema-column-list">
+<div markdown="block">
+  <dt id="sgss_covid_all_tests.specimen_taken_date">
+    <strong>specimen_taken_date</strong>
+    <a class="headerlink" href="#sgss_covid_all_tests.specimen_taken_date" title="Permanent link">🔗</a>
+    <code>date</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="sgss_covid_all_tests.is_positive">
+    <strong>is_positive</strong>
+    <a class="headerlink" href="#sgss_covid_all_tests.is_positive" title="Permanent link">🔗</a>
+    <code>boolean</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+</dl>
+
+<p class="dimension-indicator"><code>many rows per patient</code></p>
+## vaccinations
+
+
+
+<dl markdown="block" class="schema-column-list">
+<div markdown="block">
+  <dt id="vaccinations.vaccination_id">
+    <strong>vaccination_id</strong>
+    <a class="headerlink" href="#vaccinations.vaccination_id" title="Permanent link">🔗</a>
+    <code>integer</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="vaccinations.date">
+    <strong>date</strong>
+    <a class="headerlink" href="#vaccinations.date" title="Permanent link">🔗</a>
+    <code>date</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="vaccinations.target_disease">
+    <strong>target_disease</strong>
+    <a class="headerlink" href="#vaccinations.target_disease" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="vaccinations.product_name">
+    <strong>product_name</strong>
+    <a class="headerlink" href="#vaccinations.product_name" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+</dl>

--- a/docs/includes/generated_docs/schemas/examples.tutorial.md
+++ b/docs/includes/generated_docs/schemas/examples.tutorial.md
@@ -1,0 +1,263 @@
+# <strong>examples.tutorial</strong> schema
+
+_This schema is for development or testing purposes and is not available on any backend._
+
+This example schema is for use in the ehrQL tutorial.
+
+``` {.python .copy title='To use this schema in an ehrQL file:'}
+from ehrql.tables.examples.tutorial import (
+    clinical_events,
+    hospitalisations,
+    patient_address,
+    patients,
+    prescriptions,
+)
+```
+
+<p class="dimension-indicator"><code>many rows per patient</code></p>
+## clinical_events
+
+TODO.
+
+<dl markdown="block" class="schema-column-list">
+<div markdown="block">
+  <dt id="clinical_events.code">
+    <strong>code</strong>
+    <a class="headerlink" href="#clinical_events.code" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="clinical_events.system">
+    <strong>system</strong>
+    <a class="headerlink" href="#clinical_events.system" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="clinical_events.date">
+    <strong>date</strong>
+    <a class="headerlink" href="#clinical_events.date" title="Permanent link">🔗</a>
+    <code>date</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="clinical_events.numeric_value">
+    <strong>numeric_value</strong>
+    <a class="headerlink" href="#clinical_events.numeric_value" title="Permanent link">🔗</a>
+    <code>float</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+</dl>
+
+<p class="dimension-indicator"><code>many rows per patient</code></p>
+## hospitalisations
+
+TODO.
+
+<dl markdown="block" class="schema-column-list">
+<div markdown="block">
+  <dt id="hospitalisations.date">
+    <strong>date</strong>
+    <a class="headerlink" href="#hospitalisations.date" title="Permanent link">🔗</a>
+    <code>date</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="hospitalisations.code">
+    <strong>code</strong>
+    <a class="headerlink" href="#hospitalisations.code" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="hospitalisations.system">
+    <strong>system</strong>
+    <a class="headerlink" href="#hospitalisations.system" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+</dl>
+
+<p class="dimension-indicator"><code>many rows per patient</code></p>
+## patient_address
+
+TODO.
+
+<dl markdown="block" class="schema-column-list">
+<div markdown="block">
+  <dt id="patient_address.patientaddress_id">
+    <strong>patientaddress_id</strong>
+    <a class="headerlink" href="#patient_address.patientaddress_id" title="Permanent link">🔗</a>
+    <code>integer</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="patient_address.date_start">
+    <strong>date_start</strong>
+    <a class="headerlink" href="#patient_address.date_start" title="Permanent link">🔗</a>
+    <code>date</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="patient_address.date_end">
+    <strong>date_end</strong>
+    <a class="headerlink" href="#patient_address.date_end" title="Permanent link">🔗</a>
+    <code>date</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="patient_address.index_of_multiple_deprivation_rounded">
+    <strong>index_of_multiple_deprivation_rounded</strong>
+    <a class="headerlink" href="#patient_address.index_of_multiple_deprivation_rounded" title="Permanent link">🔗</a>
+    <code>integer</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="patient_address.has_postcode">
+    <strong>has_postcode</strong>
+    <a class="headerlink" href="#patient_address.has_postcode" title="Permanent link">🔗</a>
+    <code>boolean</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+</dl>
+
+<p class="dimension-indicator"><code>one row per patient</code></p>
+## patients
+
+
+
+<dl markdown="block" class="schema-column-list">
+<div markdown="block">
+  <dt id="patients.date_of_birth">
+    <strong>date_of_birth</strong>
+    <a class="headerlink" href="#patients.date_of_birth" title="Permanent link">🔗</a>
+    <code>date</code>
+  </dt>
+  <dd markdown="block">
+Patient's date of birth, rounded to first of month
+
+ * Always the first day of a month
+ * Never `NULL`
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="patients.sex">
+    <strong>sex</strong>
+    <a class="headerlink" href="#patients.sex" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+Patient's sex
+
+ * Never `NULL`
+ * Possible values: `female`, `male`, `intersex`, `unknown`
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="patients.date_of_death">
+    <strong>date_of_death</strong>
+    <a class="headerlink" href="#patients.date_of_death" title="Permanent link">🔗</a>
+    <code>date</code>
+  </dt>
+  <dd markdown="block">
+Patient's date of death
+
+  </dd>
+</div>
+
+</dl>
+
+<p class="dimension-indicator"><code>many rows per patient</code></p>
+## prescriptions
+
+TODO.
+
+<dl markdown="block" class="schema-column-list">
+<div markdown="block">
+  <dt id="prescriptions.prescribed_dmd_code">
+    <strong>prescribed_dmd_code</strong>
+    <a class="headerlink" href="#prescriptions.prescribed_dmd_code" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="prescriptions.processing_date">
+    <strong>processing_date</strong>
+    <a class="headerlink" href="#prescriptions.processing_date" title="Permanent link">🔗</a>
+    <code>date</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+</dl>

--- a/docs/schemas
+++ b/docs/schemas
@@ -1,0 +1,1 @@
+includes/generated_docs/schemas

--- a/docs/schemas.md
+++ b/docs/schemas.md
@@ -1,0 +1,10 @@
+# Table Schemas
+
+Table schemas define the tables and columns available to query in a
+dataset definition. The schema a dataset definition is written against
+determines which [backends](../backends/) it can be run inside.
+
+Below are a list of all table schemas available in ehrQL, together with
+the backends that support them.
+
+---8<-- 'includes/generated_docs/schemas.md'

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,0 +1,42 @@
+small.subtitle {
+  display: block;
+  margin-top: -1.2em;
+}
+
+dl.schema-column-list {
+  font-size: .64rem;
+  border: .05rem solid var(--md-typeset-table-color);
+  border-radius: .1rem;
+  border-bottom: none;
+}
+
+dl.schema-column-list > div {
+  border-bottom: .05rem solid var(--md-typeset-table-color);
+  padding: .7720588235em 1.1764705882em;
+}
+
+dl.schema-column-list dt code {
+  float: right;
+  padding-left: 1em;
+  padding-right: 1em;
+}
+
+dl.schema-column-list dd {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+dl.schema-column-list dd p, dl.schema-column-list ul {
+  margin-top: 0.25em;
+  margin-bottom: 0.5em;
+}
+
+p.dimension-indicator {
+  float: right;
+  margin-top: 2em;
+}
+
+p.dimension-indicator code {
+  padding-left: 1em;
+  padding-right: 1em;
+}

--- a/docs/toc.md
+++ b/docs/toc.md
@@ -33,6 +33,11 @@
 * [ehrQL examples](ehrql/examples.md)
 * [ehrQL reference](ehrql/reference.md)
 
+### Backends & Schemas
+
+ * [ehrQL backend reference](backends.md)
+ * [ehrQL schema reference](schemas.md)
+
 ### Explainers
 
 * [Installing ehrQL with Python (not recommended, use OpenSAFELY CLI)](ehrql/tutorial/python.md)

--- a/ehrql/backends/base.py
+++ b/ehrql/backends/base.py
@@ -11,12 +11,14 @@ class ValidationError(Exception):
 
 
 class BaseBackend:
+    display_name = None
     query_engine_class = None
     patient_join_column = None
     tables = None
     implements = ()
 
     def __init_subclass__(cls, **kwargs):
+        assert cls.display_name is not None
         assert cls.query_engine_class is not None
         assert cls.patient_join_column is not None
 

--- a/ehrql/backends/emis.py
+++ b/ehrql/backends/emis.py
@@ -9,6 +9,7 @@ class EMISBackend(BaseBackend):
     NOTE: This is a PLACEHOLDER in advance of completing work on the EMISBackend
     """
 
+    display_name = "EMIS"
     # Obviously the completed backend will use a TrinoQueryEngine not SQLite
     query_engine_class = SQLiteQueryEngine
     patient_join_column = "patient_id"

--- a/ehrql/backends/emis.py
+++ b/ehrql/backends/emis.py
@@ -6,7 +6,13 @@ from ehrql.query_engines.sqlite import SQLiteQueryEngine
 
 class EMISBackend(BaseBackend):
     """
-    NOTE: This is a PLACEHOLDER in advance of completing work on the EMISBackend
+    !!! warning
+        This is backend is still under development and is not ready for production use.
+
+    [EMIS Health](https://www.emishealth.com/) are the devlopers and operators of the
+    [EMIS Web](https://www.emishealth.com/products/emis-web) EHR platform. The ehrQL
+    EMIS backend provides access to primary care data from EMIS Web, plus data linked
+    from other sources.
     """
 
     display_name = "EMIS"

--- a/ehrql/backends/tpp.py
+++ b/ehrql/backends/tpp.py
@@ -8,6 +8,7 @@ from ehrql.query_engines.mssql import MSSQLQueryEngine
 class TPPBackend(BaseBackend):
     """Backend for working with data in TPP."""
 
+    display_name = "TPP"
     query_engine_class = MSSQLQueryEngine
     patient_join_column = "Patient_ID"
     implements = [

--- a/ehrql/backends/tpp.py
+++ b/ehrql/backends/tpp.py
@@ -6,7 +6,12 @@ from ehrql.query_engines.mssql import MSSQLQueryEngine
 
 
 class TPPBackend(BaseBackend):
-    """Backend for working with data in TPP."""
+    """
+    [TPP](https://tpp-uk.com/) are the developers and operators of the
+    [SystmOne](https://tpp-uk.com/products/) EHR platform. The ehrQL TPP backend
+    provides access to primary care data from SystmOne, plus data linked from other
+    sources.
+    """
 
     display_name = "TPP"
     query_engine_class = MSSQLQueryEngine

--- a/ehrql/codes.py
+++ b/ehrql/codes.py
@@ -51,7 +51,7 @@ class BNFCode(BaseCode):
 
 
 class CTV3Code(BaseCode):
-    "CTV3 (Read V3)"
+    "CTV3 (Read v3)"
 
     # Some of the CTV3 codes in the OpenCodelists coding system database (though not any
     # actually used in codelists) violate the below format, either by having a leading
@@ -93,15 +93,16 @@ class OPCS4Code(BaseCode):
 
 
 class SNOMEDCTCode(BaseCode):
-    "SNOMED CT"
+    "SNOMED-CT"
 
     # 6-18 digit number with no leading zeros
     # https://confluence.ihtsdotools.org/display/DOCRELFMT/6.1+SCTID+Data+Type
     regex = re.compile(r"[1-9][0-9]{5,17}")
 
 
+# Dictionary of Medicines and Devices
 class DMDCode(BaseCode):
-    "Dictionary of Medicines and Devices"
+    "dm+d"
 
     # Syntactically equivalent to SNOMED-CT
     regex = SNOMEDCTCode.regex

--- a/ehrql/docs/__init__.py
+++ b/ehrql/docs/__init__.py
@@ -27,7 +27,8 @@ def render(docs_data, output_dir):
 
     backends = docs_data["backends"]
     for backend_data in backends:
-        with open(output_dir / f"{backend_data['name']}.md", "w") as outfile:
+        name = backend_data["dotted_path"].rpartition(".")[2]
+        with open(output_dir / f"{name}.md", "w") as outfile:
             outfile.write(render_backend_old(backend_data))
 
     with open(output_dir / "specs.md", "w") as outfile:

--- a/ehrql/docs/__init__.py
+++ b/ehrql/docs/__init__.py
@@ -16,8 +16,8 @@ def generate_docs():
     backends = list(build_backends())
     schemas = list(build_schemas(backends))
     return {
-        "backends": sorted(backends, key=operator.itemgetter("name")),
-        "schemas": sorted(schemas, key=operator.itemgetter("dotted_path")),
+        "backends": backends,
+        "schemas": schemas,
         "contracts": sorted(build_contracts(), key=operator.itemgetter("dotted_path")),
         "specs": build_specs(),
     }

--- a/ehrql/docs/__init__.py
+++ b/ehrql/docs/__init__.py
@@ -26,26 +26,32 @@ def generate_docs():
 def render(docs_data, output_dir):
     output_dir.mkdir(exist_ok=True, parents=True)
     with open(output_dir / "contracts.md", "w") as outfile:
-        outfile.write(render_contracts(docs_data["contracts"]))
+        outfile.write(fix_whitespace(render_contracts(docs_data["contracts"])))
 
     with open(output_dir / "backends.md", "w") as outfile:
-        outfile.write(render_backends(docs_data["backends"]))
+        outfile.write(fix_whitespace(render_backends(docs_data["backends"])))
 
     with open(output_dir / "schemas.md", "w") as outfile:
-        outfile.write(render_schema_index(docs_data["schemas"]))
+        outfile.write(fix_whitespace(render_schema_index(docs_data["schemas"])))
 
     schema_dir = output_dir / "schemas"
     shutil.rmtree(schema_dir, ignore_errors=True)
     schema_dir.mkdir()
     for schema_data in docs_data["schemas"]:
         with open(schema_dir / f"{schema_data['name']}.md", "w") as outfile:
-            outfile.write(render_schema(schema_data))
+            outfile.write(fix_whitespace(render_schema(schema_data)))
 
     backends = docs_data["backends"]
     for backend_data in backends:
         name = backend_data["dotted_path"].rpartition(".")[2]
         with open(output_dir / f"{name}.md", "w") as outfile:
-            outfile.write(render_backend_old(backend_data))
+            outfile.write(fix_whitespace(render_backend_old(backend_data)))
 
     with open(output_dir / "specs.md", "w") as outfile:
-        outfile.write(render_specs(docs_data["specs"]))
+        outfile.write(fix_whitespace(render_specs(docs_data["specs"])))
+
+
+def fix_whitespace(s):
+    # Our pre-commit hook doesn't like trailing whitespace but insists on a terminating
+    # newline at the end of the file
+    return s.rstrip() + "\n"

--- a/ehrql/docs/__init__.py
+++ b/ehrql/docs/__init__.py
@@ -1,9 +1,12 @@
 import operator
+import shutil
 
 from .backends import build_backends
 from .contracts import build_contracts
+from .render_includes.backends import render_backends
 from .render_includes.backends_old import render_backend_old
 from .render_includes.contracts import render_contracts
+from .render_includes.schemas import render_schema, render_schema_index
 from .render_includes.specs import render_specs
 from .schemas import build_schemas
 from .specs import build_specs
@@ -24,6 +27,19 @@ def render(docs_data, output_dir):
     output_dir.mkdir(exist_ok=True, parents=True)
     with open(output_dir / "contracts.md", "w") as outfile:
         outfile.write(render_contracts(docs_data["contracts"]))
+
+    with open(output_dir / "backends.md", "w") as outfile:
+        outfile.write(render_backends(docs_data["backends"]))
+
+    with open(output_dir / "schemas.md", "w") as outfile:
+        outfile.write(render_schema_index(docs_data["schemas"]))
+
+    schema_dir = output_dir / "schemas"
+    shutil.rmtree(schema_dir, ignore_errors=True)
+    schema_dir.mkdir()
+    for schema_data in docs_data["schemas"]:
+        with open(schema_dir / f"{schema_data['name']}.md", "w") as outfile:
+            outfile.write(render_schema(schema_data))
 
     backends = docs_data["backends"]
     for backend_data in backends:

--- a/ehrql/docs/__init__.py
+++ b/ehrql/docs/__init__.py
@@ -2,7 +2,7 @@ import operator
 
 from .backends import build_backends
 from .contracts import build_contracts
-from .render_includes.backends import render_backend
+from .render_includes.backends_old import render_backend_old
 from .render_includes.contracts import render_contracts
 from .render_includes.specs import render_specs
 from .schemas import build_schemas
@@ -28,7 +28,7 @@ def render(docs_data, output_dir):
     backends = docs_data["backends"]
     for backend_data in backends:
         with open(output_dir / f"{backend_data['name']}.md", "w") as outfile:
-            outfile.write(render_backend(backend_data))
+            outfile.write(render_backend_old(backend_data))
 
     with open(output_dir / "specs.md", "w") as outfile:
         outfile.write(render_specs(docs_data["specs"]))

--- a/ehrql/docs/__main__.py
+++ b/ehrql/docs/__main__.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 from . import generate_docs, render
 
+
 if __name__ == "__main__":
     output_dir = sys.argv[1]
     render(generate_docs(), Path(output_dir))

--- a/ehrql/docs/backends.py
+++ b/ehrql/docs/backends.py
@@ -1,5 +1,10 @@
 import operator
+import sys
+from pathlib import Path
 
+import ehrql
+import ehrql.tables
+from ehrql.docs.common import reformat_docstring
 from ehrql.utils.module_utils import get_sibling_subclasses
 
 from ..backends.base import BaseBackend
@@ -10,12 +15,23 @@ def build_backends():
     backends.sort(key=operator.attrgetter("__name__"))
 
     for backend in backends:
-        implements = [namespace.__name__ for namespace in backend.implements]
+        implements = [
+            namespace.__name__.removeprefix(ehrql.tables.__name__ + ".")
+            for namespace in backend.implements
+        ]
         yield {
             "name": backend.display_name,
             "dotted_path": f"{backend.__module__}.{backend.__qualname__}",
+            "file_path": relative_file_path(backend.__module__),
+            "docstring": reformat_docstring(backend.__doc__),
             "implements": implements,
             # TODO: Backends no longer implement individual contracts but we leave this
             # empty list in place for now while we update the docs code which expects it
             "contracts": [],
         }
+
+
+def relative_file_path(module_dotted_path):
+    module_file = Path(sys.modules[module_dotted_path].__file__)
+    ehrql_base = Path(ehrql.__file__).parents[1]
+    return str(module_file.relative_to(ehrql_base))

--- a/ehrql/docs/backends.py
+++ b/ehrql/docs/backends.py
@@ -1,4 +1,3 @@
-import operator
 import sys
 from pathlib import Path
 
@@ -10,28 +9,41 @@ from ehrql.utils.module_utils import get_sibling_subclasses
 from ..backends.base import BaseBackend
 
 
-def build_backends():
-    backends = get_sibling_subclasses(BaseBackend)
-    backends.sort(key=operator.attrgetter("__name__"))
+SORT_ORDER = {k: i for i, k in enumerate(["TPP", "EMIS"])}
 
-    for backend in backends:
+
+def build_backends():
+    backend_classes = get_sibling_subclasses(BaseBackend)
+
+    backends = []
+    for backend in backend_classes:
         implements = [
             namespace.__name__.removeprefix(ehrql.tables.__name__ + ".")
             for namespace in backend.implements
         ]
-        yield {
-            "name": backend.display_name,
-            "dotted_path": f"{backend.__module__}.{backend.__qualname__}",
-            "file_path": relative_file_path(backend.__module__),
-            "docstring": reformat_docstring(backend.__doc__),
-            "implements": implements,
-            # TODO: Backends no longer implement individual contracts but we leave this
-            # empty list in place for now while we update the docs code which expects it
-            "contracts": [],
-        }
+        backends.append(
+            {
+                "name": backend.display_name,
+                "dotted_path": f"{backend.__module__}.{backend.__qualname__}",
+                "file_path": relative_file_path(backend.__module__),
+                "docstring": reformat_docstring(backend.__doc__),
+                "implements": implements,
+                # TODO: Backends no longer implement individual contracts but we leave this
+                # empty list in place for now while we update the docs code which expects it
+                "contracts": [],
+            }
+        )
+
+    backends.sort(key=sort_key)
+    return backends
 
 
 def relative_file_path(module_dotted_path):
     module_file = Path(sys.modules[module_dotted_path].__file__)
     ehrql_base = Path(ehrql.__file__).parents[1]
     return str(module_file.relative_to(ehrql_base))
+
+
+def sort_key(obj):
+    k = obj["name"]
+    return SORT_ORDER.get(k, float("+inf")), k

--- a/ehrql/docs/backends.py
+++ b/ehrql/docs/backends.py
@@ -12,7 +12,8 @@ def build_backends():
     for backend in backends:
         implements = [namespace.__name__ for namespace in backend.implements]
         yield {
-            "name": backend.__name__,
+            "name": backend.display_name,
+            "dotted_path": f"{backend.__module__}.{backend.__qualname__}",
             "implements": implements,
             # TODO: Backends no longer implement individual contracts but we leave this
             # empty list in place for now while we update the docs code which expects it

--- a/ehrql/docs/common.py
+++ b/ehrql/docs/common.py
@@ -1,3 +1,6 @@
+import textwrap
+
+
 def build_hierarchy(contract):
     # get the contract's hierarchy without the contracts path prefix
     hierarchy = contract.__module__.removeprefix("ehrql.contracts.")
@@ -9,8 +12,14 @@ def build_hierarchy(contract):
 def reformat_docstring(d):
     """Reformat docstring to make it easier to use in a markdown/HTML document."""
     if d is None:
-        return []
-
-    docstring = d.strip()
-
-    return [line.strip() for line in docstring.splitlines()]
+        return ""
+    # Note that before de-indenting we strip leading newlines but not leading whitespace
+    # more generally. This means we can correctly handle docstrings like:
+    #
+    #   class Foo:
+    #       """
+    #       Blah blah
+    #       blah
+    #       """
+    #
+    return textwrap.dedent(d.lstrip("\n")).strip()

--- a/ehrql/docs/render_includes/backends.py
+++ b/ehrql/docs/render_includes/backends.py
@@ -1,0 +1,27 @@
+BACKEND_TEMPLATE = """\
+## {name}
+<small class="subtitle">
+  <a href="https://github.com/opensafely-core/ehrql/blob/main/{file_path}">
+    <code>{dotted_path}</code>
+  </a>
+</small>
+
+{docstring}
+
+This backend implements the following table schemas:
+
+{schema_list}
+"""
+
+
+def render_backends(backend_data):
+    return "\n".join(
+        BACKEND_TEMPLATE.format(
+            **backend,
+            schema_list="\n".join(
+                f" * [{schema}](../schemas/{schema}/)"
+                for schema in backend["implements"]
+            ),
+        )
+        for backend in backend_data
+    )

--- a/ehrql/docs/render_includes/backends_old.py
+++ b/ehrql/docs/render_includes/backends_old.py
@@ -6,7 +6,7 @@ Contracts implemented:
 """
 
 
-def render_backend(backend_data):
+def render_backend_old(backend_data):
     contracts = [
         (c, c.lower().replace("/", "")) for c in sorted(backend_data["contracts"])
     ]

--- a/ehrql/docs/render_includes/contracts.py
+++ b/ehrql/docs/render_includes/contracts.py
@@ -17,7 +17,7 @@ def render_contracts(contracts_data):
     for contract in contracts_data:
         hierarchy = [h.title() for h in contract["hierarchy"]]
         name = "/".join([*hierarchy, contract["name"]])
-        docstring = "\n".join(contract["docstring"])
+        docstring = contract["docstring"]
         columns = "\n".join(
             f"| {c['name']} | {c['description']} | {c['type']} | {', '.join(c['constraints']).capitalize()}. |"
             for c in contract["columns"]

--- a/ehrql/docs/render_includes/schemas.py
+++ b/ehrql/docs/render_includes/schemas.py
@@ -99,7 +99,7 @@ COLUMN_TEMPLATE = """\
     <code>{type}</code>
   </dt>
   <dd markdown="block">
-    {description_with_constraints}
+{description_with_constraints}
   </dd>
 </div>
 """

--- a/ehrql/docs/render_includes/schemas.py
+++ b/ehrql/docs/render_includes/schemas.py
@@ -1,0 +1,122 @@
+SCHEMA_INDEX_TEMPLATE = """\
+## [{name}](./{name}/)
+<small class="subtitle">
+  <a href="./{name}/"> view details → </a>
+</small>
+
+{implemented_by_list}
+
+{docstring}
+"""
+
+
+def render_schema_index(schemas):
+    return "\n".join(
+        SCHEMA_INDEX_TEMPLATE.format(
+            **schema,
+            implemented_by_list=implemented_by_list(schema["implemented_by"], depth=1),
+        )
+        for schema in schemas
+    )
+
+
+def implemented_by_list(backends, depth=1):
+    if not backends:
+        return (
+            "_This schema is for development or testing purposes and is not"
+            " available on any backend._"
+        )
+    url_prefix = "/".join([".."] * depth)
+    backend_links = [
+        f"[**{backend}**]({url_prefix}/backends#{backend.lower()})"
+        for backend in backends
+    ]
+    return f"Available on backends: {', '.join(backend_links)}"
+
+
+SCHEMA_TEMPLATE = """\
+# <strong>{name}</strong> schema
+
+{implemented_by_list}
+
+{docstring}
+
+``` {{.python .copy title='To use this schema in an ehrQL file:'}}
+from {dotted_path} import (
+{table_imports}
+)
+```
+
+{table_descriptions}
+"""
+
+
+def render_schema(schema):
+    return SCHEMA_TEMPLATE.format(
+        **schema,
+        implemented_by_list=implemented_by_list(schema["implemented_by"], depth=2),
+        table_imports=table_imports(schema["tables"]),
+        table_descriptions=table_descriptions(schema["tables"]),
+    )
+
+
+def table_imports(tables):
+    return "\n".join(f"    {table['name']}," for table in tables)
+
+
+TABLE_TEMPLATE = """\
+<p class="dimension-indicator"><code>{dimension}</code></p>
+## {name}
+
+{docstring}
+
+<dl markdown="block" class="schema-column-list">
+{column_descriptions}
+</dl>
+"""
+
+
+def table_descriptions(tables):
+    return "\n".join(
+        TABLE_TEMPLATE.format(
+            **table,
+            column_descriptions=column_descriptions(table["name"], table["columns"]),
+            dimension=(
+                "one row per patient"
+                if table["has_one_row_per_patient"]
+                else "many rows per patient"
+            ),
+        )
+        for table in tables
+    )
+
+
+COLUMN_TEMPLATE = """\
+<div markdown="block">
+  <dt id="{column_id}">
+    <strong>{name}</strong>
+    <a class="headerlink" href="#{column_id}" title="Permanent link">🔗</a>
+    <code>{type}</code>
+  </dt>
+  <dd markdown="block">
+    {description_with_constraints}
+  </dd>
+</div>
+"""
+
+
+def column_descriptions(table_name, columns):
+    return "\n".join(
+        COLUMN_TEMPLATE.format(
+            **column,
+            column_id=f"{table_name}.{column['name']}",
+            description_with_constraints=description_with_constraints(column),
+        )
+        for column in columns
+    )
+
+
+def description_with_constraints(column):
+    return "\n".join(
+        [column["description"], "", *[f" * {c}" for c in column["constraints"]]]
+    )

--- a/ehrql/docs/schemas.py
+++ b/ehrql/docs/schemas.py
@@ -1,7 +1,7 @@
 from collections import defaultdict
 
 from ehrql import tables
-from ehrql.query_language import BaseFrame, Series
+from ehrql.query_language import BaseFrame, PatientFrame, Series
 from ehrql.utils.module_utils import get_submodules
 
 from .common import reformat_docstring
@@ -18,11 +18,13 @@ def build_schemas(backends=()):
         docstring = reformat_docstring(module.__doc__)
         dotted_path = module.__name__
         hierarchy = dotted_path.removeprefix(f"{tables.__name__}.").split(".")
+        name = ".".join(hierarchy)
         implemented_by = [
-            backend_name for backend_name in module_name_to_backends[module.__name__]
+            backend_name for backend_name in module_name_to_backends[name]
         ]
 
         yield {
+            "name": name,
             "dotted_path": dotted_path,
             "hierarchy": hierarchy,
             "docstring": docstring,
@@ -55,6 +57,7 @@ def build_tables(module):
             "name": name,
             "docstring": docstring,
             "columns": columns,
+            "has_one_row_per_patient": isinstance(obj, PatientFrame),
         }
 
 

--- a/ehrql/docs/schemas.py
+++ b/ehrql/docs/schemas.py
@@ -1,6 +1,8 @@
+import datetime
 from collections import defaultdict
 
 from ehrql import tables
+from ehrql.codes import BaseCode
 from ehrql.query_language import BaseFrame, PatientFrame, Series
 from ehrql.utils.module_utils import get_submodules
 
@@ -74,9 +76,21 @@ def build_column(name, series):
     return {
         "name": name,
         "description": series.description,
-        "type": series.type_.__name__,
+        "type": get_name_for_type(series.type_),
         "constraints": [c.description for c in series.constraints],
     }
+
+
+def get_name_for_type(type_):
+    if issubclass(type_, BaseCode):
+        return f"{type_.__doc__} code"
+    return {
+        bool: "boolean",
+        int: "integer",
+        float: "float",
+        str: "string",
+        datetime.date: "date",
+    }[type_]
 
 
 def sort_key(obj):

--- a/ehrql/query_model/table_schema.py
+++ b/ehrql/query_model/table_schema.py
@@ -20,16 +20,16 @@ class Constraint:
 
         @property
         def description(self):
-            return f"Must be one of: {', '.join(map(repr, self.values))}"
+            return f"Possible values: {', '.join(f'`{v}`' for v in self.values)}"
 
     class NotNull(BaseConstraint):
-        description = "Must have a value"
+        description = "Never `NULL`"
 
     class Unique(BaseConstraint):
-        description = "Must be unique"
+        description = "Always unique"
 
     class FirstOfMonth(BaseConstraint):
-        description = "Must be the first day of a month"
+        description = "Always the first day of a month"
 
     class Regex(BaseConstraint):
         regex: str
@@ -39,7 +39,7 @@ class Constraint:
 
         @property
         def description(self):
-            return f"Must match the regular expression: {self.regex!r}"
+            return f"Matches regular expression: `{self.regex}`"
 
 
 @dataclasses.dataclass(frozen=True)

--- a/ehrql/tables/beta/core.py
+++ b/ehrql/tables/beta/core.py
@@ -18,8 +18,8 @@ class patients(PatientFrame):
             'Specify how this has been determined, e.g. "sex at birth", or "current sex".'
         ),
         constraints=[
-            Constraint.NotNull(),
             Constraint.Categorical(["female", "male", "intersex", "unknown"]),
+            Constraint.NotNull(),
         ],
     )
     date_of_death = Series(

--- a/ehrql/tables/beta/core.py
+++ b/ehrql/tables/beta/core.py
@@ -1,3 +1,12 @@
+"""
+This schema defines the core tables and columns which should be available in any backend
+providing primary care data, allowing dataset definitions written using this schema to
+run across multiple backends.
+
+!!! warning
+    This schema is very much still a work-in-progress while the EMIS backend remains
+    under developemnt.
+"""
 import datetime
 
 from ehrql.codes import DMDCode, ICD10Code, SNOMEDCTCode
@@ -8,12 +17,12 @@ from ehrql.tables import Constraint, EventFrame, PatientFrame, Series, table
 class patients(PatientFrame):
     date_of_birth = Series(
         datetime.date,
-        description="Patient's date of birth, rounded to first of month",
+        description="Patient's date of birth, rounded to first of month.",
         constraints=[Constraint.FirstOfMonth(), Constraint.NotNull()],
     )
     sex = Series(
         str,
-        description="Patient's sex",
+        description="Patient's sex.",
         implementation_notes_to_add_to_description=(
             'Specify how this has been determined, e.g. "sex at birth", or "current sex".'
         ),
@@ -24,7 +33,7 @@ class patients(PatientFrame):
     )
     date_of_death = Series(
         datetime.date,
-        description="Patient's date of death",
+        description="Patient's date of death.",
     )
 
     def age_on(self, date):

--- a/ehrql/tables/beta/smoketest.py
+++ b/ehrql/tables/beta/smoketest.py
@@ -1,6 +1,9 @@
 """
-This is the minimal schema required to run the OpenSAFELY system smoke test.
-All backends should implement this schema.
+This tiny schema is used to write a [minimal dataset definition][smoketest_repo] that
+can function as a basic end-to-end test (or "smoke test") of the OpenSAFELY platform
+across all available backends.
+
+[smoketest_repo]: https://github.com/opensafely/test-age-distribution
 """
 
 import datetime

--- a/ehrql/tables/beta/tpp.py
+++ b/ehrql/tables/beta/tpp.py
@@ -1,3 +1,7 @@
+"""
+This defines all the data (both primary care and externally linked) available in the TPP
+backend.
+"""
 import datetime
 
 from ehrql import case, when
@@ -70,7 +74,7 @@ class practice_registrations(EventFrame):
         description=(
             "Name of the NUTS level 1 region of England to which the practice belongs.\n"
             "For more information see:\n"
-            "https://www.ons.gov.uk/methodology/geography/ukgeographies/eurostat"
+            "<https://www.ons.gov.uk/methodology/geography/ukgeographies/eurostat>"
         ),
     )
 
@@ -205,7 +209,7 @@ class appointments(EventFrame):
 class household_memberships_2020(PatientFrame):
     """
     Inferred household membership as of 2020-02-01, as determined by TPP using an as yet
-    undocumented algorithm
+    undocumented algorithm.
     """
 
     household_pseudo_id = Series(int)
@@ -215,7 +219,7 @@ class household_memberships_2020(PatientFrame):
 @table
 class ons_cis(EventFrame):
     """
-    ONS Covid Infection Survery
+    Data from the ONS Covid Infection Survey.
     """
 
     visit_date = Series(datetime.date)
@@ -235,8 +239,9 @@ class isaric_raw(EventFrame):
     These columns are deliberately all taken as strings while in a preliminary phase.
     They will later change to more appropriate data types.
 
-    Descriptions taken from:
-    https://github.com/isaric4c/wiki/blob/d6b87d59a277cf2f6deedeb5e8c1a970dbb970a3/ISARIC/CCP_REDCap_ISARIC_data_dictionary_codebook.pdf
+    Descriptions taken from: [CCP_REDCap_ISARIC_data_dictionary_codebook.pdf][isaric_ddc_pdf]
+
+    [isaric_ddc_pdf]: https://github.com/isaric4c/wiki/blob/d6b87d59a277cf2f6deedeb5e8c1a970dbb970a3/ISARIC/CCP_REDCap_ISARIC_data_dictionary_codebook.pdf
     """
 
     # Demographics

--- a/ehrql/tables/examples/tutorial.py
+++ b/ehrql/tables/examples/tutorial.py
@@ -1,3 +1,6 @@
+"""
+This example schema is for use in the ehrQL tutorial.
+"""
 import datetime
 
 from ehrql.tables import Constraint, EventFrame, PatientFrame, Series, table

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,6 +17,9 @@ nav:
 theme:
   name: material
 
+extra_css:
+  - stylesheets/extra.css
+
 watch:
   - docs
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -33,6 +33,7 @@ plugins:
 markdown_extensions:
   - pymdownx.details
   - pymdownx.snippets:
+      check_paths: true
       base_path: docs
   - pymdownx.superfences:
       custom_fences:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,18 +81,18 @@ line-length = 88
 exclude = [
   ".direnv",
   ".git",
-  ".github",
+  ".github/",
   ".ipynb_checkpoints",
   ".pytest_cache",
-  ".venv",
+  ".venv/",
   "__pycache__",
-  "coverage",
-  "docker",
-  "docs",
-  "htmlcov",
+  "coverage/",
+  "docker/",
+  "docs/",
+  "htmlcov/",
   "tests/acceptance/external_studies/",
   "tests/fixtures/bad_dataset_definitions",
-  "venv",
+  "venv/",
 ]
 extend-select = [
   "A", # flake8-builtins

--- a/requirements.dev.in
+++ b/requirements.dev.in
@@ -9,7 +9,6 @@ docker
 hypothesis
 pip-tools
 pre-commit
-pydocstyle
 pytest
 pytest-cov
 pytest-mock

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -412,10 +412,6 @@ pre-commit==3.3.2 \
     --hash=sha256:66e37bec2d882de1f17f88075047ef8962581f83c234ac08da21a0c58953d1f0 \
     --hash=sha256:8056bc52181efadf4aac792b1f4f255dfd2fb5a350ded7335d251a68561e8cb6
     # via -r requirements.dev.in
-pydocstyle==6.3.0 \
-    --hash=sha256:118762d452a49d6b05e194ef344a55822987a462831ade91ec5c06fd2169d019 \
-    --hash=sha256:7ce43f0c0ac87b07494eb9c0b462c0b73e6ff276807f204d6b53edc72b7e44e1
-    # via -r requirements.dev.in
 pygments==2.14.0 \
     --hash=sha256:b3ed06a9e8ac9a9aae5a6f5dbe78a8a58655d17b43b93c078f094ddc476ae297 \
     --hash=sha256:fa7bd7bd2771287c0de303af8bfdfc731f51bd2c6a47ab69d117138893b82717
@@ -600,10 +596,6 @@ six==1.16.0 \
     --hash=sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926 \
     --hash=sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254
     # via python-dateutil
-snowballstemmer==2.2.0 \
-    --hash=sha256:09b16deb8547d3412ad7b590689584cd0fe25ec8db3be37788be3810cbf19cb1 \
-    --hash=sha256:c8e1716e83cc398ae16824e5572ae04e0d9fc2c6b985fb0f900f5f0c96ecba1a
-    # via pydocstyle
 sortedcontainers==2.4.0 \
     --hash=sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88 \
     --hash=sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0

--- a/tests/integration/backends/test_base.py
+++ b/tests/integration/backends/test_base.py
@@ -25,6 +25,7 @@ class covid_tests(EventFrame):
 
 
 class TestBackend(BaseBackend):
+    display_name = "Test Backend"
     query_engine_class = BaseSQLQueryEngine
     patient_join_column = "patient_id"
 

--- a/tests/integration/test___main__.py
+++ b/tests/integration/test___main__.py
@@ -49,3 +49,8 @@ def test_all_backends_have_an_alias():
     for cls in get_sibling_subclasses(BaseBackend):
         name = f"{cls.__module__}.{cls.__name__}"
         assert name in BACKEND_ALIASES.values(), f"No alias defined for '{name}'"
+
+
+def test_all_backend_aliases_match_display_names():
+    for alias in BACKEND_ALIASES.keys():
+        assert backend_from_id(alias).display_name.lower() == alias

--- a/tests/unit/backends/test_base.py
+++ b/tests/unit/backends/test_base.py
@@ -16,6 +16,7 @@ from ehrql.tables import PatientFrame, Series, table
 
 
 class TestBackend(BaseBackend):
+    display_name = "Test Backend"
     query_engine_class = BaseSQLQueryEngine
     patient_join_column = "PatientId"
 
@@ -106,6 +107,7 @@ class Schema:
 
 def test_backend_definition_is_allowed_extra_tables_and_columns():
     class TestBackend(BaseBackend):
+        display_name = "Test Backend"
         query_engine_class = BaseSQLQueryEngine
         patient_join_column = "patient_id"
         implements = [Schema]
@@ -124,6 +126,7 @@ def test_backend_definition_is_allowed_extra_tables_and_columns():
 
 def test_backend_definition_accepts_query_table():
     class TestBackend(BaseBackend):
+        display_name = "Test Backend"
         query_engine_class = BaseSQLQueryEngine
         patient_join_column = "patient_id"
         implements = [Schema]
@@ -139,6 +142,7 @@ def test_backend_definition_fails_if_missing_tables():
     with pytest.raises(ValidationError, match="does not implement table"):
 
         class TestBackend(BaseBackend):
+            display_name = "Test Backend"
             query_engine_class = BaseSQLQueryEngine
             patient_join_column = "patient_id"
             implements = [Schema]
@@ -153,6 +157,7 @@ def test_backend_definition_fails_if_missing_column():
     with pytest.raises(ValidationError, match="missing columns"):
 
         class TestBackend(BaseBackend):
+            display_name = "Test Backend"
             query_engine_class = BaseSQLQueryEngine
             patient_join_column = "patient_id"
             implements = [Schema]
@@ -167,6 +172,7 @@ def test_backend_definition_fails_if_query_table_missing_columns():
     with pytest.raises(ValidationError, match="SQL does not reference columns"):
 
         class TestBackend(BaseBackend):
+            display_name = "Test Backend"
             query_engine_class = BaseSQLQueryEngine
             patient_join_column = "patient_id"
             implements = [Schema]

--- a/tests/unit/query_model/test_table_schema.py
+++ b/tests/unit/query_model/test_table_schema.py
@@ -103,13 +103,16 @@ def test_categorical_constraint_casts_lists_to_tuple():
 
 
 def test_categorical_constraint_description():
-    assert Constraint.Categorical([1, 2, 3]).description == "Must be one of: 1, 2, 3"
+    assert (
+        Constraint.Categorical([1, 2, 3]).description
+        == "Possible values: `1`, `2`, `3`"
+    )
 
 
 def test_regex_constraint_description():
     assert (
         Constraint.Regex("ABC[0-9]").description
-        == "Must match the regular expression: 'ABC[0-9]'"
+        == "Matches regular expression: `ABC[0-9]`"
     )
 
 

--- a/tests/unit/test_docs.py
+++ b/tests/unit/test_docs.py
@@ -10,15 +10,12 @@ def test_reformat_docstring():
     First line.
 
     Second line.
+        Indented
     """
 
     output = reformat_docstring(docstring)
 
-    expected = [
-        "First line.",
-        "",
-        "Second line.",
-    ]
+    expected = "First line.\n\nSecond line.\n    Indented"
     assert output == expected
 
 
@@ -289,7 +286,7 @@ def test_render_contracts():
             "name": "DummyClass",
             "hierarchy": ["some", "path"],
             "dotted_path": "dummy_module.DummyClass",
-            "docstring": ["Dummy docstring"],
+            "docstring": "Dummy docstring",
             "columns": [
                 {
                     "name": "patient_id",
@@ -304,7 +301,7 @@ def test_render_contracts():
             "name": "DummyClass2",
             "hierarchy": ["some", "path"],
             "dotted_path": "dummy_module2.DummyClass2",
-            "docstring": ["Dummy docstring2.", "", "Second line."],
+            "docstring": "Dummy docstring2.\n\nSecond line.",
             "columns": [],
             "backend_support": [],
         },

--- a/tests/unit/test_docs.py
+++ b/tests/unit/test_docs.py
@@ -68,10 +68,13 @@ def test_render(tmp_path):
     assert not set(tmp_path.iterdir())
     render(generate_docs(), tmp_path)
     assert {pt.name for pt in tmp_path.iterdir()} == {
-        "specs.md",
+        "backends.md",
         "contracts.md",
-        "TPPBackend.md",
+        "schemas",
+        "schemas.md",
+        "specs.md",
         "EMISBackend.md",
+        "TPPBackend.md",
     }
 
 

--- a/tests/unit/test_docs.py
+++ b/tests/unit/test_docs.py
@@ -1,6 +1,6 @@
 from ehrql.docs import generate_docs, render
 from ehrql.docs.common import reformat_docstring
-from ehrql.docs.render_includes.backends import render_backend
+from ehrql.docs.render_includes.backends_old import render_backend_old
 from ehrql.docs.render_includes.contracts import render_contracts
 from ehrql.docs.render_includes.specs import render_specs
 
@@ -332,7 +332,7 @@ Second line.
     assert render_contracts(contracts) == expected
 
 
-def test_render_backend():
+def test_render_backend_old():
     backends = [
         {
             "name": "DummyBackend1",
@@ -340,7 +340,7 @@ def test_render_backend():
         },
         {"name": "DummyBackend2", "contracts": ["some/path/DummyClass"]},
     ]
-    assert render_backend(backends[0]) == (
+    assert render_backend_old(backends[0]) == (
         """Contracts implemented:
 
 * [`Some/Path/DummyClass`](contracts-reference.md#somepathdummyclass)
@@ -348,7 +348,7 @@ def test_render_backend():
 """
     )
 
-    assert render_backend(backends[1]) == (
+    assert render_backend_old(backends[1]) == (
         """Contracts implemented:
 
 * [`some/path/DummyClass`](contracts-reference.md#somepathdummyclass)

--- a/tests/unit/test_docs.py
+++ b/tests/unit/test_docs.py
@@ -22,7 +22,7 @@ def test_reformat_docstring():
 def test_generate_docs():
     data = generate_docs()
 
-    expected = {"TPPBackend"}
+    expected = {"EMIS", "TPP"}
     output = {b["name"] for b in data["backends"]}
     assert expected <= output
 


### PR DESCRIPTION
This adds some pages to the documentation:

 * `/backends/`
 * `/schemas/`
 * a page for each individual schema (i.e. each module in `ehrql.tables`) 

Apart from some introductory text, these are auto-generated from the Python code.

Displaying our docstrings in this way exposed some obvious areas for improvement which I have implemented. But most of the TPP schema remains undocumented so it would be good to start filling this out.

Closes #1184