### PR TITLE
Fix `open_prompt.ctv3_code`

### DIFF
--- a/docs/includes/generated_docs/schemas/beta.tpp.md
+++ b/docs/includes/generated_docs/schemas/beta.tpp.md
@@ -2211,6 +2211,7 @@ GitHub.
   <dd markdown="block">
 The response to the question, as a CTV3 code. Alternatively, if the question does not admit a CTV3 code as the response, then the question, as a CTV3 code.
 
+ * Never `NULL`
   </dd>
 </div>
 

--- a/ehrql/backends/tpp.py
+++ b/ehrql/backends/tpp.py
@@ -378,9 +378,7 @@ class TPPBackend(BaseBackend):
             CASE
                 WHEN CodeSystemId = 0 THEN ConceptId
             END AS snomedct_code,
-            CASE
-                WHEN CodeSystemId = 2 THEN ConceptId
-            END ctv3_code,
+            CTV3Code AS ctv3_code,
             CAST(CreationDate AS date) AS creation_date,
             CAST(ConsultationDate AS date) AS consultation_date,
             Consultation_ID AS consultation_id,

--- a/ehrql/tables/beta/tpp.py
+++ b/ehrql/tables/beta/tpp.py
@@ -575,6 +575,7 @@ class open_prompt(EventFrame):
 
     ctv3_code = Series(
         CTV3Code,
+        constraints=[Constraint.NotNull()],
         description=(
             "The response to the question, as a CTV3 code. "
             "Alternatively, if the question does not admit a CTV3 code as the response, "

--- a/tests/integration/backends/test_tpp.py
+++ b/tests/integration/backends/test_tpp.py
@@ -976,6 +976,7 @@ def test_open_prompt(select_all):
     results = select_all(
         OpenPROMPT(
             Patient_ID=1,
+            CTV3Code="X0000",
             CodeSystemId=0,  # SNOMED CT
             ConceptId="100000",
             CreationDate="2023-01-01",
@@ -986,6 +987,7 @@ def test_open_prompt(select_all):
         ),
         OpenPROMPT(
             Patient_ID=2,
+            CTV3Code="Y0000",
             CodeSystemId=2,  # CTV3 "Y"
             ConceptId="Y0000",
             CreationDate="2023-01-01",
@@ -998,7 +1000,7 @@ def test_open_prompt(select_all):
     assert results == [
         {
             "patient_id": 1,
-            "ctv3_code": None,
+            "ctv3_code": "X0000",
             "snomedct_code": "100000",
             "creation_date": date(2023, 1, 1),
             "consultation_date": date(2023, 1, 1),

--- a/tests/lib/tpp_schema.py
+++ b/tests/lib/tpp_schema.py
@@ -2915,6 +2915,7 @@ class OpenPROMPT(Base):
     _pk = mapped_column(t.Integer, primary_key=True)
 
     Patient_ID = mapped_column(t.Integer)
+    CTV3Code = mapped_column(t.VARCHAR(50))
     CodeSystemId = mapped_column(t.Integer)
     CodedEvent_ID = mapped_column(t.BIGINT)
     ConceptId = mapped_column(t.VARCHAR(50))

--- a/tests/lib/update_tpp_schema.py
+++ b/tests/lib/update_tpp_schema.py
@@ -141,6 +141,12 @@ def apply_schema_modifications(by_table):
         {"ColumnName": "CodingSystem", "ColumnType": "int"},
     ]
 
+    # TODO: Remove this when the "OpenSAFELY-TPP database schema" report is next
+    # released.
+    by_table["OpenPROMPT"] += [
+        {"ColumnName": "CTV3Code", "ColumnType": "varchar", "MaxLength": 50},
+    ]
+
     # We don't get column collation information but we know this matters in some cases
     # because you can't compare columns across tables unless the collations are
     # compatible. We add collations here for the two critical columns whose collations


### PR DESCRIPTION
aaee849 adds `OpenPROMPT.CTV3Code` to TPP schema as a temporary measure, until the "OpenSAFELY-TPP database schema" report is next released. We don't want to release that report now, because we don't want to block the OpenPROMPT team.

9600870 is the feature commit, mapping `open_prompt.ctv3_code` to `OpenPROMPT.CTV3Code`.
