### PR TITLE
feat: Expose `Appointment.Status`

### DIFF
--- a/docs/includes/generated_docs/schemas/beta.tpp.md
+++ b/docs/includes/generated_docs/schemas/beta.tpp.md
@@ -317,6 +317,19 @@ The date the appointment was due to start
   </dd>
 </div>
 
+<div markdown="block">
+  <dt id="appointments.status">
+    <strong>status</strong>
+    <a class="headerlink" href="#appointments.status" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+The status of the appointment
+
+ * Possible values: `Booked`, `Arrived`, `Did Not Attend`, `In Progress`, `Finished`, `Requested`, `Blocked`, `Visit`, `Waiting`, `Cancelled by Patient`, `Cancelled by Unit`, `Cancelled by Other Service`, `No Access Visit`, `Cancelled Due To Death`, `Patient Walked Out`
+  </dd>
+</div>
+
   </dl>
 </div>
 

--- a/ehrql/backends/tpp.py
+++ b/ehrql/backends/tpp.py
@@ -220,8 +220,17 @@ class TPPBackend(BaseBackend):
                 Appointment_ID AS appointment_id,
                 Patient_ID AS patient_id,
                 CAST(BookedDate AS date) AS booked_date,
-                CAST(StartDate AS date) AS start_date
-            FROM Appointment
+                CAST(StartDate AS date) AS start_date,
+                Description AS status
+            FROM Appointment AS appt
+            LEFT JOIN (
+                SELECT
+                    Code,
+                    Description
+                FROM DataDictionary
+                WHERE [Table] = 'Appointment'
+            ) AS dict
+            ON appt.Status = dict.Code
         """
     )
 

--- a/ehrql/tables/beta/tpp.py
+++ b/ehrql/tables/beta/tpp.py
@@ -224,6 +224,31 @@ class appointments(EventFrame):
         datetime.date,
         description="The date the appointment was due to start",
     )
+    status = Series(
+        str,
+        description="The status of the appointment",
+        constraints=[
+            Constraint.Categorical(
+                [
+                    "Booked",
+                    "Arrived",
+                    "Did Not Attend",
+                    "In Progress",
+                    "Finished",
+                    "Requested",
+                    "Blocked",
+                    "Visit",
+                    "Waiting",
+                    "Cancelled by Patient",
+                    "Cancelled by Unit",
+                    "Cancelled by Other Service",
+                    "No Access Visit",
+                    "Cancelled Due To Death",
+                    "Patient Walked Out",
+                ]
+            )
+        ],
+    )
 
 
 @table

--- a/tests/integration/backends/test_tpp.py
+++ b/tests/integration/backends/test_tpp.py
@@ -15,6 +15,7 @@ from tests.lib.tpp_schema import (
     CodedEvent,
     CodedEvent_SNOMED,
     CustomMedicationDictionary,
+    DataDictionary,
     EC_Cost,
     EC_Diagnosis,
     HealthCareWorker,
@@ -522,10 +523,12 @@ def test_hospital_admissions(select_all):
 def test_appointments(select_all):
     results = select_all(
         Patient(Patient_ID=1),
+        DataDictionary(Code=0, Description="Booked", Table="Appointment"),
         Appointment(
             Patient_ID=1,
             BookedDate="2021-01-01T09:00:00",
             StartDate="2021-01-01T09:00:00",
+            Status=0,
         ),
     )
     assert results == [
@@ -533,6 +536,7 @@ def test_appointments(select_all):
             "patient_id": 1,
             "booked_date": date(2021, 1, 1),
             "start_date": date(2021, 1, 1),
+            "status": "Booked",
         },
     ]
 


### PR DESCRIPTION
This PR exposes the `Appointment.Status` and joins to the DataDictionary to map the numeric values to more descriptive strings.

Closes #1308 