### PR TITLE
feat: Query `CustomMedicationDictionary`

### DIFF
--- a/ehrql/backends/tpp.py
+++ b/ehrql/backends/tpp.py
@@ -101,17 +101,22 @@ class TPPBackend(BaseBackend):
         """
     )
 
-    medications = QueryTable(
-        """
+    @QueryTable.from_function
+    def medications(self):
+        temp_database_name = self.config.get(
+            "TEMP_DATABASE_NAME", "PLACEHOLDER_FOR_TEMP_DATABASE_NAME"
+        )
+        return f"""
             SELECT
                 meds.Patient_ID AS patient_id,
                 CAST(meds.ConsultationDate AS date) AS date,
-                dict.DMD_ID AS dmd_code
+                COALESCE(dict.DMD_ID, custom_dict.DMD_ID) AS dmd_code
             FROM MedicationIssue AS meds
             LEFT JOIN MedicationDictionary AS dict
             ON meds.MultilexDrug_ID = dict.MultilexDrug_ID
+            LEFT JOIN {temp_database_name}..CustomMedicationDictionary AS custom_dict
+            ON meds.MultilexDrug_ID = custom_dict.MultilexDrug_ID
         """
-    )
 
     addresses = QueryTable(
         """

--- a/tests/lib/tpp_schema.py
+++ b/tests/lib/tpp_schema.py
@@ -13,6 +13,24 @@ class Base(DeclarativeBase):
     "Common base class to signal that models below belong to the same database"
 
 
+# This table isn't included in the schema definition TPP provide for us because it isn't
+# created or managed by TPP. Instead we create and populate this table ourselves,
+# currently via a command in Cohort Extractor though this may eventually be moved to a
+# new repo:
+# [1]: https://github.com/opensafely-core/cohort-extractor/blob/dd681275/cohortextractor/update_custom_medication_dictionary.py
+class CustomMedicationDictionary(Base):
+    __tablename__ = "CustomMedicationDictionary"
+    # Because we don't have write privileges on the main TPP database schema this table
+    # lives in our "temporary tables" database. To mimic this as closely as possible in
+    # testing we create it in a separate schema from the other tables.
+    __table_args__ = {"schema": "temp_tables.dbo"}
+
+    _pk = mapped_column(t.Integer, primary_key=True)
+
+    DMD_ID = mapped_column(t.VARCHAR(50, collation="Latin1_General_CI_AS"))
+    MultilexDrug_ID = mapped_column(t.VARCHAR(767))
+
+
 class APCS(Base):
     __tablename__ = "APCS"
     _pk = mapped_column(t.Integer, primary_key=True)

--- a/tests/lib/update_tpp_schema.py
+++ b/tests/lib/update_tpp_schema.py
@@ -49,6 +49,24 @@ from sqlalchemy.orm import DeclarativeBase, mapped_column
 
 class Base(DeclarativeBase):
     "Common base class to signal that models below belong to the same database"
+
+
+# This table isn't included in the schema definition TPP provide for us because it isn't
+# created or managed by TPP. Instead we create and populate this table ourselves,
+# currently via a command in Cohort Extractor though this may eventually be moved to a
+# new repo:
+# [1]: https://github.com/opensafely-core/cohort-extractor/blob/dd681275/cohortextractor/update_custom_medication_dictionary.py
+class CustomMedicationDictionary(Base):
+    __tablename__ = "CustomMedicationDictionary"
+    # Because we don't have write privileges on the main TPP database schema this table
+    # lives in our "temporary tables" database. To mimic this as closely as possible in
+    # testing we create it in a separate schema from the other tables.
+    __table_args__ = {"schema": "temp_tables.dbo"}
+
+    _pk = mapped_column(t.Integer, primary_key=True)
+
+    DMD_ID = mapped_column(t.VARCHAR(50, collation="Latin1_General_CI_AS"))
+    MultilexDrug_ID = mapped_column(t.VARCHAR(767))
 """
 
 


### PR DESCRIPTION
In this PR, we add support for querying medications that don't have dm+d codes stored in the `MedicationDictionary` table (#1270). The dm+d codes for these medications are now stored in the `CustomMedicationDictionary` table (it exists!), which is managed by cohort-extractor (opensafely-core/cohort-extractor#961).

If `CustomMedicationDictionary` doesn't exist -- because it hasn't been created, for example -- then the query will fail. I think this is desired behaviour: If we're not querying both `MedicationDictionary` and `CustomMedicationDictionary`, then we want to know ASAP.

As required by #1270, we prefer `MedicationDictionary` to `CustomMedicationDictionary`.