### PR TITLE
Add date columns to SUS tables

### DIFF
--- a/docs/includes/generated_docs/schemas/beta.tpp.md
+++ b/docs/includes/generated_docs/schemas/beta.tpp.md
@@ -2547,6 +2547,30 @@ TODO
   </dd>
 </div>
 
+<div markdown="block">
+  <dt id="opa_proc.appointment_date">
+    <strong>appointment_date</strong>
+    <a class="headerlink" href="#opa_proc.appointment_date" title="Permanent link">🔗</a>
+    <code>date</code>
+  </dt>
+  <dd markdown="block">
+TODO
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="opa_proc.referral_request_received_date">
+    <strong>referral_request_received_date</strong>
+    <a class="headerlink" href="#opa_proc.referral_request_received_date" title="Permanent link">🔗</a>
+    <code>date</code>
+  </dt>
+  <dd markdown="block">
+TODO
+
+  </dd>
+</div>
+
   </dl>
 </div>
 

--- a/docs/includes/generated_docs/schemas/beta.tpp.md
+++ b/docs/includes/generated_docs/schemas/beta.tpp.md
@@ -449,6 +449,42 @@ TODO
   </dd>
 </div>
 
+<div markdown="block">
+  <dt id="ec_cost.arrival_date">
+    <strong>arrival_date</strong>
+    <a class="headerlink" href="#ec_cost.arrival_date" title="Permanent link">🔗</a>
+    <code>date</code>
+  </dt>
+  <dd markdown="block">
+TODO
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="ec_cost.ec_decision_to_admit_date">
+    <strong>ec_decision_to_admit_date</strong>
+    <a class="headerlink" href="#ec_cost.ec_decision_to_admit_date" title="Permanent link">🔗</a>
+    <code>date</code>
+  </dt>
+  <dd markdown="block">
+TODO
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="ec_cost.ec_injury_date">
+    <strong>ec_injury_date</strong>
+    <a class="headerlink" href="#ec_cost.ec_injury_date" title="Permanent link">🔗</a>
+    <code>date</code>
+  </dt>
+  <dd markdown="block">
+TODO
+
+  </dd>
+</div>
+
   </dl>
 </div>
 

--- a/docs/includes/generated_docs/schemas/beta.tpp.md
+++ b/docs/includes/generated_docs/schemas/beta.tpp.md
@@ -274,6 +274,30 @@ TODO
   </dd>
 </div>
 
+<div markdown="block">
+  <dt id="apcs_cost.admission_date">
+    <strong>admission_date</strong>
+    <a class="headerlink" href="#apcs_cost.admission_date" title="Permanent link">🔗</a>
+    <code>date</code>
+  </dt>
+  <dd markdown="block">
+TODO
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="apcs_cost.discharge_date">
+    <strong>discharge_date</strong>
+    <a class="headerlink" href="#apcs_cost.discharge_date" title="Permanent link">🔗</a>
+    <code>date</code>
+  </dt>
+  <dd markdown="block">
+TODO
+
+  </dd>
+</div>
+
   </dl>
 </div>
 

--- a/docs/includes/generated_docs/schemas/beta.tpp.md
+++ b/docs/includes/generated_docs/schemas/beta.tpp.md
@@ -2319,6 +2319,30 @@ TODO
   </dd>
 </div>
 
+<div markdown="block">
+  <dt id="opa_cost.appointment_date">
+    <strong>appointment_date</strong>
+    <a class="headerlink" href="#opa_cost.appointment_date" title="Permanent link">🔗</a>
+    <code>date</code>
+  </dt>
+  <dd markdown="block">
+TODO
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="opa_cost.referral_request_received_date">
+    <strong>referral_request_received_date</strong>
+    <a class="headerlink" href="#opa_cost.referral_request_received_date" title="Permanent link">🔗</a>
+    <code>date</code>
+  </dt>
+  <dd markdown="block">
+TODO
+
+  </dd>
+</div>
+
   </dl>
 </div>
 

--- a/docs/includes/generated_docs/schemas/beta.tpp.md
+++ b/docs/includes/generated_docs/schemas/beta.tpp.md
@@ -2451,6 +2451,30 @@ TODO
   </dd>
 </div>
 
+<div markdown="block">
+  <dt id="opa_diag.appointment_date">
+    <strong>appointment_date</strong>
+    <a class="headerlink" href="#opa_diag.appointment_date" title="Permanent link">🔗</a>
+    <code>date</code>
+  </dt>
+  <dd markdown="block">
+TODO
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="opa_diag.referral_request_received_date">
+    <strong>referral_request_received_date</strong>
+    <a class="headerlink" href="#opa_diag.referral_request_received_date" title="Permanent link">🔗</a>
+    <code>date</code>
+  </dt>
+  <dd markdown="block">
+TODO
+
+  </dd>
+</div>
+
   </dl>
 </div>
 

--- a/ehrql/backends/tpp.py
+++ b/ehrql/backends/tpp.py
@@ -443,11 +443,16 @@ class TPPBackend(BaseBackend):
     ec_cost = QueryTable(
         """
         SELECT
-            Patient_ID AS patient_id,
-            EC_Ident AS ec_ident,
-            Grand_Total_Payment_MFF AS grand_total_payment_mff,
-            Tariff_Total_Payment AS tariff_total_payment
-        FROM EC_Cost
+            cost.Patient_ID AS patient_id,
+            cost.EC_Ident AS ec_ident,
+            cost.Grand_Total_Payment_MFF AS grand_total_payment_mff,
+            cost.Tariff_Total_Payment AS tariff_total_payment,
+            ec.Arrival_Date AS arrival_date,
+            ec.EC_Decision_To_Admit_Date AS ec_decision_to_admit_date,
+            ec.EC_Injury_Date AS ec_injury_date
+        FROM EC_Cost AS cost
+        LEFT JOIN EC AS ec
+        ON cost.EC_Ident = ec.EC_Ident
     """
     )
 

--- a/ehrql/backends/tpp.py
+++ b/ehrql/backends/tpp.py
@@ -454,12 +454,16 @@ class TPPBackend(BaseBackend):
     opa_cost = QueryTable(
         """
         SELECT
-            Patient_ID AS patient_id,
-            OPA_Ident AS opa_ident,
-            Tariff_OPP AS tariff_opp,
-            Grand_Total_Payment_MFF AS grand_total_payment_mff,
-            Tariff_Total_Payment AS tariff_total_payment
-        FROM OPA_Cost
+            cost.Patient_ID AS patient_id,
+            cost.OPA_Ident AS opa_ident,
+            cost.Tariff_OPP AS tariff_opp,
+            cost.Grand_Total_Payment_MFF AS grand_total_payment_mff,
+            cost.Tariff_Total_Payment AS tariff_total_payment,
+            opa.Appointment_Date AS appointment_date,
+            opa.Referral_Request_Received_Date AS referral_request_received_date
+        FROM OPA_Cost AS cost
+        LEFT JOIN OPA AS opa
+        ON cost.OPA_Ident = opa.OPA_Ident
     """
     )
 

--- a/ehrql/backends/tpp.py
+++ b/ehrql/backends/tpp.py
@@ -427,12 +427,16 @@ class TPPBackend(BaseBackend):
     apcs_cost = QueryTable(
         """
         SELECT
-            Patient_ID AS patient_id,
-            APCS_Ident AS apcs_ident,
-            Grand_Total_Payment_MFF AS grand_total_payment_mff,
-            Tariff_Initial_Amount AS tariff_initial_amount,
-            Tariff_Total_Payment AS tariff_total_payment
-        FROM APCS_Cost
+            cost.Patient_ID AS patient_id,
+            cost.APCS_Ident AS apcs_ident,
+            cost.Grand_Total_Payment_MFF AS grand_total_payment_mff,
+            cost.Tariff_Initial_Amount AS tariff_initial_amount,
+            cost.Tariff_Total_Payment AS tariff_total_payment,
+            apcs.Admission_Date AS admission_date,
+            apcs.Discharge_Date AS discharge_date
+        FROM APCS_Cost AS cost
+        LEFT JOIN APCS AS apcs
+        ON cost.APCS_Ident = apcs.APCS_Ident
     """
     )
 

--- a/ehrql/backends/tpp.py
+++ b/ehrql/backends/tpp.py
@@ -475,13 +475,17 @@ class TPPBackend(BaseBackend):
     opa_diag = QueryTable(
         """
         SELECT
-            Patient_ID AS patient_id,
-            OPA_Ident AS opa_ident,
-            Primary_Diagnosis_Code AS primary_diagnosis_code,
-            Primary_Diagnosis_Code_Read AS primary_diagnosis_code_read,
-            Secondary_Diagnosis_Code_1 AS secondary_diagnosis_code_1,
-            Secondary_Diagnosis_Code_1_Read AS secondary_diagnosis_code_1_read
-        FROM OPA_Diag
+            diag.Patient_ID AS patient_id,
+            diag.OPA_Ident AS opa_ident,
+            diag.Primary_Diagnosis_Code AS primary_diagnosis_code,
+            diag.Primary_Diagnosis_Code_Read AS primary_diagnosis_code_read,
+            diag.Secondary_Diagnosis_Code_1 AS secondary_diagnosis_code_1,
+            diag.Secondary_Diagnosis_Code_1_Read AS secondary_diagnosis_code_1_read,
+            opa.Appointment_Date AS appointment_date,
+            opa.Referral_Request_Received_Date AS referral_request_received_date
+        FROM OPA_Diag AS diag
+        LEFT JOIN OPA AS opa
+        ON diag.OPA_Ident = opa.OPA_Ident
     """
     )
 

--- a/ehrql/backends/tpp.py
+++ b/ehrql/backends/tpp.py
@@ -490,14 +490,19 @@ class TPPBackend(BaseBackend):
     )
 
     opa_proc = QueryTable(
+        # "PROC" is a reserved word in T-SQL, so we drop the "O"
         """
         SELECT
-            Patient_ID AS patient_id,
-            OPA_Ident AS opa_ident,
-            Primary_Procedure_Code AS primary_procedure_code,
-            Primary_Procedure_Code_Read AS primary_procedure_code_read,
-            Procedure_Code_2 AS procedure_code_1,
-            Procedure_Code_2_Read AS procedure_code_2_read
-        FROM OPA_Proc
+            prc.Patient_ID AS patient_id,
+            prc.OPA_Ident AS opa_ident,
+            prc.Primary_Procedure_Code AS primary_procedure_code,
+            prc.Primary_Procedure_Code_Read AS primary_procedure_code_read,
+            prc.Procedure_Code_2 AS procedure_code_1,
+            prc.Procedure_Code_2_Read AS procedure_code_2_read,
+            opa.Appointment_Date AS appointment_date,
+            opa.Referral_Request_Received_Date AS referral_request_received_date
+        FROM OPA_Proc AS prc
+        LEFT JOIN OPA AS opa
+        ON prc.OPA_Ident = opa.OPA_Ident
     """
     )

--- a/ehrql/tables/beta/tpp.py
+++ b/ehrql/tables/beta/tpp.py
@@ -734,3 +734,11 @@ class opa_proc(EventFrame):
         CTV3Code,
         description="TODO",
     )
+    appointment_date = Series(
+        datetime.date,
+        description="TODO",
+    )
+    referral_request_received_date = Series(
+        datetime.date,
+        description="TODO",
+    )

--- a/ehrql/tables/beta/tpp.py
+++ b/ehrql/tables/beta/tpp.py
@@ -656,6 +656,14 @@ class opa_cost(EventFrame):
         float,
         description="TODO",
     )
+    appointment_date = Series(
+        datetime.date,
+        description="TODO",
+    )
+    referral_request_received_date = Series(
+        datetime.date,
+        description="TODO",
+    )
 
 
 @table

--- a/ehrql/tables/beta/tpp.py
+++ b/ehrql/tables/beta/tpp.py
@@ -701,6 +701,14 @@ class opa_diag(EventFrame):
         CTV3Code,
         description="TODO",
     )
+    appointment_date = Series(
+        datetime.date,
+        description="TODO",
+    )
+    referral_request_received_date = Series(
+        datetime.date,
+        description="TODO",
+    )
 
 
 @table

--- a/ehrql/tables/beta/tpp.py
+++ b/ehrql/tables/beta/tpp.py
@@ -635,6 +635,18 @@ class ec_cost(EventFrame):
         float,
         description="TODO",
     )
+    arrival_date = Series(
+        datetime.date,
+        description="TODO",
+    )
+    ec_decision_to_admit_date = Series(
+        datetime.date,
+        description="TODO",
+    )
+    ec_injury_date = Series(
+        datetime.date,
+        description="TODO",
+    )
 
 
 @table

--- a/ehrql/tables/beta/tpp.py
+++ b/ehrql/tables/beta/tpp.py
@@ -610,6 +610,14 @@ class apcs_cost(EventFrame):
         float,
         description="TODO",
     )
+    admission_date = Series(
+        datetime.date,
+        description="TODO",
+    )
+    discharge_date = Series(
+        datetime.date,
+        description="TODO",
+    )
 
 
 @table

--- a/tests/integration/backends/test_tpp.py
+++ b/tests/integration/backends/test_tpp.py
@@ -1238,6 +1238,11 @@ def test_opa_diag(select_all):
 @register_test_for(tpp.opa_proc)
 def test_opa_proc(select_all):
     results = select_all(
+        OPA(
+            OPA_Ident=1,
+            Appointment_Date=date(2023, 2, 1),
+            Referral_Request_Received_Date=date(2023, 1, 1),
+        ),
         OPA_Proc(
             Patient_ID=1,
             OPA_Ident=1,
@@ -1255,5 +1260,7 @@ def test_opa_proc(select_all):
             "primary_procedure_code_read": "Y0000",
             "procedure_code_1": "100000",
             "procedure_code_2_read": "Y0000",
+            "appointment_date": date(2023, 2, 1),
+            "referral_request_received_date": date(2023, 1, 1),
         },
     ]

--- a/tests/integration/backends/test_tpp.py
+++ b/tests/integration/backends/test_tpp.py
@@ -1149,6 +1149,12 @@ def test_apcs_cost(select_all):
 @register_test_for(tpp.ec_cost)
 def test_ec_cost(select_all):
     results = select_all(
+        EC(
+            EC_Ident=1,
+            Arrival_Date=date(2023, 1, 2),
+            EC_Decision_To_Admit_Date=date(2023, 1, 3),
+            EC_Injury_Date=date(2023, 1, 1),
+        ),
         EC_Cost(
             Patient_ID=1,
             EC_Ident=1,
@@ -1162,6 +1168,9 @@ def test_ec_cost(select_all):
             "ec_ident": 1,
             "grand_total_payment_mff": pytest.approx(1.1, rel=1e-5),
             "tariff_total_payment": pytest.approx(2.2, rel=1e-5),
+            "arrival_date": date(2023, 1, 2),
+            "ec_decision_to_admit_date": date(2023, 1, 3),
+            "ec_injury_date": date(2023, 1, 1),
         },
     ]
 

--- a/tests/integration/backends/test_tpp.py
+++ b/tests/integration/backends/test_tpp.py
@@ -9,6 +9,7 @@ from ehrql.tables.beta import tpp
 from tests.lib.tpp_schema import (
     APCS,
     EC,
+    OPA,
     APCS_Cost,
     APCS_Der,
     Appointment,
@@ -1168,6 +1169,11 @@ def test_ec_cost(select_all):
 @register_test_for(tpp.opa_cost)
 def test_opa_cost(select_all):
     results = select_all(
+        OPA(
+            OPA_Ident=1,
+            Appointment_Date=date(2023, 2, 1),
+            Referral_Request_Received_Date=date(2023, 1, 1),
+        ),
         OPA_Cost(
             Patient_ID=1,
             OPA_Ident=1,
@@ -1183,6 +1189,8 @@ def test_opa_cost(select_all):
             "tariff_opp": pytest.approx(1.1, rel=1e-5),
             "grand_total_payment_mff": pytest.approx(2.2, rel=1e-5),
             "tariff_total_payment": pytest.approx(3.3, rel=1e-5),
+            "appointment_date": date(2023, 2, 1),
+            "referral_request_received_date": date(2023, 1, 1),
         },
     ]
 

--- a/tests/integration/backends/test_tpp.py
+++ b/tests/integration/backends/test_tpp.py
@@ -1207,6 +1207,11 @@ def test_opa_cost(select_all):
 @register_test_for(tpp.opa_diag)
 def test_opa_diag(select_all):
     results = select_all(
+        OPA(
+            OPA_Ident=1,
+            Appointment_Date=date(2023, 2, 1),
+            Referral_Request_Received_Date=date(2023, 1, 1),
+        ),
         OPA_Diag(
             Patient_ID=1,
             OPA_Ident=1,
@@ -1224,6 +1229,8 @@ def test_opa_diag(select_all):
             "primary_diagnosis_code_read": "Y0000",
             "secondary_diagnosis_code_1": "100000",
             "secondary_diagnosis_code_1_read": "Y0000",
+            "appointment_date": date(2023, 2, 1),
+            "referral_request_received_date": date(2023, 1, 1),
         },
     ]
 

--- a/tests/integration/backends/test_tpp.py
+++ b/tests/integration/backends/test_tpp.py
@@ -1119,6 +1119,11 @@ def test_registered_tests_are_exhaustive():
 @register_test_for(tpp.apcs_cost)
 def test_apcs_cost(select_all):
     results = select_all(
+        APCS(
+            APCS_Ident=1,
+            Admission_Date=date(2023, 1, 1),
+            Discharge_Date=date(2023, 2, 1),
+        ),
         APCS_Cost(
             Patient_ID=1,
             APCS_Ident=1,
@@ -1134,6 +1139,8 @@ def test_apcs_cost(select_all):
             "grand_total_payment_mff": pytest.approx(1.1, rel=1e-5),
             "tariff_initial_amount": pytest.approx(2.2, rel=1e-5),
             "tariff_total_payment": pytest.approx(3.3, rel=1e-5),
+            "admission_date": date(2023, 1, 1),
+            "discharge_date": date(2023, 2, 1),
         },
     ]
 


### PR DESCRIPTION
Closes #1426 

One commit for each table:

* 3479e4e9
* 715cb430
* 211dec78
* 12187332
* 4159c30b

In each case, I've set `description="TODO"` for consistency with the other tables/columns. We might wish to remove these entirely, now that they're appearing in the schema documentation. If you think we should, then say! I'll add a follow-up PR.