### PR TITLE
Disable hash seed randomisation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,8 @@ ENV VIRTUAL_ENV=/opt/venv/ \
     PATH="/opt/venv/bin:/opt/mssql-tools/bin:$PATH" \
     ACTION_EXEC=ehrql \
     PYTHONUNBUFFERED=True \
-    PYTHONDONTWRITEBYTECODE=1
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONHASHSEED=0
 
 RUN mkdir /workspace
 WORKDIR /workspace

--- a/Justfile
+++ b/Justfile
@@ -7,6 +7,10 @@ export BIN := VIRTUAL_ENV + "/bin"
 export PIP := BIN + "/python -m pip"
 # enforce our chosen pip compile flags
 export COMPILE := BIN + "/pip-compile --allow-unsafe --generate-hashes"
+# Disable hash randomisation. The kinds of DoS attacks hash seed randomisation
+# is designed to protect against don't apply to ehrQL, and having consistent
+# output makes debugging much easier
+export PYTHONHASHSEED := "0"
 
 
 alias help := list

--- a/ehrql/__main__.py
+++ b/ehrql/__main__.py
@@ -1,6 +1,7 @@
 import importlib
 import os
 import sys
+import warnings
 from argparse import ArgumentParser, ArgumentTypeError
 from pathlib import Path
 
@@ -30,6 +31,15 @@ BACKEND_ALIASES = {
     "emis": "ehrql.backends.emis.EMISBackend",
     "tpp": "ehrql.backends.tpp.TPPBackend",
 }
+
+
+if not os.environ.get("PYTHONHASHSEED") == "0":  # pragma: no cover
+    # The kinds of DoS attacks hash seed randomisation is designed to protect against
+    # don't apply to ehrQL, and having consistent output makes debugging much easier
+    warnings.warn(
+        "PYTHONHASHSEED environment variable not set to 0, so generated SQL may not"
+        " exactly match what is generated in production."
+    )
 
 
 def entrypoint():

--- a/tests/integration/test_query_engines.py
+++ b/tests/integration/test_query_engines.py
@@ -6,7 +6,7 @@ import sqlalchemy
 from ehrql import Dataset
 from ehrql.query_language import PatientFrame, Series, table_from_file
 from ehrql.query_model.nodes import Value
-from ehrql.tables.beta import tpp
+from ehrql.tables.beta.core import patients
 
 
 def test_handles_degenerate_population(engine):
@@ -26,7 +26,7 @@ def test_handles_inline_patient_table(engine, tmp_path):
 
     engine.populate(
         {
-            tpp.patients: [
+            patients: [
                 dict(patient_id=1, date_of_birth=date(1980, 1, 1)),
                 dict(patient_id=2, date_of_birth=date(1990, 2, 2)),
                 dict(patient_id=3, date_of_birth=date(2000, 3, 3)),
@@ -56,11 +56,11 @@ def test_handles_inline_patient_table(engine, tmp_path):
 
     dataset = Dataset()
     dataset.define_population(
-        tpp.patients.exists_for_patient() & test_table.exists_for_patient()
+        patients.exists_for_patient() & test_table.exists_for_patient()
     )
 
     dataset.n = test_table.i + (test_table.i * 10)
-    dataset.age = tpp.patients.age_on(test_table.d)
+    dataset.age = patients.age_on(test_table.d)
     dataset.s = test_table.s
 
     results = engine.extract(dataset)


### PR DESCRIPTION
The kinds of DoS attacks hash seed randomisation is designed to protect against don't apply to ehrQL, and having consistent output makes debugging much easier. I noticed this when trying to diff the SQL output from two different versions of study and realised that the order of codes in a codelist, and the order of columns in some sub-queries, varied arbitrarily between them.

Unfortunately this can only be done via an environment variable, so the best we can do is set it automatically for all invocations via Docker or Just and then warn if ehrQL is invoked via other routes and the variable is not set.

For more on hash seed randomisation see the note on:
https://docs.python.org/3.11/reference/datamodel.html#object.__hash__