### PR TITLE
Expose `ONS_CIS_New.pseudo_visit_id`

### DIFF
--- a/docs/includes/generated_docs/schemas/beta.tpp.md
+++ b/docs/includes/generated_docs/schemas/beta.tpp.md
@@ -1670,6 +1670,18 @@ Data from the ONS Covid Infection Survey.
 </div>
 
 <div markdown="block">
+  <dt id="ons_cis.visit_id">
+    <strong>visit_id</strong>
+    <a class="headerlink" href="#ons_cis.visit_id" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
   <dt id="ons_cis.visit_num">
     <strong>visit_num</strong>
     <a class="headerlink" href="#ons_cis.visit_num" title="Permanent link">🔗</a>

--- a/ehrql/backends/tpp.py
+++ b/ehrql/backends/tpp.py
@@ -269,17 +269,19 @@ class TPPBackend(BaseBackend):
         ),
     )
 
-    ons_cis = MappedTable(
-        source="ONS_CIS_New",
-        columns=dict(
-            visit_date="visit_date",
-            visit_num="visit_num",
-            is_opted_out_of_nhs_data_share="nhs_data_share",
-            last_linkage_dt="last_linkage_dt",
-            imd_decile_e="imd_decile_E",
-            imd_quartile_e="imd_quartile_E",
-            rural_urban="rural_urban",
-        ),
+    ons_cis = QueryTable(
+        """
+            SELECT
+                Patient_ID as patient_id,
+                visit_date AS visit_date,
+                visit_num AS visit_num,
+                nhs_data_share AS is_opted_out_of_nhs_data_share,
+                last_linkage_dt AS last_linkage_dt,
+                imd_decile_E AS imd_decile_e,
+                imd_quartile_E AS imd_quartile_e,
+                rural_urban AS rural_urban
+            FROM ONS_CIS_New
+        """
     )
 
     isaric_raw = QueryTable(

--- a/ehrql/backends/tpp.py
+++ b/ehrql/backends/tpp.py
@@ -274,6 +274,7 @@ class TPPBackend(BaseBackend):
             SELECT
                 Patient_ID as patient_id,
                 visit_date AS visit_date,
+                CONVERT(varchar(max), pseudo_visit_id, 2) AS visit_id,
                 visit_num AS visit_num,
                 nhs_data_share AS is_opted_out_of_nhs_data_share,
                 last_linkage_dt AS last_linkage_dt,

--- a/ehrql/tables/beta/tpp.py
+++ b/ehrql/tables/beta/tpp.py
@@ -282,6 +282,7 @@ class ons_cis(EventFrame):
     """
 
     visit_date = Series(datetime.date)
+    visit_id = Series(str)
     visit_num = Series(int)
     is_opted_out_of_nhs_data_share = Series(bool)
     last_linkage_dt = Series(datetime.date)

--- a/tests/integration/backends/test_tpp.py
+++ b/tests/integration/backends/test_tpp.py
@@ -1,3 +1,4 @@
+import hashlib
 from datetime import date
 
 import pytest
@@ -634,6 +635,7 @@ def test_ons_cis(select_all):
         ONS_CIS_New(
             Patient_ID=1,
             visit_date=date(2021, 10, 20),
+            pseudo_visit_id=hashlib.sha256(b"1").digest(),
             visit_num=1,
             last_linkage_dt=date(2022, 8, 15),
             nhs_data_share=1,
@@ -646,6 +648,7 @@ def test_ons_cis(select_all):
         {
             "patient_id": 1,
             "visit_date": date(2021, 10, 20),
+            "visit_id": hashlib.sha256(b"1").digest().hex().upper(),
             "visit_num": 1,
             "is_opted_out_of_nhs_data_share": True,
             "last_linkage_dt": date(2022, 8, 15),


### PR DESCRIPTION
Closes #1416

The `ONS_CIS_New.pseudo_visit_id` column is a `varbinary`. Investigation
on L2 tells us the values are 32 bytes (256 bits) in length, so we
assume the values are SHA-256 hashes.

When we expose this column, we want the values to be intelligible
strings. Consequently, when we convert from a `varbinary` to a
`varchar`, we also convert each binary character to two hex characters
by passing `2` as the third positional argument to `CONVERT`. The T-SQL
documentation for [binary styles][1] makes this clear, if you read it
enough:

> 1, 2 A data_type of type character requires a binary expression.
> Each binary character is converted into two hexadecimal characters.
> The characters 0x aren't added to the left of the converted result
> for style 2.

Because of this conversion, we expose this column as `ons_cis.visit_id`
rather than `ons_cis_raw.visit_id`.

[1]: https://learn.microsoft.com/en-us/sql/t-sql/functions/cast-and-convert-transact-sql?view=sql-server-2017#binary-styles