### PR TITLE
Remove redundant `parser.set_defaults`

### DIFF
--- a/ehrql/__main__.py
+++ b/ehrql/__main__.py
@@ -187,7 +187,6 @@ def add_generate_measures(subparsers, environ, user_args):
     parser = subparsers.add_parser("generate-measures", help="Generate measures")
     parser.set_defaults(function=generate_measures)
     parser.set_defaults(user_args=user_args)
-    parser.set_defaults(user_args=user_args)
     parser.add_argument(
         "--output",
         help=(


### PR DESCRIPTION
I think this is a copy-paste error, as I can't see a reason to call the same method with the same arguments on two adjacent lines.