### PR TITLE
fix: Set `environ` when generating measures

### DIFF
--- a/ehrql/__main__.py
+++ b/ehrql/__main__.py
@@ -183,6 +183,7 @@ def add_create_dummy_tables(subparsers, environ, user_args):
 def add_generate_measures(subparsers, environ, user_args):
     parser = subparsers.add_parser("generate-measures", help="Generate measures")
     parser.set_defaults(function=generate_measures)
+    parser.set_defaults(environ=environ)
     parser.set_defaults(user_args=user_args)
     parser.add_argument(
         "--output",


### PR DESCRIPTION
We did this when generating a dataset, but not when generating measures. Consequently, environment variables such as `TEMP_DATABASE_NAME` were available to subclasses of `BaseBackend` when generating datasets but, not when generating measures.

Users, like @alschaffer, who included the `medications` table in their measures definitions would have seen references to `PLACEHOLDER_FOR_TEMP_DATABASE_NAME` in the logs because `TEMP_DATABASE_NAME` was not passed to `BaseBackend.config`. Now, they won't.