### PR TITLE
fix: Drop `is_between()` date series method

### DIFF
--- a/docs/includes/generated_docs/specs.md
+++ b/docs/includes/generated_docs/specs.md
@@ -2411,36 +2411,7 @@ returns the following patient series:
 
 
 
-#### 11.2.7 Is between
-
-This example makes use of a patient-level table named `p` containing the following data:
-
-| patient|d1 |
-| - | - |
-| 1|2010-01-01 |
-| 2|2010-01-02 |
-| 3|2010-01-03 |
-| 4|2010-01-04 |
-| 5|2010-01-05 |
-| 6| |
-
-```
-p.d1.is_between(date(2010, 1, 2), date(2010, 1, 4))
-```
-returns the following patient series:
-
-| patient | value |
-| - | - |
-| 1|F |
-| 2|F |
-| 3|T |
-| 4|F |
-| 5|F |
-| 6| |
-
-
-
-#### 11.2.8 Is on or between
+#### 11.2.7 Is on or between
 
 This example makes use of a patient-level table named `p` containing the following data:
 
@@ -2469,7 +2440,7 @@ returns the following patient series:
 
 
 
-#### 11.2.9 Is during
+#### 11.2.8 Is during
 
 This example makes use of a patient-level table named `p` containing the following data:
 
@@ -2498,36 +2469,7 @@ returns the following patient series:
 
 
 
-#### 11.2.10 Is between backwards
-
-This example makes use of a patient-level table named `p` containing the following data:
-
-| patient|d1 |
-| - | - |
-| 1|2010-01-01 |
-| 2|2010-01-02 |
-| 3|2010-01-03 |
-| 4|2010-01-04 |
-| 5|2010-01-05 |
-| 6| |
-
-```
-p.d1.is_between(date(2010, 1, 4), date(2010, 1, 2))
-```
-returns the following patient series:
-
-| patient | value |
-| - | - |
-| 1|F |
-| 2|F |
-| 3|F |
-| 4|F |
-| 5|F |
-| 6| |
-
-
-
-#### 11.2.11 Is on or between backwards
+#### 11.2.9 Is on or between backwards
 
 This example makes use of a patient-level table named `p` containing the following data:
 

--- a/ehrql/query_language.py
+++ b/ehrql/query_language.py
@@ -380,9 +380,6 @@ class DateFunctions(ComparableFunctions):
     def is_on_or_after(self, other):
         return self.__ge__(other)
 
-    def is_between(self, start, end):
-        return (self > start) & (self < end)
-
     def is_on_or_between(self, start, end):
         return (self >= start) & (self <= end)
 

--- a/tests/acceptance/external_studies/ons-mental-health/analysis/dataset_definition_ons_cis_new.py
+++ b/tests/acceptance/external_studies/ons-mental-health/analysis/dataset_definition_ons_cis_new.py
@@ -1,4 +1,4 @@
-from databuilder.ehrql import Dataset
+from databuilder.ehrql import Dataset, days
 from databuilder.tables.beta import tpp as schema
 
 

--- a/tests/acceptance/external_studies/openprompt-long-covid-vaccines/analysis/dataset_definition_longcovid_prevaccine.py
+++ b/tests/acceptance/external_studies/openprompt-long-covid-vaccines/analysis/dataset_definition_longcovid_prevaccine.py
@@ -115,16 +115,16 @@ dataset.define_population(population)
 # covid tests ------------------------------------------------------------
 dataset.first_test_post_lc = sgss_covid_all_tests \
     .where(sgss_covid_all_tests.is_positive) \
-    .where(sgss_covid_all_tests.specimen_taken_date.is_between(dataset.pt_start_date, dataset.pt_end_date)) \
+    .where(sgss_covid_all_tests.specimen_taken_date.is_on_or_between(dataset.pt_start_date + days(1), dataset.pt_end_date - days(1))) \
     .sort_by(sgss_covid_all_tests.specimen_taken_date).first_for_patient().specimen_taken_date
 
 dataset.all_test_positive = sgss_covid_all_tests \
     .where(sgss_covid_all_tests.is_positive) \
-    .where(sgss_covid_all_tests.specimen_taken_date.is_between(dataset.pt_start_date, dataset.pt_end_date)) \
+    .where(sgss_covid_all_tests.specimen_taken_date.is_on_or_between(dataset.pt_start_date + days(1), dataset.pt_end_date - days(1))) \
     .count_for_patient()
 
 dataset.all_tests = sgss_covid_all_tests \
-    .where(sgss_covid_all_tests.specimen_taken_date.is_between(dataset.pt_start_date, dataset.pt_end_date)) \
+    .where(sgss_covid_all_tests.specimen_taken_date.is_on_or_between(dataset.pt_start_date + days(1), dataset.pt_end_date - days(1))) \
     .count_for_patient()
 
 # VACCCINES ------------------------------------------------------------

--- a/tests/acceptance/external_studies/openprompt-long-covid-vaccines/analysis/datasets.py
+++ b/tests/acceptance/external_studies/openprompt-long-covid-vaccines/analysis/datasets.py
@@ -280,7 +280,7 @@ def add_common_variables(dataset, study_start_date, end_date, population):
     fracture_hospitalisations = hospitalisation_diagnosis_matches(hospital_admissions, codelists.hosp_fractures)
 
     dataset.first_fracture_hosp = fracture_hospitalisations \
-        .where(fracture_hospitalisations.admission_date.is_between(dataset.pt_start_date, dataset.pt_end_date)) \
+        .where(fracture_hospitalisations.admission_date.is_on_or_between(dataset.pt_start_date + days(1), dataset.pt_end_date - days(1))) \
         .sort_by(fracture_hospitalisations.admission_date) \
         .first_for_patient().admission_date
 

--- a/tests/acceptance/external_studies/openprompt-long-covid-vaccines/analysis/variable_lib.py
+++ b/tests/acceptance/external_studies/openprompt-long-covid-vaccines/analysis/variable_lib.py
@@ -2,7 +2,7 @@ import operator
 from functools import reduce
 
 from databuilder.codes import ICD10Code
-from databuilder.ehrql import case, when
+from databuilder.ehrql import case, when, days
 from databuilder.tables.beta import tpp as schema
 
 import codelists
@@ -138,6 +138,6 @@ def long_covid_dx_during(start, end):
 
 def long_covid_inhosp(start, end):
     in_study_admissions = schema.hospital_admissions \
-      .where(schema.hospital_admissions.admission_date.is_between(start, end))
+      .where(schema.hospital_admissions.admission_date.is_on_or_between(start + days(1), end - days(1)))
 
     return hospitalisation_diagnosis_matches(admissions=in_study_admissions, codelist=codelists.long_covid_hosp)

--- a/tests/spec/date_series_ops/test_date_comparisons.py
+++ b/tests/spec/date_series_ops/test_date_comparisons.py
@@ -109,22 +109,6 @@ table_data_for_between_tests = {
 }
 
 
-def test_is_between(spec_test):
-    table_data = table_data_for_between_tests
-    spec_test(
-        table_data,
-        p.d1.is_between(date(2010, 1, 2), date(2010, 1, 4)),
-        {
-            1: False,
-            2: False,
-            3: True,
-            4: False,
-            5: False,
-            6: None,
-        },
-    )
-
-
 def test_is_on_or_between(spec_test):
     table_data = table_data_for_between_tests
     spec_test(
@@ -155,22 +139,6 @@ def test_is_during(spec_test):
             2: True,
             3: True,
             4: True,
-            5: False,
-            6: None,
-        },
-    )
-
-
-def test_is_between_backwards(spec_test):
-    table_data = table_data_for_between_tests
-    spec_test(
-        table_data,
-        p.d1.is_between(date(2010, 1, 4), date(2010, 1, 2)),
-        {
-            1: False,
-            2: False,
-            3: False,
-            4: False,
             5: False,
             6: None,
         },


### PR DESCRIPTION
Drop `is_between()` as described in #1188. For acceptance test studies in this repo suggest an identical alternative using `is_on_or_between()` together with adding and subtracting one day to/from the interval. 

Closes #1188 