### PR TITLE
Link to short data reports

### DIFF
--- a/docs/includes/generated_docs/schemas/beta.tpp.md
+++ b/docs/includes/generated_docs/schemas/beta.tpp.md
@@ -1807,7 +1807,7 @@ The question, as a CTV3 code
     <code>SNOMED-CT code</code>
   </dt>
   <dd markdown="block">
-The question, as a SNOMED CT code or None
+The question, as a SNOMED CT code
 
   </dd>
 </div>

--- a/docs/includes/generated_docs/schemas/beta.tpp.md
+++ b/docs/includes/generated_docs/schemas/beta.tpp.md
@@ -1794,7 +1794,7 @@ You can find out more about this table in the associated short data report:
     <code>CTV3 (Read v3) code</code>
   </dt>
   <dd markdown="block">
-The question, as a CTV3 code
+The response to the question, as a CTV3 code
 
  * Never `NULL`
   </dd>
@@ -1807,7 +1807,7 @@ The question, as a CTV3 code
     <code>SNOMED-CT code</code>
   </dt>
   <dd markdown="block">
-The question, as a SNOMED CT code
+The response to the question, as a SNOMED CT code
 
   </dd>
 </div>

--- a/docs/includes/generated_docs/schemas/beta.tpp.md
+++ b/docs/includes/generated_docs/schemas/beta.tpp.md
@@ -214,7 +214,8 @@ return ordered_addrs.last_for_patient()
 <p class="dimension-indicator"><code>many rows per patient</code></p>
 ## appointments
 
-
+You can find out more about this table in the associated short data report:
+<https://github.com/opensafely/appointments-short-data-report>.
 <div markdown="block" class="definition-list-wrapper">
   <div class="title">Columns</div>
   <dl markdown="block">

--- a/docs/includes/generated_docs/schemas/beta.tpp.md
+++ b/docs/includes/generated_docs/schemas/beta.tpp.md
@@ -1845,7 +1845,7 @@ The ID of the survey
     <code>float</code>
   </dt>
   <dd markdown="block">
-The response to the question
+The response to the question, as a number
 
  * Never `NULL`
   </dd>

--- a/docs/includes/generated_docs/schemas/beta.tpp.md
+++ b/docs/includes/generated_docs/schemas/beta.tpp.md
@@ -1807,7 +1807,7 @@ The response to the question, as a CTV3 code
     <code>SNOMED-CT code</code>
   </dt>
   <dd markdown="block">
-The response to the question, as a SNOMED CT code
+The response to the question, as a SNOMED CT code, for responses where the CTV3 code has a corresponding SNOMED CT code
 
   </dd>
 </div>

--- a/docs/includes/generated_docs/schemas/beta.tpp.md
+++ b/docs/includes/generated_docs/schemas/beta.tpp.md
@@ -226,7 +226,7 @@ You can find out more about this table in the associated short data report:
     <code>date</code>
   </dt>
   <dd markdown="block">
-
+The date the appointment was booked
 
   </dd>
 </div>
@@ -238,7 +238,7 @@ You can find out more about this table in the associated short data report:
     <code>date</code>
   </dt>
   <dd markdown="block">
-
+The date the appointment was due to start
 
   </dd>
 </div>

--- a/docs/includes/generated_docs/schemas/beta.tpp.md
+++ b/docs/includes/generated_docs/schemas/beta.tpp.md
@@ -1780,7 +1780,10 @@ Data from the ONS Covid Infection Survey.
 <p class="dimension-indicator"><code>many rows per patient</code></p>
 ## open_prompt
 
+This table contains responses to questions from the OpenPROMPT project.
 
+You can find out more about this table in the associated short data report:
+<https://github.com/opensafely/airmid-short-data-report>.
 <div markdown="block" class="definition-list-wrapper">
   <div class="title">Columns</div>
   <dl markdown="block">

--- a/docs/includes/generated_docs/schemas/beta.tpp.md
+++ b/docs/includes/generated_docs/schemas/beta.tpp.md
@@ -1845,7 +1845,7 @@ The ID of the survey
     <code>float</code>
   </dt>
   <dd markdown="block">
-The response to the question, as a number
+The response to the question, as a number. Alternatively, if the question admits a code as the response, then zero.
 
  * Never `NULL`
   </dd>

--- a/docs/includes/generated_docs/schemas/beta.tpp.md
+++ b/docs/includes/generated_docs/schemas/beta.tpp.md
@@ -1794,7 +1794,7 @@ You can find out more about this table in the associated short data report:
     <code>CTV3 (Read v3) code</code>
   </dt>
   <dd markdown="block">
-The response to the question, as a CTV3 code
+The response to the question, as a CTV3 code. Alternatively, if the question admits a number as the response, then the question, as a CTV3 code.
 
  * Never `NULL`
   </dd>
@@ -1807,7 +1807,7 @@ The response to the question, as a CTV3 code
     <code>SNOMED-CT code</code>
   </dt>
   <dd markdown="block">
-The response to the question, as a SNOMED CT code, for responses where the CTV3 code has a corresponding SNOMED CT code
+The response to the question, as a SNOMED CT code, for responses where the CTV3 code has a corresponding SNOMED CT code. Alternatively, if the question admits a number as the response, then the question, as a SNOMED CT code, for questions where the CTV3 code has a corresponding SNOMED CT code.
 
   </dd>
 </div>

--- a/ehrql/tables/beta/tpp.py
+++ b/ehrql/tables/beta/tpp.py
@@ -487,13 +487,20 @@ class open_prompt(EventFrame):
     ctv3_code = Series(
         CTV3Code,
         constraints=[Constraint.NotNull()],
-        description="The response to the question, as a CTV3 code",
+        description=(
+            "The response to the question, as a CTV3 code. "
+            "Alternatively, if the question admits a number as the response, "
+            "then the question, as a CTV3 code."
+        ),
     )
     snomedct_code = Series(
         SNOMEDCTCode,
         description=(
             "The response to the question, as a SNOMED CT code, "
-            "for responses where the CTV3 code has a corresponding SNOMED CT code"
+            "for responses where the CTV3 code has a corresponding SNOMED CT code. "
+            "Alternatively, if the question admits a number as the response, "
+            "then the question, as a SNOMED CT code, "
+            "for questions where the CTV3 code has a corresponding SNOMED CT code."
         ),
     )
     consultation_date = Series(

--- a/ehrql/tables/beta/tpp.py
+++ b/ehrql/tables/beta/tpp.py
@@ -516,5 +516,8 @@ class open_prompt(EventFrame):
     numeric_value = Series(
         float,
         constraints=[Constraint.NotNull()],
-        description="The response to the question, as a number",
+        description=(
+            "The response to the question, as a number. "
+            "Alternatively, if the question admits a code as the response, then zero."
+        ),
     )

--- a/ehrql/tables/beta/tpp.py
+++ b/ehrql/tables/beta/tpp.py
@@ -201,6 +201,11 @@ class hospital_admissions(EventFrame):
 
 @table
 class appointments(EventFrame):
+    """
+    You can find out more about this table in the associated short data report:
+    <https://github.com/opensafely/appointments-short-data-report>.
+    """
+
     booked_date = Series(datetime.date)
     start_date = Series(datetime.date)
 

--- a/ehrql/tables/beta/tpp.py
+++ b/ehrql/tables/beta/tpp.py
@@ -491,7 +491,10 @@ class open_prompt(EventFrame):
     )
     snomedct_code = Series(
         SNOMEDCTCode,
-        description="The response to the question, as a SNOMED CT code",
+        description=(
+            "The response to the question, as a SNOMED CT code, "
+            "for responses where the CTV3 code has a corresponding SNOMED CT code"
+        ),
     )
     consultation_date = Series(
         datetime.date,

--- a/ehrql/tables/beta/tpp.py
+++ b/ehrql/tables/beta/tpp.py
@@ -206,8 +206,14 @@ class appointments(EventFrame):
     <https://github.com/opensafely/appointments-short-data-report>.
     """
 
-    booked_date = Series(datetime.date)
-    start_date = Series(datetime.date)
+    booked_date = Series(
+        datetime.date,
+        description="The date the appointment was booked",
+    )
+    start_date = Series(
+        datetime.date,
+        description="The date the appointment was due to start",
+    )
 
 
 @table

--- a/ehrql/tables/beta/tpp.py
+++ b/ehrql/tables/beta/tpp.py
@@ -477,6 +477,13 @@ class isaric_raw(EventFrame):
 
 @table
 class open_prompt(EventFrame):
+    """
+    This table contains responses to questions from the OpenPROMPT project.
+
+    You can find out more about this table in the associated short data report:
+    <https://github.com/opensafely/airmid-short-data-report>.
+    """
+
     ctv3_code = Series(
         CTV3Code,
         constraints=[Constraint.NotNull()],

--- a/ehrql/tables/beta/tpp.py
+++ b/ehrql/tables/beta/tpp.py
@@ -506,5 +506,5 @@ class open_prompt(EventFrame):
     numeric_value = Series(
         float,
         constraints=[Constraint.NotNull()],
-        description="The response to the question",
+        description="The response to the question, as a number",
     )

--- a/ehrql/tables/beta/tpp.py
+++ b/ehrql/tables/beta/tpp.py
@@ -487,11 +487,11 @@ class open_prompt(EventFrame):
     ctv3_code = Series(
         CTV3Code,
         constraints=[Constraint.NotNull()],
-        description="The question, as a CTV3 code",
+        description="The response to the question, as a CTV3 code",
     )
     snomedct_code = Series(
         SNOMEDCTCode,
-        description="The question, as a SNOMED CT code",
+        description="The response to the question, as a SNOMED CT code",
     )
     consultation_date = Series(
         datetime.date,

--- a/ehrql/tables/beta/tpp.py
+++ b/ehrql/tables/beta/tpp.py
@@ -491,7 +491,7 @@ class open_prompt(EventFrame):
     )
     snomedct_code = Series(
         SNOMEDCTCode,
-        description="The question, as a SNOMED CT code or None",
+        description="The question, as a SNOMED CT code",
     )
     consultation_date = Series(
         datetime.date,


### PR DESCRIPTION
This links to two short data reports for `appointments` and `open_prompt`, and clarifies several of the descriptions associated with those tables.

Previews:
* [`appointments`](https://59dd4c2d.databuilder.pages.dev/schemas/beta.tpp/#appointments)
* [`open_prompt`](https://59dd4c2d.databuilder.pages.dev/schemas/beta.tpp/#open_prompt)