### PR TITLE
Add `NotNull` constraints to `open_prompt`

### DIFF
--- a/ehrql/tables/beta/tpp.py
+++ b/ehrql/tables/beta/tpp.py
@@ -474,6 +474,7 @@ class isaric_raw(EventFrame):
 class open_prompt(EventFrame):
     ctv3_code = Series(
         CTV3Code,
+        constraints=[Constraint.NotNull()],
         description="The question, as a CTV3 code",
     )
     snomedct_code = Series(
@@ -482,13 +483,16 @@ class open_prompt(EventFrame):
     )
     consultation_date = Series(
         datetime.date,
+        constraints=[Constraint.NotNull()],
         description="The date the survey was administered",
     )
     consultation_id = Series(
         int,
+        constraints=[Constraint.NotNull()],
         description="The ID of the survey",
     )
     numeric_value = Series(
         float,
+        constraints=[Constraint.NotNull()],
         description="The response to the question",
     )


### PR DESCRIPTION
We know these properties are not nullable from the database schema [1] and from the results of airmid-short-data-report [2].

[1]: https://reports.opensafely.org/reports/opensafely-tpp-database-schema/#OpenPROMPT
[2]: https://github.com/opensafely/airmid-short-data-report