### PR TITLE
Add support for querying medications without dm+d codes in TPP

### DIFF
--- a/ehrql/__main__.py
+++ b/ehrql/__main__.py
@@ -16,6 +16,7 @@ from .main import (
     generate_measures,
     run_sandbox,
     test_connection,
+    update_custom_medication_dictionary,
 )
 
 
@@ -66,6 +67,7 @@ def main(args, environ=None):
     add_generate_measures(subparsers, environ, user_args)
     add_run_sandbox(subparsers, environ, user_args)
     add_test_connection(subparsers, environ, user_args)
+    add_update_custom_medication_dictionary(subparsers, environ, user_args)
 
     kwargs = vars(parser.parse_args(args))
     function = kwargs.pop("function")
@@ -256,6 +258,28 @@ def add_test_connection(subparsers, environ, user_args):
         "--url",
         "-u",
         help="db url",
+        default=environ.get("DATABASE_URL"),
+    )
+
+
+def add_update_custom_medication_dictionary(subparsers, environ, user_args):
+    parser = subparsers.add_parser(
+        "update-custom-medication-dictionary",
+        help="Update the custom medication dictionary",
+    )
+    parser.set_defaults(function=update_custom_medication_dictionary)
+    parser.set_defaults(environ=environ)
+    parser.add_argument(
+        "--backend",
+        type=backend_from_id,
+        help=f"Dotted import path to class, or one of: {', '.join(BACKEND_ALIASES)}",
+        default=environ.get("OPENSAFELY_BACKEND"),
+        dest="backend_class",
+    )
+    parser.add_argument(
+        "--dsn",
+        type=str,
+        help="Data Source Name: URL of remote database, or path to data on disk",
         default=environ.get("DATABASE_URL"),
     )
 

--- a/ehrql/backends/tpp.py
+++ b/ehrql/backends/tpp.py
@@ -106,10 +106,12 @@ class TPPBackend(BaseBackend):
             SELECT
                 meds.Patient_ID AS patient_id,
                 CAST(meds.ConsultationDate AS date) AS date,
-                dict.DMD_ID AS dmd_code
+                COALESCE(dict.DMD_ID, custom_dict.DMD_ID) AS dmd_code
             FROM MedicationIssue AS meds
             LEFT JOIN MedicationDictionary AS dict
             ON meds.MultilexDrug_ID = dict.MultilexDrug_ID
+            LEFT JOIN CustomMedicationDictionary AS custom_dict
+            ON meds.MultilexDrug_ID = custom_dict.MultilexDrug_ID
         """
     )
 

--- a/tests/lib/tpp_schema.py
+++ b/tests/lib/tpp_schema.py
@@ -213,6 +213,14 @@ class Consultation(Base):
     Registration_ID = mapped_column(t.BIGINT)
 
 
+class CustomMedicationDictionary(Base):
+    __tablename__ = "CustomMedicationDictionary"
+    _pk = mapped_column(t.Integer, primary_key=True)
+
+    DMD_ID = mapped_column(t.VARCHAR(50, collation="Latin1_General_CI_AS"))
+    MultilexDrug_ID = mapped_column(t.VARCHAR(767))
+
+
 class DataDictionary(Base):
     __tablename__ = "DataDictionary"
     _pk = mapped_column(t.Integer, primary_key=True)

--- a/tests/lib/update_tpp_schema.py
+++ b/tests/lib/update_tpp_schema.py
@@ -123,6 +123,12 @@ def apply_schema_modifications(by_table):
         {"ColumnName": "CodingSystem", "ColumnType": "int"},
     ]
 
+    assert "CustomMedicationDictionary" not in by_table
+    by_table["CustomMedicationDictionary"] = [
+        {"ColumnName": "DMD_ID", "ColumnType": "varchar", "MaxLength": "50"},
+        {"ColumnName": "MultilexDrug_ID", "ColumnType": "varchar", "MaxLength": "767"},
+    ]
+
     # We don't get column collation information but we know this matters in some cases
     # because you can't compare columns across tables unless the collations are
     # compatible. We add collations here for the two critical columns whose collations
@@ -135,6 +141,11 @@ def apply_schema_modifications(by_table):
     )
     add_to_column(
         by_table["MedicationDictionary"],
+        "DMD_ID",
+        collation="Latin1_General_CI_AS",
+    )
+    add_to_column(
+        by_table["CustomMedicationDictionary"],
         "DMD_ID",
         collation="Latin1_General_CI_AS",
     )


### PR DESCRIPTION
I'd like some help with two aspects of this PR, which addresses #1270.

---

**First**, the `CustomMedicationDictionary` table contains our (Bennett Institute) mapping. I think this table should live within a temporary database; and I think the name of this temporary database is the value of `query_engine_instance.config.get("TEMP_DATABASE_NAME")`. However, I'm unsure how to access this value, here:

https://github.com/opensafely-core/ehrql/blob/de94fb15fc5fad1dbaf83678b40962b6add81623/ehrql/backends/tpp.py#L113

To put that another way, how do I access a query engine instance from a backend class?

I think I should make `TPPBackend.medications` a property, but how do I access a query engine instance from a backend instance?

---

**Second**, I've separated the management of `CustomMedicationDictionary` (i.e. dropping it, creating it, and inserting into it) from the use of this table. The management of this table is done here:

https://github.com/opensafely-core/ehrql/blob/de94fb15fc5fad1dbaf83678b40962b6add81623/ehrql/main.py#L279-L314

However, the implementation is tightly-coupled to TPP. Originally, I'd located the SQL statements (`text(...)`) within `TPPBackend`, reasoning that we'd have different SQL statements for `EMISBackend`. Doing so ensures the implementation is loosely coupled to TPP, but the separation between the data on the one hand and ehrQL on the other isn't as clean. Is there an approach that affords loose coupling _and_ separation between data and ehrQL?