### PR TITLE
feat: Add the `ons_cis_raw` table

### DIFF
--- a/docs/includes/generated_docs/schemas/beta.tpp.md
+++ b/docs/includes/generated_docs/schemas/beta.tpp.md
@@ -19,6 +19,7 @@ from ehrql.tables.beta.tpp import (
     medications,
     occupation_on_covid_vaccine_record,
     ons_cis,
+    ons_cis_raw,
     ons_deaths,
     opa_cost,
     opa_diag,
@@ -1672,6 +1673,332 @@ Data from the ONS Covid Infection Survey.
   <dt id="ons_cis.rural_urban">
     <strong>rural_urban</strong>
     <a class="headerlink" href="#ons_cis.rural_urban" title="Permanent link">🔗</a>
+    <code>integer</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+  </dl>
+</div>
+
+
+<p class="dimension-indicator"><code>many rows per patient</code></p>
+## ons_cis_raw
+
+Raw data from the ONS Covid Infection Survey.
+
+This table exposes the raw data; that is, the values haven't been transformed on
+their journey from the database table to the ehrQL table.
+<div markdown="block" class="definition-list-wrapper">
+  <div class="title">Columns</div>
+  <dl markdown="block">
+<div markdown="block">
+  <dt id="ons_cis_raw.covid_admitted">
+    <strong>covid_admitted</strong>
+    <a class="headerlink" href="#ons_cis_raw.covid_admitted" title="Permanent link">🔗</a>
+    <code>integer</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="ons_cis_raw.covid_date">
+    <strong>covid_date</strong>
+    <a class="headerlink" href="#ons_cis_raw.covid_date" title="Permanent link">🔗</a>
+    <code>date</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="ons_cis_raw.covid_nhs_contact">
+    <strong>covid_nhs_contact</strong>
+    <a class="headerlink" href="#ons_cis_raw.covid_nhs_contact" title="Permanent link">🔗</a>
+    <code>integer</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="ons_cis_raw.covid_test_swab">
+    <strong>covid_test_swab</strong>
+    <a class="headerlink" href="#ons_cis_raw.covid_test_swab" title="Permanent link">🔗</a>
+    <code>integer</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="ons_cis_raw.covid_test_swab_neg_last_date">
+    <strong>covid_test_swab_neg_last_date</strong>
+    <a class="headerlink" href="#ons_cis_raw.covid_test_swab_neg_last_date" title="Permanent link">🔗</a>
+    <code>date</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="ons_cis_raw.covid_test_swab_pos_first_date">
+    <strong>covid_test_swab_pos_first_date</strong>
+    <a class="headerlink" href="#ons_cis_raw.covid_test_swab_pos_first_date" title="Permanent link">🔗</a>
+    <code>date</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="ons_cis_raw.covid_test_swab_result">
+    <strong>covid_test_swab_result</strong>
+    <a class="headerlink" href="#ons_cis_raw.covid_test_swab_result" title="Permanent link">🔗</a>
+    <code>integer</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="ons_cis_raw.covid_think_havehad">
+    <strong>covid_think_havehad</strong>
+    <a class="headerlink" href="#ons_cis_raw.covid_think_havehad" title="Permanent link">🔗</a>
+    <code>integer</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="ons_cis_raw.ctsgene_result">
+    <strong>ctsgene_result</strong>
+    <a class="headerlink" href="#ons_cis_raw.ctsgene_result" title="Permanent link">🔗</a>
+    <code>integer</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="ons_cis_raw.health_care_clean">
+    <strong>health_care_clean</strong>
+    <a class="headerlink" href="#ons_cis_raw.health_care_clean" title="Permanent link">🔗</a>
+    <code>integer</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="ons_cis_raw.hhsize">
+    <strong>hhsize</strong>
+    <a class="headerlink" href="#ons_cis_raw.hhsize" title="Permanent link">🔗</a>
+    <code>integer</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="ons_cis_raw.imd_decile_e">
+    <strong>imd_decile_e</strong>
+    <a class="headerlink" href="#ons_cis_raw.imd_decile_e" title="Permanent link">🔗</a>
+    <code>integer</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="ons_cis_raw.imd_quartile_e">
+    <strong>imd_quartile_e</strong>
+    <a class="headerlink" href="#ons_cis_raw.imd_quartile_e" title="Permanent link">🔗</a>
+    <code>integer</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="ons_cis_raw.last_linkage_dt">
+    <strong>last_linkage_dt</strong>
+    <a class="headerlink" href="#ons_cis_raw.last_linkage_dt" title="Permanent link">🔗</a>
+    <code>date</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="ons_cis_raw.long_covid_have_symptoms">
+    <strong>long_covid_have_symptoms</strong>
+    <a class="headerlink" href="#ons_cis_raw.long_covid_have_symptoms" title="Permanent link">🔗</a>
+    <code>integer</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="ons_cis_raw.nhs_data_share">
+    <strong>nhs_data_share</strong>
+    <a class="headerlink" href="#ons_cis_raw.nhs_data_share" title="Permanent link">🔗</a>
+    <code>integer</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="ons_cis_raw.patient_facing_clean">
+    <strong>patient_facing_clean</strong>
+    <a class="headerlink" href="#ons_cis_raw.patient_facing_clean" title="Permanent link">🔗</a>
+    <code>integer</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="ons_cis_raw.result_combined">
+    <strong>result_combined</strong>
+    <a class="headerlink" href="#ons_cis_raw.result_combined" title="Permanent link">🔗</a>
+    <code>integer</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="ons_cis_raw.result_mk">
+    <strong>result_mk</strong>
+    <a class="headerlink" href="#ons_cis_raw.result_mk" title="Permanent link">🔗</a>
+    <code>integer</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="ons_cis_raw.result_mk_date">
+    <strong>result_mk_date</strong>
+    <a class="headerlink" href="#ons_cis_raw.result_mk_date" title="Permanent link">🔗</a>
+    <code>date</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="ons_cis_raw.rural_urban">
+    <strong>rural_urban</strong>
+    <a class="headerlink" href="#ons_cis_raw.rural_urban" title="Permanent link">🔗</a>
+    <code>integer</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="ons_cis_raw.think_have_covid_sympt_now">
+    <strong>think_have_covid_sympt_now</strong>
+    <a class="headerlink" href="#ons_cis_raw.think_have_covid_sympt_now" title="Permanent link">🔗</a>
+    <code>integer</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="ons_cis_raw.visit_date">
+    <strong>visit_date</strong>
+    <a class="headerlink" href="#ons_cis_raw.visit_date" title="Permanent link">🔗</a>
+    <code>date</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="ons_cis_raw.visit_num">
+    <strong>visit_num</strong>
+    <a class="headerlink" href="#ons_cis_raw.visit_num" title="Permanent link">🔗</a>
+    <code>integer</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="ons_cis_raw.visit_status">
+    <strong>visit_status</strong>
+    <a class="headerlink" href="#ons_cis_raw.visit_status" title="Permanent link">🔗</a>
+    <code>integer</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="ons_cis_raw.visit_type">
+    <strong>visit_type</strong>
+    <a class="headerlink" href="#ons_cis_raw.visit_type" title="Permanent link">🔗</a>
     <code>integer</code>
   </dt>
   <dd markdown="block">

--- a/ehrql/backends/tpp.py
+++ b/ehrql/backends/tpp.py
@@ -237,6 +237,38 @@ class TPPBackend(BaseBackend):
         """
     )
 
+    ons_cis_raw = MappedTable(
+        source="ONS_CIS_New",
+        columns=dict(
+            covid_admitted="covid_admitted",
+            covid_date="covid_date",
+            covid_nhs_contact="covid_nhs_contact",
+            covid_test_swab="covid_test_swab",
+            covid_test_swab_neg_last_date="covid_test_swab_neg_last_date",
+            covid_test_swab_pos_first_date="covid_test_swab_pos_first_date",
+            covid_test_swab_result="covid_test_swab_result",
+            covid_think_havehad="covid_think_havehad",
+            ctsgene_result="ctSgene_result",
+            health_care_clean="health_care_clean",
+            hhsize="hhsize",
+            imd_decile_e="imd_decile_E",
+            imd_quartile_e="imd_quartile_E",
+            last_linkage_dt="last_linkage_dt",
+            long_covid_have_symptoms="long_covid_have_symptoms",
+            nhs_data_share="nhs_data_share",
+            patient_facing_clean="patient_facing_clean",
+            result_combined="result_combined",
+            result_mk="result_mk",
+            result_mk_date="result_mk_date",
+            rural_urban="rural_urban",
+            think_have_covid_sympt_now="think_have_covid_sympt_now",
+            visit_date="visit_date",
+            visit_num="visit_num",
+            visit_status="visit_status",
+            visit_type="visit_type",
+        ),
+    )
+
     ons_cis = MappedTable(
         source="ONS_CIS_New",
         columns=dict(

--- a/ehrql/tables/beta/tpp.py
+++ b/ehrql/tables/beta/tpp.py
@@ -23,6 +23,7 @@ __all__ = [
     "emergency_care_attendances",
     "hospital_admissions",
     "appointments",
+    "ons_cis_raw",
     "ons_cis",
     "isaric_raw",
     "open_prompt",
@@ -235,6 +236,43 @@ class household_memberships_2020(PatientFrame):
 
     household_pseudo_id = Series(int)
     household_size = Series(int)
+
+
+@table
+class ons_cis_raw(EventFrame):
+    """
+    Raw data from the ONS Covid Infection Survey.
+
+    This table exposes the raw data; that is, the values haven't been transformed on
+    their journey from the database table to the ehrQL table.
+    """
+
+    covid_admitted = Series(int)
+    covid_date = Series(datetime.date)
+    covid_nhs_contact = Series(int)
+    covid_test_swab = Series(int)
+    covid_test_swab_neg_last_date = Series(datetime.date)
+    covid_test_swab_pos_first_date = Series(datetime.date)
+    covid_test_swab_result = Series(int)
+    covid_think_havehad = Series(int)
+    ctsgene_result = Series(int)
+    health_care_clean = Series(int)
+    hhsize = Series(int)
+    imd_decile_e = Series(int)
+    imd_quartile_e = Series(int)
+    last_linkage_dt = Series(datetime.date)
+    long_covid_have_symptoms = Series(int)
+    nhs_data_share = Series(int)
+    patient_facing_clean = Series(int)
+    result_combined = Series(int)
+    result_mk = Series(int)
+    result_mk_date = Series(datetime.date)
+    rural_urban = Series(int)
+    think_have_covid_sympt_now = Series(int)
+    visit_date = Series(datetime.date)
+    visit_num = Series(int)
+    visit_status = Series(int)
+    visit_type = Series(int)
 
 
 @table

--- a/tests/integration/backends/test_tpp.py
+++ b/tests/integration/backends/test_tpp.py
@@ -559,6 +559,73 @@ def test_household_memberships_2020(select_all):
     ]
 
 
+@register_test_for(tpp.ons_cis_raw)
+def test_ons_cis_raw(select_all):
+    results = select_all(
+        Patient(Patient_ID=1),
+        ONS_CIS_New(
+            covid_admitted=None,
+            covid_date=None,
+            covid_nhs_contact=None,
+            covid_test_swab=None,
+            covid_test_swab_neg_last_date=None,
+            covid_test_swab_pos_first_date=None,
+            covid_test_swab_result=None,
+            covid_think_havehad=None,
+            ctSgene_result=None,
+            health_care_clean=None,
+            hhsize=None,
+            imd_decile_E=1,
+            imd_quartile_E=1,
+            last_linkage_dt=date(2022, 8, 15),
+            long_covid_have_symptoms=None,
+            nhs_data_share=1,
+            patient_facing_clean=None,
+            Patient_ID=1,
+            result_combined=None,
+            result_mk=None,
+            result_mk_date=None,
+            rural_urban=1,
+            think_have_covid_sympt_now=None,
+            visit_date=date(2021, 10, 20),
+            visit_num=1,
+            visit_status=None,
+            visit_type=None,
+        ),
+    )
+    assert results == [
+        {
+            "covid_admitted": None,
+            "covid_date": None,
+            "covid_nhs_contact": None,
+            "covid_test_swab": None,
+            "covid_test_swab_neg_last_date": None,
+            "covid_test_swab_pos_first_date": None,
+            "covid_test_swab_result": None,
+            "covid_think_havehad": None,
+            "ctsgene_result": None,
+            "health_care_clean": None,
+            "hhsize": None,
+            "imd_decile_e": 1,
+            "imd_quartile_e": 1,
+            "last_linkage_dt": date(2022, 8, 15),
+            "long_covid_have_symptoms": None,
+            "nhs_data_share": 1,
+            "patient_facing_clean": None,
+            "patient_id": 1,
+            "result_combined": None,
+            "result_mk": None,
+            "result_mk_date": None,
+            "rural_urban": 1,
+            "think_have_covid_sympt_now": None,
+            "visit_date": date(2021, 10, 20),
+            "visit_num": 1,
+            "visit_status": None,
+            "visit_type": None,
+        },
+    ]
+
+
 @register_test_for(tpp.ons_cis)
 def test_ons_cis(select_all):
     results = select_all(


### PR DESCRIPTION
`ons_cis_raw` contains the columns requested by #1358, with the exception of the `pseudo_visit_id` column (see below), as well as the columns of the `ons_cis` table.

I've taken a conservative approach to mapping from the database table columns (`ONS_CIS_New`) to the ehrQL table (`ons_cis_raw`) columns: I've lower-cased the former to give the latter.

I'm adding `ons_cis_raw` because we need to do more exploration of the raw data before modifying `ons_cis` (e.g. checking the values of `visit_num` are drawn from the interval `[0-15]`), but it's hard to do more exploration without exposing the raw data through ehrQL.

`pseudo_visit_id` is not included, because `ONS_CIS_New.pseudo_visit_id` is of type `VARBINARY` and it's not clear how to expose that type through ehrQL.