### PR TITLE
Improve performance of `medications` queries

### DIFF
--- a/tests/integration/backends/test_tpp.py
+++ b/tests/integration/backends/test_tpp.py
@@ -318,6 +318,14 @@ def test_medications(select_all):
             ConsultationDate="2020-05-18T10:10:10",
             MultilexDrug_ID="5;0;0",
         ),
+        # MedicationIssue.MultilexDrug_ID found in MedicationDictionary but DMD_ID
+        # contains the empty string; dmd_code is NULL not empty string
+        MedicationDictionary(MultilexDrug_ID="6;0;0", DMD_ID=""),
+        MedicationIssue(
+            Patient_ID=1,
+            ConsultationDate="2020-05-19T10:10:10",
+            MultilexDrug_ID="6;0;0",
+        ),
     )
     assert results == [
         {
@@ -339,6 +347,11 @@ def test_medications(select_all):
             "patient_id": 1,
             "date": date(2020, 5, 18),
             "dmd_code": "500000",
+        },
+        {
+            "patient_id": 1,
+            "date": date(2020, 5, 19),
+            "dmd_code": None,
         },
     ]
 


### PR DESCRIPTION
TPP provide a `MedicationDictionary` table which maps internal drug IDs to standard dm+d codes. Where this dictionary is incomplete we want to be able to supply custom entries. The facility to do so was added in:

 * https://github.com/opensafely-core/ehrql/pull/1348

Unfortunately the combination of the two joins and the COALESCE and NULLIF expressions caused abysmal query performance.

We can test this using a simple query template:
```sql
SELECT COUNT(*) FROM (
  /* table definition */
) AS t
WHERE t.date >= '20220101' AND t.date <= '20221231' AND t.dmd_code IN (
  /* prednisolone codelist */
)
```

Using the old, single-join table definition given here the query takes 48 seconds:
https://github.com/opensafely-core/ehrql/blob/488a9933425e7f4f169192c8563b2ae9f7954a58/ehrql/backends/tpp.py#L106-L112

Using the two-joins-and-coalesce approach the same query takes 22 minutes:
https://github.com/opensafely-core/ehrql/blob/a17cbeab3eecec2455a974e07dbfc6fa36df4094/ehrql/backends/tpp.py#L114-L122

The approach we take in this PR is to dynamically construct a single, combined dictionary table with NULL entries removed and then do a single join against that. It's not obvious that should perform better but it turns out that it does: the same query using this approach takes just over 1 minute.

Prednisolone codelist, for reference:
https://github.com/opensafely-core/ehrql/blob/a17cbeab/tests/acceptance/external_studies/openprompt-long-covid-vaccines/codelists/opensafely-asthma-oral-prednisolone-medication.csv