### PR TITLE
Support QueryTables with dynamically constructed queries

### DIFF
--- a/ehrql/backends/base.py
+++ b/ehrql/backends/base.py
@@ -17,6 +17,9 @@ class BaseBackend:
     tables = None
     implements = ()
 
+    def __init__(self, config=None):
+        self.config = config or {}
+
     def __init_subclass__(cls, **kwargs):
         assert cls.display_name is not None
         assert cls.query_engine_class is not None
@@ -140,6 +143,9 @@ class QueryTable(SQLTable):
 
 
 class DefaultBackend:
+    def __init__(self, config=None):
+        pass
+
     def get_table_expression(self, table_name, schema):
         """
         Returns a SQLAlchemy Table object matching the supplied name and schema

--- a/ehrql/backends/base.py
+++ b/ehrql/backends/base.py
@@ -32,8 +32,10 @@ class BaseBackend:
                 cls._init_table(value)
                 cls.tables[name] = value
 
-        for table_namespace in cls.implements:
-            cls.validate_against_table_namespace(table_namespace)
+        # Construct an instance in order to validate it
+        instance = cls()
+        for table_namespace in instance.implements:
+            instance.validate_against_table_namespace(table_namespace)
 
     @classmethod
     def _init_table(cls, table):
@@ -44,23 +46,24 @@ class BaseBackend:
         """
         table.learn_patient_join(cls.patient_join_column)
 
-    @classmethod
-    def validate_against_table_namespace(cls, table_namespace):
+    def validate_against_table_namespace(self, table_namespace):
         for attr, ql_table in get_tables_from_namespace(table_namespace):
             table = ql_table.qm_node
-            if table.name not in cls.tables:
+            if table.name not in self.tables:
                 raise ValidationError(
-                    f"{cls} does not implement table '{table.name}' from "
+                    f"{self.__class__} does not implement table '{table.name}' from "
                     f"{table_namespace}.{attr}"
                 )
 
-            table_def = cls.tables[table.name]
+            table_def = self.tables[table.name]
             try:
-                table_def.validate_against_table_schema(table.schema)
+                table_def.validate_against_table_schema(
+                    backend=self, schema=table.schema
+                )
             except ValidationError as e:
                 # Wrap error message to indicate source
                 raise ValidationError(
-                    f"{cls}.{table.name} does not match {table_namespace}.{attr}, {e}"
+                    f"{self.__class__}.{table.name} does not match {table_namespace}.{attr}, {e}"
                 ) from e
 
     def get_table_expression(self, table_name, schema):
@@ -74,14 +77,16 @@ class BaseBackend:
         Raises:
             ValueError: If unknown table passed in
         """
-        return self.tables[table_name].get_expression(table_name, schema)
+        return self.tables[table_name].get_expression(
+            backend=self, table_name=table_name, schema=schema
+        )
 
 
 class SQLTable:
     def learn_patient_join(self, source):
         self.patient_join_column = source
 
-    def validate_against_table_schema(self, schema):
+    def validate_against_table_schema(self, backend, schema):
         raise NotImplementedError()
 
 
@@ -92,12 +97,12 @@ class MappedTable(SQLTable):
         # Not to be confused with the schema which defines the column names and types
         self.db_schema_name = schema
 
-    def validate_against_table_schema(self, schema):
+    def validate_against_table_schema(self, backend, schema):
         missing = set(schema.column_names) - set(self.column_map)
         if missing:
             raise ValidationError(f"missing columns: {', '.join(missing)}")
 
-    def get_expression(self, table_name, schema):
+    def get_expression(self, backend, table_name, schema):
         patient_id_column = self.column_map.get("patient_id", self.patient_join_column)
         return sqlalchemy.table(
             self.source_table_name,
@@ -117,7 +122,7 @@ class QueryTable(SQLTable):
         self.query = query
         self.implementation_notes = implementation_notes or {}
 
-    def validate_against_table_schema(self, schema):
+    def validate_against_table_schema(self, backend, schema):
         # This is a very crude form of validation: we just check that the SQL string
         # contains each of the column names as words. But without actually executing the
         # SQL we can't know what it returns
@@ -132,7 +137,7 @@ class QueryTable(SQLTable):
                 f"SQL does not reference columns: {', '.join(missing)}"
             )
 
-    def get_expression(self, table_name, schema):
+    def get_expression(self, backend, table_name, schema):
         columns = [sqlalchemy.Column("patient_id")]
         columns.extend(
             sqlalchemy.Column(name, type_=type_from_python_type(type_))

--- a/ehrql/main.py
+++ b/ehrql/main.py
@@ -178,7 +178,7 @@ def get_query_engine(
 ):
     # Construct backend if supplied
     if backend_class:
-        backend = backend_class()
+        backend = backend_class(config=environ)
     else:
         backend = None
 

--- a/tests/integration/backends/test_base.py
+++ b/tests/integration/backends/test_base.py
@@ -24,8 +24,8 @@ class covid_tests(EventFrame):
     positive = Series(int)
 
 
-class TestBackend(BaseBackend):
-    display_name = "Test Backend"
+class BackendFixture(BaseBackend):
+    display_name = "Backend Fixture"
     query_engine_class = BaseSQLQueryEngine
     patient_join_column = "patient_id"
 
@@ -102,5 +102,6 @@ def _extract(engine, series):
     )
     dataset.v = series
     return {
-        r["patient_id"]: r["v"] for r in engine.extract(dataset, backend=TestBackend())
+        r["patient_id"]: r["v"]
+        for r in engine.extract(dataset, backend=BackendFixture())
     }

--- a/tests/unit/backends/test_base.py
+++ b/tests/unit/backends/test_base.py
@@ -15,8 +15,8 @@ from ehrql.query_model.nodes import Column, TableSchema
 from ehrql.tables import PatientFrame, Series, table
 
 
-class TestBackend(BaseBackend):
-    display_name = "Test Backend"
+class BackendFixture(BaseBackend):
+    display_name = "Backend Fixture"
     query_engine_class = BaseSQLQueryEngine
     patient_join_column = "PatientId"
 
@@ -43,7 +43,7 @@ class TestBackend(BaseBackend):
 def test_backend_registers_tables():
     """Test that a backend registers its table names"""
 
-    assert set(TestBackend.tables) == {
+    assert set(BackendFixture.tables) == {
         "patients",
         "events",
         "practice_registrations",
@@ -51,7 +51,7 @@ def test_backend_registers_tables():
 
 
 def test_mapped_table_sql_with_modified_names():
-    table = TestBackend().get_table_expression(
+    table = BackendFixture().get_table_expression(
         "patients",
         TableSchema(
             date_of_birth=Column(datetime.date),
@@ -62,7 +62,7 @@ def test_mapped_table_sql_with_modified_names():
 
 
 def test_mapped_table_sql_with_matching_names():
-    table = TestBackend().get_table_expression(
+    table = BackendFixture().get_table_expression(
         "events",
         TableSchema(
             date=Column(datetime.date),
@@ -73,7 +73,7 @@ def test_mapped_table_sql_with_matching_names():
 
 
 def test_query_table_sql():
-    table = TestBackend().get_table_expression(
+    table = BackendFixture().get_table_expression(
         "practice_registrations",
         TableSchema(
             date_start=Column(datetime.date),
@@ -106,8 +106,8 @@ class Schema:
 
 
 def test_backend_definition_is_allowed_extra_tables_and_columns():
-    class TestBackend(BaseBackend):
-        display_name = "Test Backend"
+    class BackendFixture(BaseBackend):
+        display_name = "Backend Fixture"
         query_engine_class = BaseSQLQueryEngine
         patient_join_column = "patient_id"
         implements = [Schema]
@@ -121,12 +121,12 @@ def test_backend_definition_is_allowed_extra_tables_and_columns():
             columns=dict(date="date", code="code"),
         )
 
-    assert TestBackend
+    assert BackendFixture
 
 
 def test_backend_definition_accepts_query_table():
-    class TestBackend(BaseBackend):
-        display_name = "Test Backend"
+    class BackendFixture(BaseBackend):
+        display_name = "Backend Fixture"
         query_engine_class = BaseSQLQueryEngine
         patient_join_column = "patient_id"
         implements = [Schema]
@@ -135,14 +135,14 @@ def test_backend_definition_accepts_query_table():
             "SELECT patient_id, CAST(DoB AS date) AS date_of_birth FROM patients",
         )
 
-    assert TestBackend
+    assert BackendFixture
 
 
 def test_backend_definition_fails_if_missing_tables():
     with pytest.raises(ValidationError, match="does not implement table"):
 
-        class TestBackend(BaseBackend):
-            display_name = "Test Backend"
+        class BackendFixture(BaseBackend):
+            display_name = "Backend Fixture"
             query_engine_class = BaseSQLQueryEngine
             patient_join_column = "patient_id"
             implements = [Schema]
@@ -156,8 +156,8 @@ def test_backend_definition_fails_if_missing_tables():
 def test_backend_definition_fails_if_missing_column():
     with pytest.raises(ValidationError, match="missing columns"):
 
-        class TestBackend(BaseBackend):
-            display_name = "Test Backend"
+        class BackendFixture(BaseBackend):
+            display_name = "Backend Fixture"
             query_engine_class = BaseSQLQueryEngine
             patient_join_column = "patient_id"
             implements = [Schema]
@@ -171,8 +171,8 @@ def test_backend_definition_fails_if_missing_column():
 def test_backend_definition_fails_if_query_table_missing_columns():
     with pytest.raises(ValidationError, match="SQL does not reference columns"):
 
-        class TestBackend(BaseBackend):
-            display_name = "Test Backend"
+        class BackendFixture(BaseBackend):
+            display_name = "Backend Fixture"
             query_engine_class = BaseSQLQueryEngine
             patient_join_column = "patient_id"
             implements = [Schema]

--- a/tests/unit/backends/test_base.py
+++ b/tests/unit/backends/test_base.py
@@ -39,6 +39,11 @@ class BackendFixture(BaseBackend):
         "SELECT patient_id, date_start, date_end FROM some_table"
     )
 
+    @QueryTable.from_function
+    def positive_tests(self):
+        table_name = self.config.get("table_name", "some_table")
+        return f"SELECT patient_id, date FROM {table_name}"
+
 
 def test_backend_registers_tables():
     """Test that a backend registers its table names"""
@@ -47,6 +52,7 @@ def test_backend_registers_tables():
         "patients",
         "events",
         "practice_registrations",
+        "positive_tests",
     }
 
 
@@ -86,6 +92,15 @@ def test_query_table_sql():
         "FROM (SELECT patient_id, date_start, date_end FROM some_table) AS "
         "practice_registrations"
     )
+
+
+def test_query_table_from_function_sql():
+    backend = BackendFixture(config={"table_name": "other_table"})
+    table = backend.get_table_expression(
+        "positive_tests",
+        TableSchema(date=Column(datetime.date)),
+    )
+    assert str(table) == "SELECT patient_id, date FROM other_table"
 
 
 def test_default_backend_sql():

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -31,7 +31,9 @@ class DefaultQueryEngine:
     config: dict
 
 
+@dataclasses.dataclass
 class DummyBackend:
+    config: dict
     query_engine_class = DummyQueryEngine
 
 
@@ -100,12 +102,13 @@ def test_get_query_engine_with_backend():
         dsn=None,
         backend_class=DummyBackend,
         query_engine_class=None,
-        environ={},
+        environ={"foo": "bar"},
         default_query_engine_class=None,
     )
     assert isinstance(query_engine, DummyQueryEngine)
     assert isinstance(query_engine.backend, DummyBackend)
-    assert query_engine.config == {}
+    assert query_engine.config == {"foo": "bar"}
+    assert query_engine.backend.config == {"foo": "bar"}
 
 
 def test_get_query_engine_with_backend_and_query_engine():


### PR DESCRIPTION
This refactors the backed definition code in two ways:
 * Backend instances now receive a copy of the environment via the `config` keyword argument in the same way that QueryEngines do.
 * Methods on SQLTable objects are now passed a reference to the backend instances.

These allow us to provide a new way of constructing a QueryTable by using `@QueryTable.from_function` as a decorator. This means that the query returned can now depend on the contents of the `config` dictionary, for example:
```py
class SomeBackend:
    ...

    @QueryTable.from_function
    def positive_tests(self):
        table_name = self.config.get("table_name", "some_table")
        return f"SELECT patient_id, date FROM {table_name}"

```