### PR TITLE
Improve table metadata

### DIFF
--- a/docs/includes/generated_docs/schemas/beta.tpp.md
+++ b/docs/includes/generated_docs/schemas/beta.tpp.md
@@ -2120,8 +2120,15 @@ TODO
 
 This table contains responses to questions from the OpenPROMPT project.
 
-You can find out more about this table in the associated short data report:
-<https://github.com/opensafely/airmid-short-data-report>.
+You can find out more about this table in the associated short data report. To view
+it, you will need a login for [Level 4][open_prompt_1]. The
+[workspace][open_prompt_2] shows when the code that comprises the report was run;
+the code itself is in the [airmid-short-data-report][open_prompt_3] repository on
+GitHub.
+
+[open_prompt_1]: https://docs.opensafely.org/security-levels/#level-4-nhs-england-are-data-controllers-of-the-data
+[open_prompt_2]: https://jobs.opensafely.org/datalab/opensafely-internal/airmid-short-data-report/
+[open_prompt_3]: https://github.com/opensafely/airmid-short-data-report
 <div markdown="block" class="definition-list-wrapper">
   <div class="title">Columns</div>
   <dl markdown="block">

--- a/docs/includes/generated_docs/schemas/beta.tpp.md
+++ b/docs/includes/generated_docs/schemas/beta.tpp.md
@@ -279,8 +279,16 @@ TODO
 <p class="dimension-indicator"><code>many rows per patient</code></p>
 ## appointments
 
-You can find out more about this table in the associated short data report:
-<https://github.com/opensafely/appointments-short-data-report>.
+You can find out more about this table in the associated [short data
+report][appointments_1]. To view it, you will need a login for OpenSAFELY Jobs and
+the Project Collaborator or Project Developer role for the OpenSAFELY Internal
+project. The [workspace][appointments_2] shows when the code that comprises the
+report was run; the code itself is in the
+[appointments-short-data-report][appointments_3] repository on GitHub.
+
+[appointments_1]: https://jobs.opensafely.org/datalab/opensafely-internal/appointments-short-data-report/outputs/latest/tpp/output/reports/report.html
+[appointments_2]: https://jobs.opensafely.org/datalab/opensafely-internal/appointments-short-data-report/
+[appointments_3]: https://github.com/opensafely/appointments-short-data-report
 <div markdown="block" class="definition-list-wrapper">
   <div class="title">Columns</div>
   <dl markdown="block">

--- a/ehrql/tables/beta/tpp.py
+++ b/ehrql/tables/beta/tpp.py
@@ -501,8 +501,15 @@ class open_prompt(EventFrame):
     """
     This table contains responses to questions from the OpenPROMPT project.
 
-    You can find out more about this table in the associated short data report:
-    <https://github.com/opensafely/airmid-short-data-report>.
+    You can find out more about this table in the associated short data report. To view
+    it, you will need a login for [Level 4][open_prompt_1]. The
+    [workspace][open_prompt_2] shows when the code that comprises the report was run;
+    the code itself is in the [airmid-short-data-report][open_prompt_3] repository on
+    GitHub.
+
+    [open_prompt_1]: https://docs.opensafely.org/security-levels/#level-4-nhs-england-are-data-controllers-of-the-data
+    [open_prompt_2]: https://jobs.opensafely.org/datalab/opensafely-internal/airmid-short-data-report/
+    [open_prompt_3]: https://github.com/opensafely/airmid-short-data-report
     """
 
     ctv3_code = Series(

--- a/ehrql/tables/beta/tpp.py
+++ b/ehrql/tables/beta/tpp.py
@@ -204,8 +204,16 @@ class hospital_admissions(EventFrame):
 @table
 class appointments(EventFrame):
     """
-    You can find out more about this table in the associated short data report:
-    <https://github.com/opensafely/appointments-short-data-report>.
+    You can find out more about this table in the associated [short data
+    report][appointments_1]. To view it, you will need a login for OpenSAFELY Jobs and
+    the Project Collaborator or Project Developer role for the OpenSAFELY Internal
+    project. The [workspace][appointments_2] shows when the code that comprises the
+    report was run; the code itself is in the
+    [appointments-short-data-report][appointments_3] repository on GitHub.
+
+    [appointments_1]: https://jobs.opensafely.org/datalab/opensafely-internal/appointments-short-data-report/outputs/latest/tpp/output/reports/report.html
+    [appointments_2]: https://jobs.opensafely.org/datalab/opensafely-internal/appointments-short-data-report/
+    [appointments_3]: https://github.com/opensafely/appointments-short-data-report
     """
 
     booked_date = Series(


### PR DESCRIPTION
A couple of improvements to `appointments` and `open_prompt` table metadata, following [this Slack thread](https://bennettoxford.slack.com/archives/C03FB777L1M/p1688133357818489).

In both cases, I've documented what a user needs to do to access "the report" (which, in the case of the `open_prompt` table, is currently a set of results); where they can find information about when the report was run; and where they can find the code that comprises the report.

* [Preview of `appointments`](https://ae8e7a2d.databuilder.pages.dev/reference/schemas/beta.tpp/#appointments)
* [Preview of `open_prompt`](https://ae8e7a2d.databuilder.pages.dev/reference/schemas/beta.tpp/#open_prompt)