### PR TITLE
Don't treat `values_used` as categories

### DIFF
--- a/ehrql/dummy_data/generator.py
+++ b/ehrql/dummy_data/generator.py
@@ -209,9 +209,12 @@ class DummyPatientGenerator:
 
     def get_random_value(self, column_info):
         # TODO: This never returns None although for realism it sometimes should
-        if column_info.choices:
+        if cat_constraint := column_info.get_constraint(Constraint.Categorical):
             # TODO: It's obviously not true in general that categories are equiprobable
-            return self.rnd.choice(column_info.choices)
+            return self.rnd.choice(cat_constraint.values)
+        elif column_info.values_used:
+            if self.rnd.randint(0, len(column_info.values_used)) != 0:
+                return self.rnd.choice(column_info.values_used)
         elif column_info.type is bool:
             return self.rnd.choice((True, False))
         elif column_info.type is int:

--- a/ehrql/dummy_data/query_info.py
+++ b/ehrql/dummy_data/query_info.py
@@ -4,7 +4,6 @@ from functools import cached_property
 
 from ehrql.query_model.nodes import (
     Column,
-    Constraint,
     Function,
     InlinePatientTable,
     SelectColumn,
@@ -26,7 +25,7 @@ class ColumnInfo:
     name: str
     type: type  # NOQA: A003
     constraints: tuple = ()
-    values_used: set = dataclasses.field(default_factory=set)
+    _values_used: set = dataclasses.field(default_factory=set)
 
     @classmethod
     def from_column(cls, name, column):
@@ -41,15 +40,11 @@ class ColumnInfo:
     def record_value(self, value):
         if hasattr(value, "_to_primitive_type"):
             value = value._to_primitive_type()
-        self.values_used.add(value)
+        self._values_used.add(value)
 
     @cached_property
-    def choices(self):
-        cat_constraint = self.get_constraint(Constraint.Categorical)
-        if cat_constraint is not None:
-            return cat_constraint.values
-        else:
-            return sorted(self.values_used)
+    def values_used(self):
+        return sorted(self._values_used)
 
     def get_constraint(self, type_):
         return self._constraints_by_type.get(type_)

--- a/tests/unit/dummy_data/test_query_info.py
+++ b/tests/unit/dummy_data/test_query_info.py
@@ -54,7 +54,7 @@ def test_query_info_from_variable_definitions():
                     "code": ColumnInfo(
                         name="code",
                         type=str,
-                        values_used={"abc00"},
+                        _values_used={"abc00"},
                     )
                 },
             ),
@@ -106,7 +106,7 @@ def test_query_info_records_values():
     assert column_info == ColumnInfo(
         name="value",
         type=str,
-        values_used={"a", "b", "c", "d"},
+        _values_used={"a", "b", "c", "d"},
     )
 
 
@@ -155,4 +155,4 @@ def test_query_info_ignores_complex_comparisons():
     query_info = QueryInfo.from_variable_definitions(variable_definitions)
     column_info = query_info.tables["patients"].columns["date_of_birth"]
 
-    assert column_info.values_used == {datetime.date(2022, 10, 5)}
+    assert column_info.values_used == [datetime.date(2022, 10, 5)]


### PR DESCRIPTION
A column may admit more values than those stored within `values_used`. Consequently, we fall through to other values with a probability of `1/(N+1)`.

Closes #1266