### PR TITLE
fix: Rename `is_between()` to `is_between_but_not_on()`

### DIFF
--- a/docs/includes/generated_docs/language__series.md
+++ b/docs/includes/generated_docs/language__series.md
@@ -1701,6 +1701,17 @@ NULL if either value is NULL).
   <a class="headerlink" href="#DatePatientSeries.is_between" title="Permanent link">🔗</a>
 </div>
 <div markdown="block" class="indent">
+NOTE: We will remove this method after (1) releasing is_between_but_not_on and
+(2) updating all existing studies that use is_between.
+Return a boolean series which is True for each date in this series which is
+strictly between (i.e. not equal to) the corresponding dates in `start` and `end`.
+</div>
+
+<div class="attr-heading" id="DatePatientSeries.is_between_but_not_on">
+  <tt><strong>is_between_but_not_on</strong>(<em>start</em>, <em>end</em>)</tt>
+  <a class="headerlink" href="#DatePatientSeries.is_between_but_not_on" title="Permanent link">🔗</a>
+</div>
+<div markdown="block" class="indent">
 Return a boolean series which is True for each date in this series which is
 strictly between (i.e. not equal to) the corresponding dates in `start` and `end`.
 </div>
@@ -1949,6 +1960,17 @@ NULL if either value is NULL).
 <div class="attr-heading" id="DateEventSeries.is_between">
   <tt><strong>is_between</strong>(<em>start</em>, <em>end</em>)</tt>
   <a class="headerlink" href="#DateEventSeries.is_between" title="Permanent link">🔗</a>
+</div>
+<div markdown="block" class="indent">
+NOTE: We will remove this method after (1) releasing is_between_but_not_on and
+(2) updating all existing studies that use is_between.
+Return a boolean series which is True for each date in this series which is
+strictly between (i.e. not equal to) the corresponding dates in `start` and `end`.
+</div>
+
+<div class="attr-heading" id="DateEventSeries.is_between_but_not_on">
+  <tt><strong>is_between_but_not_on</strong>(<em>start</em>, <em>end</em>)</tt>
+  <a class="headerlink" href="#DateEventSeries.is_between_but_not_on" title="Permanent link">🔗</a>
 </div>
 <div markdown="block" class="indent">
 Return a boolean series which is True for each date in this series which is

--- a/docs/includes/generated_docs/specs.md
+++ b/docs/includes/generated_docs/specs.md
@@ -2440,7 +2440,36 @@ returns the following patient series:
 
 
 
-#### 11.2.8 Is on or between
+#### 11.2.8 Is between but not on
+
+This example makes use of a patient-level table named `p` containing the following data:
+
+| patient|d1 |
+| - | - |
+| 1|2010-01-01 |
+| 2|2010-01-02 |
+| 3|2010-01-03 |
+| 4|2010-01-04 |
+| 5|2010-01-05 |
+| 6| |
+
+```python
+p.d1.is_between_but_not_on(date(2010, 1, 2), date(2010, 1, 4))
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1|F |
+| 2|F |
+| 3|T |
+| 4|F |
+| 5|F |
+| 6| |
+
+
+
+#### 11.2.9 Is on or between
 
 This example makes use of a patient-level table named `p` containing the following data:
 
@@ -2469,7 +2498,7 @@ returns the following patient series:
 
 
 
-#### 11.2.9 Is during
+#### 11.2.10 Is during
 
 This example makes use of a patient-level table named `p` containing the following data:
 
@@ -2498,7 +2527,7 @@ returns the following patient series:
 
 
 
-#### 11.2.10 Is between backwards
+#### 11.2.11 Is between backwards
 
 This example makes use of a patient-level table named `p` containing the following data:
 
@@ -2527,7 +2556,7 @@ returns the following patient series:
 
 
 
-#### 11.2.11 Is on or between backwards
+#### 11.2.12 Is on or between backwards
 
 This example makes use of a patient-level table named `p` containing the following data:
 

--- a/ehrql/query_language.py
+++ b/ehrql/query_language.py
@@ -580,6 +580,15 @@ class DateFunctions(ComparableFunctions):
 
     def is_between(self, start, end):
         """
+        NOTE: We will remove this method after (1) releasing is_between_but_not_on and
+        (2) updating all existing studies that use is_between.
+        Return a boolean series which is True for each date in this series which is
+        strictly between (i.e. not equal to) the corresponding dates in `start` and `end`.
+        """
+        return (self > start) & (self < end)
+
+    def is_between_but_not_on(self, start, end):
+        """
         Return a boolean series which is True for each date in this series which is
         strictly between (i.e. not equal to) the corresponding dates in `start` and `end`.
         """

--- a/tests/spec/date_series_ops/test_date_comparisons.py
+++ b/tests/spec/date_series_ops/test_date_comparisons.py
@@ -125,6 +125,22 @@ def test_is_between(spec_test):
     )
 
 
+def test_is_between_but_not_on(spec_test):
+    table_data = table_data_for_between_tests
+    spec_test(
+        table_data,
+        p.d1.is_between_but_not_on(date(2010, 1, 2), date(2010, 1, 4)),
+        {
+            1: False,
+            2: False,
+            3: True,
+            4: False,
+            5: False,
+            6: None,
+        },
+    )
+
+
 def test_is_on_or_between(spec_test):
     table_data = table_data_for_between_tests
     spec_test(


### PR DESCRIPTION
This creates an identical copy of the `is_between()` method with a new name `is_between_but_not_on()`. We will drop `is_between()` after release and updating all research studies that use `is_between()`. 