### PR TITLE
Remove join between `Appointment` and `DataDictionary`

### DIFF
--- a/ehrql/backends/tpp.py
+++ b/ehrql/backends/tpp.py
@@ -224,16 +224,24 @@ class TPPBackend(BaseBackend):
                 Patient_ID AS patient_id,
                 CAST(BookedDate AS date) AS booked_date,
                 CAST(StartDate AS date) AS start_date,
-                Description AS status
-            FROM Appointment AS appt
-            LEFT JOIN (
-                SELECT
-                    Code,
-                    Description
-                FROM DataDictionary
-                WHERE [Table] = 'Appointment'
-            ) AS dict
-            ON appt.Status = dict.Code
+                CASE Status
+                    WHEN 0 THEN 'Booked'
+                    WHEN 1 THEN 'Arrived'
+                    WHEN 2 THEN 'Did Not Attend'
+                    WHEN 3 THEN 'In Progress'
+                    WHEN 4 THEN 'Finished'
+                    WHEN 5 THEN 'Requested'
+                    WHEN 6 THEN 'Blocked'
+                    WHEN 7 THEN 'Visit'
+                    WHEN 8 THEN 'Waiting'
+                    WHEN 9 THEN 'Cancelled by Patient'
+                    WHEN 10 THEN 'Cancelled by Unit'
+                    WHEN 11 THEN 'Cancelled by Other Service'
+                    WHEN 12 THEN 'No Access Visit'
+                    WHEN 13 THEN 'Cancelled Due To Death'
+                    WHEN 14 THEN 'Patient Walked Out'
+                END AS status
+            FROM Appointment
         """
     )
 

--- a/tests/integration/backends/test_tpp.py
+++ b/tests/integration/backends/test_tpp.py
@@ -16,7 +16,6 @@ from tests.lib.tpp_schema import (
     CodedEvent,
     CodedEvent_SNOMED,
     CustomMedicationDictionary,
-    DataDictionary,
     EC_Cost,
     EC_Diagnosis,
     HealthCareWorker,
@@ -523,12 +522,11 @@ def test_hospital_admissions(select_all):
 def test_appointments(select_all):
     results = select_all(
         Patient(Patient_ID=1),
-        DataDictionary(Code=0, Description="Booked", Table="Appointment"),
         Appointment(
             Patient_ID=1,
             BookedDate="2021-01-01T09:00:00",
             StartDate="2021-01-01T09:00:00",
-            Status=0,
+            Status=5,
         ),
     )
     assert results == [
@@ -536,7 +534,7 @@ def test_appointments(select_all):
             "patient_id": 1,
             "booked_date": date(2021, 1, 1),
             "start_date": date(2021, 1, 1),
-            "status": "Booked",
+            "status": "Requested",
         },
     ]
 


### PR DESCRIPTION
This join (added in #1413) looks innocuous but it caused a catastrophic performance regression: queries which previously took 15 minutes were taking 11 hours.

The problem is compounded by the presence of the DISTINCT clause (which we hope is only temporary, see #1053) which seems to increase query times by 4-5x. However this is dwarfed by the join which increases query times by another 40-50x on top of that.

Replacing the join with a hardcoded case expression is only marginally slower than not including the `status` field at all so we do that instead.