### PR TITLE
Improve `appointments` schema docs

### DIFF
--- a/docs/includes/generated_docs/schemas/beta.tpp.md
+++ b/docs/includes/generated_docs/schemas/beta.tpp.md
@@ -314,6 +314,24 @@ project. The [workspace][appointments_2] shows when the code that comprises the
 report was run; the code itself is in the
 [appointments-short-data-report][appointments_3] repository on GitHub.
 
+!!! tip
+    Querying this table is similar to using Cohort Extractor's
+    `patients.with_gp_consultations` function. However, that function filters by
+    the status of the appointment. To achieve a similar result with this table:
+
+    ```py
+    appointments.where(
+        appointments.status.is_in([
+            "Arrived",
+            "In Progress",
+            "Finished",
+            "Visit",
+            "Waiting",
+            "Patient Walked Out",
+        ])
+    )
+    ```
+
 [appointments_1]: https://jobs.opensafely.org/datalab/opensafely-internal/appointments-short-data-report/outputs/latest/tpp/output/reports/report.html
 [appointments_2]: https://jobs.opensafely.org/datalab/opensafely-internal/appointments-short-data-report/
 [appointments_3]: https://github.com/opensafely/appointments-short-data-report

--- a/docs/includes/generated_docs/schemas/beta.tpp.md
+++ b/docs/includes/generated_docs/schemas/beta.tpp.md
@@ -305,6 +305,8 @@ TODO
 <p class="dimension-indicator"><code>many rows per patient</code></p>
 ## appointments
 
+Appointments in primary care.
+
 You can find out more about this table in the associated [short data
 report][appointments_1]. To view it, you will need a login for OpenSAFELY Jobs and
 the Project Collaborator or Project Developer role for the OpenSAFELY Internal

--- a/ehrql/tables/beta/tpp.py
+++ b/ehrql/tables/beta/tpp.py
@@ -237,6 +237,8 @@ class hospital_admissions(EventFrame):
 @table
 class appointments(EventFrame):
     """
+    Appointments in primary care.
+
     You can find out more about this table in the associated [short data
     report][appointments_1]. To view it, you will need a login for OpenSAFELY Jobs and
     the Project Collaborator or Project Developer role for the OpenSAFELY Internal

--- a/ehrql/tables/beta/tpp.py
+++ b/ehrql/tables/beta/tpp.py
@@ -246,6 +246,24 @@ class appointments(EventFrame):
     report was run; the code itself is in the
     [appointments-short-data-report][appointments_3] repository on GitHub.
 
+    !!! tip
+        Querying this table is similar to using Cohort Extractor's
+        `patients.with_gp_consultations` function. However, that function filters by
+        the status of the appointment. To achieve a similar result with this table:
+
+        ```py
+        appointments.where(
+            appointments.status.is_in([
+                "Arrived",
+                "In Progress",
+                "Finished",
+                "Visit",
+                "Waiting",
+                "Patient Walked Out",
+            ])
+        )
+        ```
+
     [appointments_1]: https://jobs.opensafely.org/datalab/opensafely-internal/appointments-short-data-report/outputs/latest/tpp/output/reports/report.html
     [appointments_2]: https://jobs.opensafely.org/datalab/opensafely-internal/appointments-short-data-report/
     [appointments_3]: https://github.com/opensafely/appointments-short-data-report


### PR DESCRIPTION
Two improvements, following a discussion with @markdrussell. Whilst Cohort Extractor and ehrQL are different, I think we should support users transitioning from the former to the latter with judicious use of tips, as in 229ad97. (I've deliberately not linked to the Cohort Extractor docs, though, as users don't need to know any more about `patients.with_gp_consultations`.)

We can remove the tips when most users have transitioned.

Preview: https://iaindillingham-improve-appoi.databuilder.pages.dev/reference/schemas/beta.tpp/#appointments