### PR TITLE
Move `test_patients_age_on`

### DIFF
--- a/tests/integration/tables/beta/test_core.py
+++ b/tests/integration/tables/beta/test_core.py
@@ -1,0 +1,29 @@
+from datetime import date
+
+from ehrql import Dataset
+from ehrql.tables.beta import core
+
+
+def test_patients_age_on(in_memory_engine):
+    in_memory_engine.populate(
+        {
+            core.patients: [
+                dict(patient_id=1, date_of_birth=date(1980, 1, 1)),
+                dict(patient_id=2, date_of_birth=date(1800, 1, 1)),
+                dict(patient_id=3, date_of_birth=date(2010, 1, 1)),
+                dict(patient_id=4, date_of_birth=date(2010, 1, 2)),
+            ]
+        }
+    )
+
+    dataset = Dataset()
+    dataset.define_population(core.patients.exists_for_patient())
+    dataset.age_2010 = core.patients.age_on("2010-01-01")
+    results = in_memory_engine.extract(dataset)
+
+    assert results == [
+        {"patient_id": 1, "age_2010": 30},
+        {"patient_id": 2, "age_2010": 210},
+        {"patient_id": 3, "age_2010": 0},
+        {"patient_id": 4, "age_2010": -1},
+    ]

--- a/tests/integration/tables/beta/test_tpp.py
+++ b/tests/integration/tables/beta/test_tpp.py
@@ -4,7 +4,7 @@ from ehrql import Dataset
 from ehrql.tables.beta import tpp
 
 
-def tests_patients_age_on(in_memory_engine):
+def test_patients_age_on(in_memory_engine):
     in_memory_engine.populate(
         {
             tpp.patients: [

--- a/tests/integration/tables/beta/test_tpp.py
+++ b/tests/integration/tables/beta/test_tpp.py
@@ -4,31 +4,6 @@ from ehrql import Dataset
 from ehrql.tables.beta import tpp
 
 
-def test_patients_age_on(in_memory_engine):
-    in_memory_engine.populate(
-        {
-            tpp.patients: [
-                dict(patient_id=1, date_of_birth=date(1980, 1, 1)),
-                dict(patient_id=2, date_of_birth=date(1800, 1, 1)),
-                dict(patient_id=3, date_of_birth=date(2010, 1, 1)),
-                dict(patient_id=4, date_of_birth=date(2010, 1, 2)),
-            ]
-        }
-    )
-
-    dataset = Dataset()
-    dataset.define_population(tpp.patients.exists_for_patient())
-    dataset.age_2010 = tpp.patients.age_on("2010-01-01")
-    results = in_memory_engine.extract(dataset)
-
-    assert results == [
-        {"patient_id": 1, "age_2010": 30},
-        {"patient_id": 2, "age_2010": 210},
-        {"patient_id": 3, "age_2010": 0},
-        {"patient_id": 4, "age_2010": -1},
-    ]
-
-
 def test_practice_registrations_for_patient_on(in_memory_engine):
     in_memory_engine.populate(
         # Simple case: successive registrations


### PR DESCRIPTION
The `patients` table moved from `tpp` to `core`, so its associated tests should also move from `test_tpp` to `test_core`. Doing so is discussed in #1363.