### PR TITLE
Fix ONS Deaths code example in docs

### DIFF
--- a/docs/how-to/examples.md
+++ b/docs/how-to/examples.md
@@ -126,7 +126,8 @@ dataset.date_of_death = patients.date_of_death
 :notepad_spiral: This value comes from the patient's EHR record.
 
 There is generally a lag between the death being recorded in ONS data and appearing in the primary care record,
-but the date itself is usually reliable when it appears.
+but the date itself is usually reliable when it appears. There may be multiple records of death for each patient
+within this table, so you may wish to take the earliest or latest record available for each patient.
 By contrast, cause of death is often not accurate in the primary care record so we don't make it available to query here.
 
 ### Finding each patient's date, place, and cause of death from ONS records
@@ -136,9 +137,10 @@ from ehrql import Dataset
 from ehrql.tables.beta.tpp import ons_deaths
 
 dataset = Dataset()
-dataset.date_of_death = ons_deaths.date
-dataset.place_of_death = ons_deaths.place
-dataset.cause_of_death = ons_deaths.cause_of_death_01
+last_ons_death = ons_deaths.sort_by(ons_deaths.date).last_for_patient()
+dataset.date_of_death = last_ons_death.date
+dataset.place_of_death = last_ons_death.place
+dataset.cause_of_death = last_ons_death.cause_of_death_01
 ```
 
 :notepad_spiral: There are currently [multiple](https://github.com/opensafely-core/ehrql/blob/8341a03ec55114fe026f326d55e81a462ad8d8c2/ehrql/tables/beta/tpp.py#L140-L155) cause of death fields. We aim to resolve these to a single feature in the future.


### PR DESCRIPTION
The [code example in the current docs for ONS Deaths](https://docs.opensafely.org/ehrql/how-to/examples/#finding-each-patients-date-place-and-cause-of-death-from-ons-records) fails with the following error because ONS Deaths table is not one row per patient.

```
Compiling dataset definition from analysis/dataset_definition.py [ehrql.main] 
     Failed to import 'analysis/dataset_definition.py':

     Traceback (most recent call last):
       File "/workspace/analysis/dataset_definition.py", line 35, in <module>
         dataset.date_of_death = ons_deaths.date
         ^^^^^^^^^^^^^^^^^^^^^
     TypeError: Invalid variable 'date_of_death'. Dataset variables must return one row per patient
```


This change provides a working code example that aggregates it to 1RPP and explains why in the preceding text.