### PR TITLE
fix: Fix `open_prompt.ctv3_code`

### DIFF
--- a/docs/includes/generated_docs/schemas/beta.tpp.md
+++ b/docs/includes/generated_docs/schemas/beta.tpp.md
@@ -2469,7 +2469,6 @@ GitHub.
   <dd markdown="block">
 The response to the question, as a CTV3 code. Alternatively, if the question does not admit a CTV3 code as the response, then the question, as a CTV3 code.
 
- * Never `NULL`
   </dd>
 </div>
 
@@ -2480,7 +2479,7 @@ The response to the question, as a CTV3 code. Alternatively, if the question doe
     <code>SNOMED-CT code</code>
   </dt>
   <dd markdown="block">
-The response to the question, as a SNOMED CT code, for responses where the CTV3 code has a corresponding SNOMED CT code. Alternatively, if the question does not admit a SNOMED CT code as the response, then the question, as a SNOMED CT code, for questions where the CTV3 code has a corresponding SNOMED CT code.
+The response to the question, as a SNOMED CT code. Alternatively, if the question does not admit a SNOMED CT code as the response, then the question, as a SNOMED CT code.
 
   </dd>
 </div>

--- a/ehrql/backends/tpp.py
+++ b/ehrql/backends/tpp.py
@@ -405,27 +405,22 @@ class TPPBackend(BaseBackend):
     )
 
     open_prompt = QueryTable(
-        # There doesn't seem to be an index on CodedEvent.CodedEvent_ID. However, there
-        # does seem to be an index on CodedEvent.Patient_ID. We join on both, to make
-        # the query faster. We know it's faster, because we compared the time without
-        # the extra join (the query was still executing after 60s) to the time with the
-        # extra join (the query executed in 5s).
         """
         SELECT
-            prompt.Patient_ID AS patient_id,
-            event.CTV3Code AS ctv3_code,
+            Patient_ID AS patient_id,
             CASE
-                WHEN prompt.CodeSystemId = 0 THEN prompt.ConceptId
+                WHEN CodeSystemId = 0 THEN ConceptId
             END AS snomedct_code,
-            CAST(prompt.CreationDate AS date) AS creation_date,
-            CAST(prompt.ConsultationDate AS date) AS consultation_date,
-            prompt.Consultation_ID AS consultation_id,
             CASE
-                WHEN prompt.NumericCode = 1 THEN prompt.NumericValue
+                WHEN CodeSystemId = 2 THEN ConceptId
+            END ctv3_code,
+            CAST(CreationDate AS date) AS creation_date,
+            CAST(ConsultationDate AS date) AS consultation_date,
+            Consultation_ID AS consultation_id,
+            CASE
+                WHEN NumericCode = 1 THEN NumericValue
             END AS numeric_value
-        FROM OpenPROMPT AS prompt LEFT JOIN CodedEvent AS event
-        ON prompt.CodedEvent_ID = event.CodedEvent_ID
-        AND prompt.Patient_ID = event.Patient_ID
+        FROM OpenPROMPT
     """
     )
 

--- a/ehrql/tables/beta/tpp.py
+++ b/ehrql/tables/beta/tpp.py
@@ -552,7 +552,6 @@ class open_prompt(EventFrame):
 
     ctv3_code = Series(
         CTV3Code,
-        constraints=[Constraint.NotNull()],
         description=(
             "The response to the question, as a CTV3 code. "
             "Alternatively, if the question does not admit a CTV3 code as the response, "
@@ -562,11 +561,9 @@ class open_prompt(EventFrame):
     snomedct_code = Series(
         SNOMEDCTCode,
         description=(
-            "The response to the question, as a SNOMED CT code, "
-            "for responses where the CTV3 code has a corresponding SNOMED CT code. "
+            "The response to the question, as a SNOMED CT code. "
             "Alternatively, if the question does not admit a SNOMED CT code as the response, "
-            "then the question, as a SNOMED CT code, "
-            "for questions where the CTV3 code has a corresponding SNOMED CT code."
+            "then the question, as a SNOMED CT code."
         ),
     )
     creation_date = Series(

--- a/tests/integration/backends/test_tpp.py
+++ b/tests/integration/backends/test_tpp.py
@@ -1066,14 +1066,8 @@ def test_isaric_raw_clinical_variables(select_all):
 @register_test_for(tpp.open_prompt)
 def test_open_prompt(select_all):
     results = select_all(
-        CodedEvent(
-            Patient_ID=1,
-            CodedEvent_ID=1,
-            CTV3Code="00000",
-        ),
         OpenPROMPT(
             Patient_ID=1,
-            CodedEvent_ID=1,
             CodeSystemId=0,  # SNOMED CT
             ConceptId="100000",
             CreationDate="2023-01-01",
@@ -1082,14 +1076,8 @@ def test_open_prompt(select_all):
             NumericCode=1,
             NumericValue=1.0,
         ),
-        CodedEvent(
-            Patient_ID=2,
-            CodedEvent_ID=2,
-            CTV3Code="Y0000",
-        ),
         OpenPROMPT(
             Patient_ID=2,
-            CodedEvent_ID=2,
             CodeSystemId=2,  # CTV3 "Y"
             ConceptId="Y0000",
             CreationDate="2023-01-01",
@@ -1102,7 +1090,7 @@ def test_open_prompt(select_all):
     assert results == [
         {
             "patient_id": 1,
-            "ctv3_code": "00000",
+            "ctv3_code": None,
             "snomedct_code": "100000",
             "creation_date": date(2023, 1, 1),
             "consultation_date": date(2023, 1, 1),


### PR DESCRIPTION
914bb0a joined `OpenPROMPT` to `CodedEvent` to return CTV3 codes. However, `CodedEvent` doesn't contain CTV3 codes for `OpenPROMPT`. It might, eventually, which is why the commit was merged in #1410. However, it doesn't, now.

Fortunately, `OpenPROMPT.ConceptId` contains SNOMED CT codes and CTV3 "Y" codes, which we can expose as `open_prompt.snomedct_code` and `open_prompt.ctv3_code`. This means, of course, that both columns will contain missing values; it may also be the case that a given row may have missing values for both columns. But both are better than having no CTV3 codes at all.