### PR TITLE
feat: Support bare `when` expressions

### DIFF
--- a/docs/includes/generated_docs/language__general.md
+++ b/docs/includes/generated_docs/language__general.md
@@ -59,6 +59,19 @@ Note that because the conditions are evaluated in order we don't need the condit
 for "medium" to specify `(size >= 10) & (size < 20)` because by the time the
 condition for "medium" is being evaluated we already know the condition for "small"
 is False.
+
+A simpler form is available when there is a single condition.  This example:
+```py
+category = case(
+    when(size < 15).then("small"),
+    default="large",
+)
+```
+
+can be rewritten as:
+```py
+category = when(size < 15).then("small").otherwise("large")
+```
 </div>
 
 

--- a/docs/includes/generated_docs/specs.md
+++ b/docs/includes/generated_docs/specs.md
@@ -2849,6 +2849,57 @@ returns the following patient series:
 
 
 
+### 10.2 Case expressions with single condition
+
+
+#### 10.2.1 When with expression
+
+This example makes use of a patient-level table named `p` containing the following data:
+
+| patient|i1 |
+| - | - |
+| 1|6 |
+| 2|7 |
+| 3|8 |
+| 4| |
+
+```python
+when(p.i1 < 8).then(p.i1).otherwise(100)
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1|6 |
+| 2|7 |
+| 3|100 |
+| 4|100 |
+
+
+
+#### 10.2.2 When with boolean column
+
+This example makes use of a patient-level table named `p` containing the following data:
+
+| patient|i1|b1 |
+| - | - | - |
+| 1|6|T |
+| 2|7|F |
+| 3|| |
+
+```python
+when(p.b1).then(p.i1).otherwise(100)
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1|6 |
+| 2|100 |
+| 3|100 |
+
+
+
 ## 11 Operations on all series containing dates
 
 

--- a/ehrql/docs/language.py
+++ b/ehrql/docs/language.py
@@ -13,7 +13,8 @@ from ehrql.docs.common import (
 EXCLUDE_FROM_DOCS = {
     ql.BaseCode,
     ql.Series,
-    # We document `when` as part of `case`
+    # We document `WhenThen` and `when` as part of `case`
+    ql.WhenThen,
     ql.when,
 }
 

--- a/ehrql/query_language.py
+++ b/ehrql/query_language.py
@@ -1250,9 +1250,16 @@ class when:
         self._condition = condition
 
     def then(self, value):
-        new = self.__class__(self._condition)
-        new._value = value
-        return new
+        return WhenThen(self._condition, value)
+
+
+class WhenThen:
+    def __init__(self, condition, value):
+        self._condition = condition
+        self._value = value
+
+    def otherwise(self, default):
+        return case(self, default=default)
 
 
 def case(*when_thens, default=None):
@@ -1280,6 +1287,20 @@ def case(*when_thens, default=None):
     for "medium" to specify `(size >= 10) & (size < 20)` because by the time the
     condition for "medium" is being evaluated we already know the condition for "small"
     is False.
+
+    A simpler form is available when there is a single condition.  This example:
+    ```py
+    category = case(
+        when(size < 15).then("small"),
+        default="large",
+    )
+    ```
+
+    can be rewritten as:
+    ```py
+    category = when(size < 15).then("small").otherwise("large")
+    ```
+
     """
     cases = _DictArg((case._condition, case._value) for case in when_thens)
     # If we don't want a default then we shouldn't supply an argument, or else it will

--- a/tests/spec/case_expressions/test_when.py
+++ b/tests/spec/case_expressions/test_when.py
@@ -1,0 +1,51 @@
+from ehrql import when
+
+from ..tables import p
+
+
+title = "Case expressions with single condition"
+
+
+def test_when_with_expression(spec_test):
+    table_data = {
+        p: """
+          | i1
+        --+----
+        1 | 6
+        2 | 7
+        3 | 8
+        4 |
+        """,
+    }
+    spec_test(
+        table_data,
+        when(p.i1 < 8).then(p.i1).otherwise(100),
+        {
+            1: 6,
+            2: 7,
+            3: 100,
+            4: 100,
+        },
+    )
+
+
+def test_when_with_boolean_column(spec_test):
+    table_data = {
+        p: """
+              | i1 | b1
+            --+----+----
+            1 | 6  | T
+            2 | 7  | F
+            3 |    |
+            """,
+    }
+
+    spec_test(
+        table_data,
+        when(p.b1).then(p.i1).otherwise(100),
+        {
+            1: 6,
+            2: 100,
+            3: 100,
+        },
+    )

--- a/tests/spec/toc.py
+++ b/tests/spec/toc.py
@@ -49,6 +49,7 @@ contents = {
     ],
     "case_expressions": [
         "test_case",
+        "test_when",
     ],
     "date_series_ops": [
         "test_date_series_ops",


### PR DESCRIPTION
This simplifies `case` expressions that have a single `when` clause.

We can now replace:

    category = case(
        when(size < 15).then("small"),
        default="large",
    )

with:

    category = when(size < 15).then("small").otherwise("large")