### PR TITLE
Make `weeks` importable like other time durations

### DIFF
--- a/ehrql/__init__.py
+++ b/ehrql/__init__.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 from ehrql.codes import codelist_from_csv
 from ehrql.measures import INTERVAL, Measures
-from ehrql.query_language import Dataset, case, days, months, when, years
+from ehrql.query_language import Dataset, case, days, months, weeks, when, years
 from ehrql.utils.log_utils import init_logging
 
 
@@ -25,6 +25,7 @@ __all__ = [
     "case",
     "days",
     "months",
+    "weeks",
     "when",
     "years",
 ]


### PR DESCRIPTION
Spotted this inconsistency while updating imports for ehrQL example code in the documentation.

The current import used is:

```
from databuilder.query_language import weeks
```

https://github.com/opensafely-core/ehrql/blob/2ab0e357aa86ecff6103666d274794eed73c7c06/docs/explanation/examples.md#L554

I wanted to update this to `from ehrql import weeks` and noticed that this wasn't possible.