### PR TITLE
Ignore warnings so vs code pytest integration works

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,7 @@ add_ignore = [
 [tool.pytest.ini_options]
 addopts = "--tb=native --strict-markers --dist=loadgroup"
 testpaths = ["tests"]
-filterwarnings = ["ignore::UserWarning"]
+filterwarnings = ['ignore: PYTHONHASHSEED environment variable not set to 0']
 
 [tool.ruff]
 line-length = 88

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,7 @@ add_ignore = [
 [tool.pytest.ini_options]
 addopts = "--tb=native --strict-markers --dist=loadgroup"
 testpaths = ["tests"]
+filterwarnings = ["ignore::UserWarning"]
 
 [tool.ruff]
 line-length = 88


### PR DESCRIPTION
e7cc523 introduced a warning which causes Pytest to error when VS Code Python Testing extension runs `python  -m pytest --collect-only --rootdir tests -s --cache-clear .` to discover the tests in the project. This causes the extension to refuse to load the discovered tests, the change in this PR tells Pytest not to raise an Error on Warnings and thus makes the extension work again