### PR TITLE
Move `refomat_docstring` to `utils` and use it more widely

### DIFF
--- a/ehrql/docs/backends.py
+++ b/ehrql/docs/backends.py
@@ -3,8 +3,8 @@ from pathlib import Path
 
 import ehrql
 import ehrql.tables
-from ehrql.docs.common import reformat_docstring
 from ehrql.utils.module_utils import get_sibling_subclasses
+from ehrql.utils.string_utils import strip_indent
 
 from ..backends.base import BaseBackend
 
@@ -26,7 +26,7 @@ def build_backends():
                 "name": backend.display_name,
                 "dotted_path": f"{backend.__module__}.{backend.__qualname__}",
                 "file_path": relative_file_path(backend.__module__),
-                "docstring": reformat_docstring(backend.__doc__),
+                "docstring": strip_indent(backend.__doc__),
                 "implements": implements,
             }
         )

--- a/ehrql/docs/common.py
+++ b/ehrql/docs/common.py
@@ -7,22 +7,6 @@ from collections import ChainMap
 from ehrql.codes import BaseCode
 
 
-def reformat_docstring(d):
-    """Reformat docstring to make it easier to use in a markdown/HTML document."""
-    if d is None:
-        return ""
-    # Note that before de-indenting we strip leading newlines but not leading whitespace
-    # more generally. This means we can correctly handle docstrings like:
-    #
-    #   class Foo:
-    #       """
-    #       Blah blah
-    #       blah
-    #       """
-    #
-    return textwrap.dedent(d.lstrip("\n")).strip()
-
-
 def get_class_attrs(cls):
     # We can't iterate the class attributes directly because that would invoke the
     # `Series` descriptors, and we can't use `inspect.getmembers_static` because that

--- a/ehrql/docs/language.py
+++ b/ehrql/docs/language.py
@@ -6,8 +6,8 @@ from ehrql.docs.common import (
     get_arguments,
     get_class_attrs,
     get_name_for_type,
-    reformat_docstring,
 )
+from ehrql.utils.string_utils import strip_indent
 
 
 EXCLUDE_FROM_DOCS = {
@@ -234,7 +234,7 @@ def get_missing_values(target_values, included_values):
 
 
 def require_docstring(obj):
-    docstring = reformat_docstring(obj.__doc__)
+    docstring = strip_indent(obj.__doc__ or "")
     if not docstring and is_proper_subclass(obj, ql.BaseSeries):
         docstring = generate_docstring_for_series(obj)
     assert docstring.strip(), f"No docstring found for {obj}"

--- a/ehrql/docs/schemas.py
+++ b/ehrql/docs/schemas.py
@@ -10,13 +10,13 @@ from ehrql.query_language import (
     get_all_series_from_class,
 )
 from ehrql.utils.module_utils import get_submodules
+from ehrql.utils.string_utils import strip_indent
 
 from .common import (
     get_arguments,
     get_class_attrs,
     get_function_body,
     get_name_for_type,
-    reformat_docstring,
 )
 
 
@@ -32,7 +32,7 @@ def build_schemas(backends=()):
         if not module_tables:
             continue
 
-        docstring = reformat_docstring(module.__doc__)
+        docstring = strip_indent(module.__doc__)
         dotted_path = module.__name__
         hierarchy = dotted_path.removeprefix(f"{tables.__name__}.").split(".")
         name = ".".join(hierarchy)
@@ -68,7 +68,7 @@ def build_tables(module):
         if not isinstance(obj, BaseFrame):
             continue
         cls = obj.__class__
-        docstring = reformat_docstring(cls.__doc__)
+        docstring = strip_indent(cls.__doc__ or "")
         columns = [
             build_column(name, series)
             for name, series in get_all_series_from_class(cls).items()
@@ -104,7 +104,7 @@ def build_table_methods(table_name, cls):
 def build_method(table_name, name, method):
     return {
         "name": name,
-        "docstring": reformat_docstring(method.__doc__),
+        "docstring": strip_indent(method.__doc__),
         "arguments": get_arguments(method, ignore_self=True),
         # Replace the `self` argument with the table name so the resulting code makes
         # more sense in isolation

--- a/ehrql/query_language.py
+++ b/ehrql/query_language.py
@@ -12,6 +12,7 @@ from ehrql.query_model.column_specs import get_column_specs_from_schema
 from ehrql.query_model.nodes import get_series_type, has_one_row_per_patient
 from ehrql.query_model.population_validation import validate_population_definition
 from ehrql.utils import date_utils
+from ehrql.utils.string_utils import strip_indent
 
 
 VALID_VARIABLE_NAME_RE = re.compile(r"^[A-Za-z]+[A-Za-z0-9_]*$")
@@ -1211,13 +1212,13 @@ class Series:
         notes_for_implementors="",
     ):
         self.type_ = type_
-        self.description = description
+        self.description = strip_indent(description)
         self.constraints = constraints
         self.required = required
-        self.implementation_notes_to_add_to_description = (
+        self.implementation_notes_to_add_to_description = strip_indent(
             implementation_notes_to_add_to_description
         )
-        self.notes_for_implementors = notes_for_implementors
+        self.notes_for_implementors = strip_indent(notes_for_implementors)
 
     def __set_name__(self, owner, name):
         self.name = name

--- a/ehrql/tables/beta/tpp.py
+++ b/ehrql/tables/beta/tpp.py
@@ -74,11 +74,11 @@ class practice_registrations(EventFrame):
                 ]
             ),
         ],
-        description=(
-            "Name of the NUTS level 1 region of England to which the practice belongs.\n"
-            "For more information see:\n"
-            "<https://www.ons.gov.uk/methodology/geography/ukgeographies/eurostat>"
-        ),
+        description="""
+            Name of the NUTS level 1 region of England to which the practice belongs.
+            For more information see:
+            <https://www.ons.gov.uk/methodology/geography/ukgeographies/eurostat>
+        """,
     )
 
     def for_patient_on(self, date):

--- a/ehrql/utils/string_utils.py
+++ b/ehrql/utils/string_utils.py
@@ -1,0 +1,13 @@
+import textwrap
+
+
+def strip_indent(s):
+    """
+    Remove indentation from a multiline string
+
+    This is especially useful for taking docstrings and displaying them as markdown.
+    Note that before de-indenting we strip leading newlines but not leading whitespace
+    more generally. This allow us to have the opening quotes on a different line from
+    the text body.
+    """
+    return textwrap.dedent(s.lstrip("\n")).strip()

--- a/tests/unit/test_docs.py
+++ b/tests/unit/test_docs.py
@@ -1,20 +1,5 @@
 from ehrql.docs import generate_docs, render
-from ehrql.docs.common import reformat_docstring
 from ehrql.docs.render_includes.specs import render_specs
-
-
-def test_reformat_docstring():
-    docstring = """
-    First line.
-
-    Second line.
-        Indented
-    """
-
-    output = reformat_docstring(docstring)
-
-    expected = "First line.\n\nSecond line.\n    Indented"
-    assert output == expected
 
 
 def test_generate_docs():

--- a/tests/unit/utils/test_string_utils.py
+++ b/tests/unit/utils/test_string_utils.py
@@ -1,0 +1,32 @@
+import pytest
+
+from ehrql.utils.string_utils import strip_indent
+
+
+@pytest.mark.parametrize(
+    "s,expected",
+    [
+        (
+            "Should\nbe\nuntouched",
+            "Should\nbe\nuntouched",
+        ),
+        (
+            """
+            Leading newline and indent should be stripped:
+
+              But nested indent retained
+
+            Like this.
+            """,
+            (
+                "Leading newline and indent should be stripped:\n"
+                "\n"
+                "  But nested indent retained\n"
+                "\n"
+                "Like this."
+            ),
+        ),
+    ],
+)
+def test_strip_indent(s, expected):
+    assert strip_indent(s) == expected


### PR DESCRIPTION
The `reformat_docstring()` function makes it much more convenient to write embedded Markdown in triple-quoted strings by stripping off the nested indentation. We want to be able to use for things other than just docstrings, so we move it out of the `docs` module and into `string_utils`.