### PR TITLE
Fix `open_prompt`

### DIFF
--- a/docs/includes/generated_docs/schemas/beta.tpp.md
+++ b/docs/includes/generated_docs/schemas/beta.tpp.md
@@ -2140,7 +2140,7 @@ GitHub.
     <code>CTV3 (Read v3) code</code>
   </dt>
   <dd markdown="block">
-The response to the question, as a CTV3 code. Alternatively, if the question admits a number as the response, then the question, as a CTV3 code.
+The response to the question, as a CTV3 code. Alternatively, if the question does not admit a CTV3 code as the response, then the question, as a CTV3 code.
 
  * Never `NULL`
   </dd>
@@ -2153,7 +2153,7 @@ The response to the question, as a CTV3 code. Alternatively, if the question adm
     <code>SNOMED-CT code</code>
   </dt>
   <dd markdown="block">
-The response to the question, as a SNOMED CT code, for responses where the CTV3 code has a corresponding SNOMED CT code. Alternatively, if the question admits a number as the response, then the question, as a SNOMED CT code, for questions where the CTV3 code has a corresponding SNOMED CT code.
+The response to the question, as a SNOMED CT code, for responses where the CTV3 code has a corresponding SNOMED CT code. Alternatively, if the question does not admit a SNOMED CT code as the response, then the question, as a SNOMED CT code, for questions where the CTV3 code has a corresponding SNOMED CT code.
 
   </dd>
 </div>

--- a/docs/includes/generated_docs/schemas/beta.tpp.md
+++ b/docs/includes/generated_docs/schemas/beta.tpp.md
@@ -2159,13 +2159,26 @@ The response to the question, as a SNOMED CT code, for responses where the CTV3 
 </div>
 
 <div markdown="block">
+  <dt id="open_prompt.creation_date">
+    <strong>creation_date</strong>
+    <a class="headerlink" href="#open_prompt.creation_date" title="Permanent link">🔗</a>
+    <code>date</code>
+  </dt>
+  <dd markdown="block">
+The date the survey was administered
+
+ * Never `NULL`
+  </dd>
+</div>
+
+<div markdown="block">
   <dt id="open_prompt.consultation_date">
     <strong>consultation_date</strong>
     <a class="headerlink" href="#open_prompt.consultation_date" title="Permanent link">🔗</a>
     <code>date</code>
   </dt>
   <dd markdown="block">
-The date the survey was administered
+The response to the question, as a date, if the question admits a date as the response. Alternatively, the date the survey was administered.
 
  * Never `NULL`
   </dd>

--- a/docs/includes/generated_docs/schemas/beta.tpp.md
+++ b/docs/includes/generated_docs/schemas/beta.tpp.md
@@ -2204,9 +2204,8 @@ The ID of the survey
     <code>float</code>
   </dt>
   <dd markdown="block">
-The response to the question, as a number. Alternatively, if the question admits a code as the response, then zero.
+The response to the question, as a number
 
- * Never `NULL`
   </dd>
 </div>
 

--- a/ehrql/backends/tpp.py
+++ b/ehrql/backends/tpp.py
@@ -373,17 +373,24 @@ class TPPBackend(BaseBackend):
     )
 
     open_prompt = QueryTable(
+        # There doesn't seem to be an index on CodedEvent.CodedEvent_ID. However, there
+        # does seem to be an index on CodedEvent.Patient_ID. We join on both, to make
+        # the query faster. We know it's faster, because we compared the time without
+        # the extra join (the query was still executing after 60s) to the time with the
+        # extra join (the query executed in 5s).
         """
         SELECT
-            Patient_ID AS patient_id,
-            CodedEvent_ID AS ctv3_code,
+            prompt.Patient_ID AS patient_id,
+            event.CTV3Code AS ctv3_code,
             CASE
-                WHEN CodeSystemId = 0 THEN ConceptId
+                WHEN prompt.CodeSystemId = 0 THEN prompt.ConceptId
             END AS snomedct_code,
-            CAST(ConsultationDate AS date) AS consultation_date,
-            Consultation_ID AS consultation_id,
-            NumericValue AS numeric_value
-        FROM OpenPROMPT
+            CAST(prompt.ConsultationDate AS date) AS consultation_date,
+            prompt.Consultation_ID AS consultation_id,
+            prompt.NumericValue AS numeric_value
+        FROM OpenPROMPT AS prompt LEFT JOIN CodedEvent AS event
+        ON prompt.CodedEvent_ID = event.CodedEvent_ID
+        AND prompt.Patient_ID = event.Patient_ID
     """
     )
 

--- a/ehrql/backends/tpp.py
+++ b/ehrql/backends/tpp.py
@@ -388,7 +388,9 @@ class TPPBackend(BaseBackend):
             CAST(prompt.CreationDate AS date) AS creation_date,
             CAST(prompt.ConsultationDate AS date) AS consultation_date,
             prompt.Consultation_ID AS consultation_id,
-            prompt.NumericValue AS numeric_value
+            CASE
+                WHEN prompt.NumericCode = 1 THEN prompt.NumericValue
+            END AS numeric_value
         FROM OpenPROMPT AS prompt LEFT JOIN CodedEvent AS event
         ON prompt.CodedEvent_ID = event.CodedEvent_ID
         AND prompt.Patient_ID = event.Patient_ID

--- a/ehrql/backends/tpp.py
+++ b/ehrql/backends/tpp.py
@@ -385,6 +385,7 @@ class TPPBackend(BaseBackend):
             CASE
                 WHEN prompt.CodeSystemId = 0 THEN prompt.ConceptId
             END AS snomedct_code,
+            CAST(prompt.CreationDate AS date) AS creation_date,
             CAST(prompt.ConsultationDate AS date) AS consultation_date,
             prompt.Consultation_ID AS consultation_id,
             prompt.NumericValue AS numeric_value

--- a/ehrql/tables/beta/tpp.py
+++ b/ehrql/tables/beta/tpp.py
@@ -517,7 +517,7 @@ class open_prompt(EventFrame):
         constraints=[Constraint.NotNull()],
         description=(
             "The response to the question, as a CTV3 code. "
-            "Alternatively, if the question admits a number as the response, "
+            "Alternatively, if the question does not admit a CTV3 code as the response, "
             "then the question, as a CTV3 code."
         ),
     )
@@ -526,7 +526,7 @@ class open_prompt(EventFrame):
         description=(
             "The response to the question, as a SNOMED CT code, "
             "for responses where the CTV3 code has a corresponding SNOMED CT code. "
-            "Alternatively, if the question admits a number as the response, "
+            "Alternatively, if the question does not admit a SNOMED CT code as the response, "
             "then the question, as a SNOMED CT code, "
             "for questions where the CTV3 code has a corresponding SNOMED CT code."
         ),

--- a/ehrql/tables/beta/tpp.py
+++ b/ehrql/tables/beta/tpp.py
@@ -552,11 +552,7 @@ class open_prompt(EventFrame):
     )
     numeric_value = Series(
         float,
-        constraints=[Constraint.NotNull()],
-        description=(
-            "The response to the question, as a number. "
-            "Alternatively, if the question admits a code as the response, then zero."
-        ),
+        description="The response to the question, as a number",
     )
 
 

--- a/ehrql/tables/beta/tpp.py
+++ b/ehrql/tables/beta/tpp.py
@@ -531,10 +531,19 @@ class open_prompt(EventFrame):
             "for questions where the CTV3 code has a corresponding SNOMED CT code."
         ),
     )
-    consultation_date = Series(
+    creation_date = Series(
         datetime.date,
         constraints=[Constraint.NotNull()],
         description="The date the survey was administered",
+    )
+    consultation_date = Series(
+        datetime.date,
+        constraints=[Constraint.NotNull()],
+        description=(
+            "The response to the question, as a date, "
+            "if the question admits a date as the response. "
+            "Alternatively, the date the survey was administered."
+        ),
     )
     consultation_id = Series(
         int,

--- a/tests/integration/backends/test_tpp.py
+++ b/tests/integration/backends/test_tpp.py
@@ -1012,6 +1012,7 @@ def test_open_prompt(select_all):
             CreationDate="2023-01-01",
             ConsultationDate="2023-01-01",
             Consultation_ID=1,
+            NumericCode=1,
             NumericValue=1.0,
         ),
         CodedEvent(
@@ -1027,7 +1028,8 @@ def test_open_prompt(select_all):
             CreationDate="2023-01-01",
             ConsultationDate="2023-01-01",
             Consultation_ID=2,
-            NumericValue=1.0,
+            NumericCode=0,
+            NumericValue=0,
         ),
     )
     assert results == [
@@ -1047,7 +1049,7 @@ def test_open_prompt(select_all):
             "creation_date": date(2023, 1, 1),
             "consultation_date": date(2023, 1, 1),
             "consultation_id": 2,
-            "numeric_value": 1.0,
+            "numeric_value": None,
         },
     ]
 

--- a/tests/integration/backends/test_tpp.py
+++ b/tests/integration/backends/test_tpp.py
@@ -1009,6 +1009,7 @@ def test_open_prompt(select_all):
             CodedEvent_ID=1,
             CodeSystemId=0,  # SNOMED CT
             ConceptId="100000",
+            CreationDate="2023-01-01",
             ConsultationDate="2023-01-01",
             Consultation_ID=1,
             NumericValue=1.0,
@@ -1023,6 +1024,7 @@ def test_open_prompt(select_all):
             CodedEvent_ID=2,
             CodeSystemId=2,  # CTV3 "Y"
             ConceptId="Y0000",
+            CreationDate="2023-01-01",
             ConsultationDate="2023-01-01",
             Consultation_ID=2,
             NumericValue=1.0,
@@ -1033,6 +1035,7 @@ def test_open_prompt(select_all):
             "patient_id": 1,
             "ctv3_code": "00000",
             "snomedct_code": "100000",
+            "creation_date": date(2023, 1, 1),
             "consultation_date": date(2023, 1, 1),
             "consultation_id": 1,
             "numeric_value": 1.0,
@@ -1041,6 +1044,7 @@ def test_open_prompt(select_all):
             "patient_id": 2,
             "ctv3_code": "Y0000",
             "snomedct_code": None,
+            "creation_date": date(2023, 1, 1),
             "consultation_date": date(2023, 1, 1),
             "consultation_id": 2,
             "numeric_value": 1.0,

--- a/tests/integration/backends/test_tpp.py
+++ b/tests/integration/backends/test_tpp.py
@@ -999,18 +999,28 @@ def test_isaric_raw_clinical_variables(select_all):
 @register_test_for(tpp.open_prompt)
 def test_open_prompt(select_all):
     results = select_all(
+        CodedEvent(
+            Patient_ID=1,
+            CodedEvent_ID=1,
+            CTV3Code="00000",
+        ),
         OpenPROMPT(
             Patient_ID=1,
-            CodedEvent_ID="00000",
+            CodedEvent_ID=1,
             CodeSystemId=0,  # SNOMED CT
             ConceptId="100000",
             ConsultationDate="2023-01-01",
             Consultation_ID=1,
             NumericValue=1.0,
         ),
+        CodedEvent(
+            Patient_ID=2,
+            CodedEvent_ID=2,
+            CTV3Code="Y0000",
+        ),
         OpenPROMPT(
             Patient_ID=2,
-            CodedEvent_ID="Y0000",
+            CodedEvent_ID=2,
             CodeSystemId=2,  # CTV3 "Y"
             ConceptId="Y0000",
             ConsultationDate="2023-01-01",

--- a/tests/lib/tpp_schema.csv
+++ b/tests/lib/tpp_schema.csv
@@ -1,9 +1,11 @@
 DataSource,TableName,ColumnName,ColumnType,Precision,Scale,MaxLength,IsNullable
-Airmid,OpenPROMPT,CodedEvent_ID,varchar,0,0,50,False
+Airmid,OpenPROMPT,CodedEvent_ID,bigint,19,0,8,False
 Airmid,OpenPROMPT,CodeSystemId,int,10,0,4,False
 Airmid,OpenPROMPT,ConceptId,varchar,0,0,50,True
 Airmid,OpenPROMPT,Consultation_ID,bigint,19,0,8,False
 Airmid,OpenPROMPT,ConsultationDate,datetime,23,3,8,False
+Airmid,OpenPROMPT,CreationDate,datetime,23,3,8,False
+Airmid,OpenPROMPT,NumericCode,int,10,0,4,False
 Airmid,OpenPROMPT,NumericValue,real,24,0,4,False
 Airmid,OpenPROMPT,Patient_ID,int,10,0,4,False
 ICNARC,ICNARC,AdvancedDays_CardiovascularSupport,int,10,0,4,True

--- a/tests/lib/tpp_schema.py
+++ b/tests/lib/tpp_schema.py
@@ -2916,10 +2916,12 @@ class OpenPROMPT(Base):
 
     Patient_ID = mapped_column(t.Integer)
     CodeSystemId = mapped_column(t.Integer)
-    CodedEvent_ID = mapped_column(t.VARCHAR(50))
+    CodedEvent_ID = mapped_column(t.BIGINT)
     ConceptId = mapped_column(t.VARCHAR(50))
     ConsultationDate = mapped_column(t.DateTime)
     Consultation_ID = mapped_column(t.BIGINT)
+    CreationDate = mapped_column(t.DateTime)
+    NumericCode = mapped_column(t.Integer)
     NumericValue = mapped_column(t.REAL)
 
 


### PR DESCRIPTION
This PR bundles a fix, two features, and an update to the documentation that all stem from a chore: fetching and building the TPP schema. As a consequence, I bundled them into a single PR.

We start with 2102d94, which was a consequence of running

```
python tests/lib/update_tpp_schema.py fetch
python tests/lib/update_tpp_schema.py build
```

following a recent release of the [OpenSAFELY-TPP database schema][1] report.

At our request, TPP have changed the schema of the `OpenPROMPT` table, so 914bb0a, ea91391, and, ce510b6 incorporate these changes into ehrQL. Finally, b166ccc updates the documentation.

[1]: https://reports.opensafely.org/reports/opensafely-tpp-database-schema/