### PR TITLE
Fix docstring typo in `EMISBackend`

### DIFF
--- a/docs/includes/generated_docs/backends.md
+++ b/docs/includes/generated_docs/backends.md
@@ -28,7 +28,7 @@ This backend implements the following table schemas:
     Projects requiring EMIS data should continue to use the [Cohort
     Extractor](https://docs.opensafely.org/study-def/) tool.
 
-[EMIS Health](https://www.emishealth.com/) are the devlopers and operators of the
+[EMIS Health](https://www.emishealth.com/) are the developers and operators of the
 [EMIS Web](https://www.emishealth.com/products/emis-web) EHR platform. The ehrQL
 EMIS backend provides access to primary care data from EMIS Web, plus data linked
 from other sources.

--- a/ehrql/backends/emis.py
+++ b/ehrql/backends/emis.py
@@ -11,7 +11,7 @@ class EMISBackend(BaseBackend):
         Projects requiring EMIS data should continue to use the [Cohort
         Extractor](https://docs.opensafely.org/study-def/) tool.
 
-    [EMIS Health](https://www.emishealth.com/) are the devlopers and operators of the
+    [EMIS Health](https://www.emishealth.com/) are the developers and operators of the
     [EMIS Web](https://www.emishealth.com/products/emis-web) EHR platform. The ehrQL
     EMIS backend provides access to primary care data from EMIS Web, plus data linked
     from other sources.


### PR DESCRIPTION
Spotted while working on the docs migration in #1317.