### PR TITLE
chore: Add build date and commit to Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -130,3 +130,11 @@ COPY ehrql /app/ehrql
 RUN python -m compileall /app/ehrql
 COPY databuilder /app/databuilder
 RUN python -m compileall /app/databuilder
+
+# The following build details will change.
+# These are the last step to make better use of Docker's build cache,
+# avoiding rebuilding image layers unnecessarily.
+ARG BUILD_DATE=unknown
+LABEL org.opencontainers.image.created=$BUILD_DATE
+ARG GITREF=unknown
+LABEL org.opencontainers.image.revision=$GITREF

--- a/Justfile
+++ b/Justfile
@@ -129,8 +129,11 @@ build-ehrql:
     #!/usr/bin/env bash
     set -euo pipefail
 
+    export BUILD_DATE=$(date -u +'%y-%m-%dT%H:%M:%SZ')
+    export GITREF=$(git rev-parse --short HEAD)
+
     [[ -v CI ]] && echo "::group::Build ehrql (click to view)" || echo "Build ehrql"
-    DOCKER_BUILDKIT=1 docker build . -t ehrql-dev
+    DOCKER_BUILDKIT=1 docker build --build-arg BUILD_DATE="$BUILD_DATE" --build-arg GITREF="$GITREF" . -t ehrql-dev
     [[ -v CI ]] && echo "::endgroup::" || echo ""
 
 


### PR DESCRIPTION
Fixes #1484.

These details are visible with `docker inspect`.

Based on:

opensafely-core/job-server@fbb5d1747263db429c367b4f8533b3307e8ac096