### PR TITLE
Check inputs to `--dummy-data`, `--dummy-tables`

### DIFF
--- a/ehrql/__main__.py
+++ b/ehrql/__main__.py
@@ -232,7 +232,7 @@ def add_run_sandbox(subparsers, environ, user_args):
     parser.add_argument(
         "dummy_tables_path",
         help="Path to directory of CSV files (one per table)",
-        type=Path,
+        type=existing_directory,
     )
 
 

--- a/ehrql/__main__.py
+++ b/ehrql/__main__.py
@@ -114,7 +114,7 @@ def add_generate_dataset(subparsers, environ, user_args):
     parser.add_argument(
         "--dummy-data-file",
         help="Provide dummy data from a file to be validated and used as the dataset",
-        type=Path,
+        type=existing_file,
     )
     parser.add_argument(
         "--dummy-tables",
@@ -122,7 +122,7 @@ def add_generate_dataset(subparsers, environ, user_args):
             "Path to directory of CSV files (one per table) to use when generating "
             "dummy data"
         ),
-        type=Path,
+        type=existing_directory,
         dest="dummy_tables_path",
     )
     parser.add_argument(
@@ -206,7 +206,7 @@ def add_generate_measures(subparsers, environ, user_args):
             "Path to directory of CSV files (one per table) to use when generating "
             "dummy data"
         ),
-        type=Path,
+        type=existing_directory,
         dest="dummy_tables_path",
     )
     parser.add_argument(
@@ -215,7 +215,7 @@ def add_generate_measures(subparsers, environ, user_args):
             "Provide dummy data from a file to be validated and used as the "
             "measures output"
         ),
-        type=Path,
+        type=existing_file,
     )
     parser.add_argument(
         "definition_file",
@@ -293,6 +293,24 @@ def add_common_backend_arguments(parser, environ):
         default=environ.get("OPENSAFELY_BACKEND"),
         dest="backend_class",
     )
+
+
+def existing_file(value):
+    path = Path(value)
+    if not path.exists():
+        raise ArgumentTypeError(f"{value} does not exist")
+    if not path.is_file():
+        raise ArgumentTypeError(f"{value} is not a file")
+    return path
+
+
+def existing_directory(value):
+    path = Path(value)
+    if not path.exists():
+        raise ArgumentTypeError(f"{value} does not exist")
+    if not path.is_dir():
+        raise ArgumentTypeError(f"{value} is not a directory")
+    return path
 
 
 def existing_python_file(value):

--- a/tests/unit/test___main__.py
+++ b/tests/unit/test___main__.py
@@ -82,12 +82,14 @@ def test_generate_measures(mocker):
     patched.assert_called_once()
 
 
-def test_run_sandbox(mocker):
+def test_run_sandbox(mocker, tmp_path):
     # Verify that the runs_sandbox subcommand can be invoked.
+    dummy_data_path = tmp_path / "dummy-data"
+    dummy_data_path.mkdir()
     patched = mocker.patch("ehrql.sandbox.run")
     argv = [
         "sandbox",
-        "dummy_data_path",
+        str(dummy_data_path),
     ]
     main(argv)
     patched.assert_called_once()

--- a/tests/unit/test___main__.py
+++ b/tests/unit/test___main__.py
@@ -122,6 +122,70 @@ def test_existing_python_file_unpythonic_file(capsys, tmp_path):
     assert "dataset.cpp is not a Python file" in captured.err
 
 
+def test_existing_directory_missing_directory(capsys, tmp_path):
+    dataset_definition_path = tmp_path / "dataset.py"
+    dataset_definition_path.touch()
+    argv = [
+        "generate-dataset",
+        str(dataset_definition_path),
+        "--dummy-tables",
+        "non-existent-directory",
+    ]
+    with pytest.raises(SystemExit):
+        main(argv)
+    captured = capsys.readouterr()
+    assert "non-existent-directory does not exist" in captured.err
+
+
+def test_existing_directory_not_a_directory(capsys, tmp_path):
+    dataset_definition_path = tmp_path / "dataset.py"
+    dataset_definition_path.touch()
+    file_path = tmp_path / "not-a-directory.file"
+    file_path.touch()
+    argv = [
+        "generate-dataset",
+        str(dataset_definition_path),
+        "--dummy-tables",
+        str(file_path),
+    ]
+    with pytest.raises(SystemExit):
+        main(argv)
+    captured = capsys.readouterr()
+    assert "not-a-directory.file is not a directory" in captured.err
+
+
+def test_existing_file_missing_file(capsys, tmp_path):
+    dataset_definition_path = tmp_path / "dataset.py"
+    dataset_definition_path.touch()
+    argv = [
+        "generate-dataset",
+        str(dataset_definition_path),
+        "--dummy-data-file",
+        "non-existent-file",
+    ]
+    with pytest.raises(SystemExit):
+        main(argv)
+    captured = capsys.readouterr()
+    assert "non-existent-file does not exist" in captured.err
+
+
+def test_existing_file_not_a_file(capsys, tmp_path):
+    dataset_definition_path = tmp_path / "dataset.py"
+    dataset_definition_path.touch()
+    directory_path = tmp_path / "not-a-file"
+    directory_path.mkdir()
+    argv = [
+        "generate-dataset",
+        str(dataset_definition_path),
+        "--dummy-data-file",
+        str(directory_path),
+    ]
+    with pytest.raises(SystemExit):
+        main(argv)
+    captured = capsys.readouterr()
+    assert "not-a-file is not a file" in captured.err
+
+
 def test_import_string():
     assert import_string("ehrql.__main__.main") is main
 


### PR DESCRIPTION
Check inputs to `--dummy-data`, `--dummy-tables`

Specifically that `--dummy-data` gets a file, and `--dummy-tables` gets
a directory, and add specific error messages flagging this.

These two options could be easily confused.