### PR TITLE
Specify `PYTHONHASHSEED=0` in pytest configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,9 @@ add_ignore = [
 [tool.pytest.ini_options]
 addopts = "--tb=native --strict-markers --dist=loadgroup"
 testpaths = ["tests"]
+env = [
+  "PYTHONHASHSEED=0",
+]
 
 [tool.ruff]
 line-length = 88

--- a/requirements.dev.in
+++ b/requirements.dev.in
@@ -11,6 +11,7 @@ pip-tools
 pre-commit
 pytest
 pytest-cov
+pytest-env
 pytest-mock
 pytest-xdist
 ruff

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -427,11 +427,16 @@ pytest==7.4.0 \
     # via
     #   -r requirements.dev.in
     #   pytest-cov
+    #   pytest-env
     #   pytest-mock
     #   pytest-xdist
 pytest-cov==4.1.0 \
     --hash=sha256:3904b13dfbfec47f003b8e77fd5b589cd11904a21ddf1ab38a64f204d6a10ef6 \
     --hash=sha256:6ba70b9e97e69fcc3fb45bfeab2d0a138fb65c4d0d6a41ef33983ad114be8c3a
+    # via -r requirements.dev.in
+pytest-env==0.8.2 \
+    --hash=sha256:5e533273f4d9e6a41c3a3120e0c7944aae5674fa773b329f00a5eb1f23c53a38 \
+    --hash=sha256:baed9b3b6bae77bd75b9238e0ed1ee6903a42806ae9d6aeffb8754cd5584d4ff
     # via -r requirements.dev.in
 pytest-mock==3.11.1 \
     --hash=sha256:21c279fff83d70763b05f8874cc9cfb3fcacd6d354247a976f9529d19f9acf39 \


### PR DESCRIPTION
#1453 describes the rationale for this problem; warnings can appear if you run `pytest` directly, because this environment variable may not be set.

This uses the `pytest-env` package to do so, which is maintained by the pytest developers.

@inglesp suggested this approach over suppressing the pytest warning that results if you don't have `PYTHONHASHSEED=0` set.