### PR TITLE
docs: Document `patients` table

### DIFF
--- a/docs/includes/generated_docs/schemas/beta.core.md
+++ b/docs/includes/generated_docs/schemas/beta.core.md
@@ -333,7 +333,27 @@ Patient's date of death. Only deaths registered from February 2019 are recorded.
 <p class="dimension-indicator"><code>one row per patient</code></p>
 ## patients
 
+Patients in primary care.
 
+### Representativeness
+
+You can find out more about the representativeness of these data in the
+OpenSAFELY-TPP backend in:
+
+> The OpenSAFELY Collaborative, Colm D. Andrews, Anna Schultze, Helen J. Curtis, William J. Hulme, John Tazare, Stephen J. W. Evans, _et al._ 2022.
+> "OpenSAFELY: Representativeness of Electronic Health Record Platform OpenSAFELY-TPP Data Compared to the Population of England."
+> Wellcome Open Res 2022, 7:191.
+> <https://doi.org/10.12688/wellcomeopenres.18010.1>
+
+
+### Orphan records
+
+If a practice becomes aware that a patient has moved house,
+then the practice _deducts_, or removes, the patient's records from their register.
+If the patient doesn't register with a new practice within a given amount of time
+(normally from four to eight weeks),
+then the patient's records are permanently deducted and are _orphan records_.
+There are roughly 1.6 million orphan records.
 <div markdown="block" class="definition-list-wrapper">
   <div class="title">Columns</div>
   <dl markdown="block">
@@ -344,7 +364,7 @@ Patient's date of death. Only deaths registered from February 2019 are recorded.
     <code>date</code>
   </dt>
   <dd markdown="block">
-Patient's date of birth, rounded to first of month.
+Patient's date of birth.
 
  * Always the first day of a month
  * Never `NULL`
@@ -390,10 +410,10 @@ Patient's date of death.
   </dt>
   <dd markdown="block">
 Patient's age as an integer, in whole elapsed calendar years, as it would be on
-the supplied date.
+the given date.
 
-Note that this takes no account of whether the patient is alive at the given
-date. In particular, it may return negative values if the date is before the
+This method takes no account of whether the patient is alive on the given date.
+In particular, it may return negative values if the given date is before the
 patient's date of birth.
     <details markdown="block">
     <summary>View method definition</summary>

--- a/docs/includes/generated_docs/schemas/beta.tpp.md
+++ b/docs/includes/generated_docs/schemas/beta.tpp.md
@@ -2285,7 +2285,27 @@ The response to the question, as a number
 <p class="dimension-indicator"><code>one row per patient</code></p>
 ## patients
 
+Patients in primary care.
 
+### Representativeness
+
+You can find out more about the representativeness of these data in the
+OpenSAFELY-TPP backend in:
+
+> The OpenSAFELY Collaborative, Colm D. Andrews, Anna Schultze, Helen J. Curtis, William J. Hulme, John Tazare, Stephen J. W. Evans, _et al._ 2022.
+> "OpenSAFELY: Representativeness of Electronic Health Record Platform OpenSAFELY-TPP Data Compared to the Population of England."
+> Wellcome Open Res 2022, 7:191.
+> <https://doi.org/10.12688/wellcomeopenres.18010.1>
+
+
+### Orphan records
+
+If a practice becomes aware that a patient has moved house,
+then the practice _deducts_, or removes, the patient's records from their register.
+If the patient doesn't register with a new practice within a given amount of time
+(normally from four to eight weeks),
+then the patient's records are permanently deducted and are _orphan records_.
+There are roughly 1.6 million orphan records.
 <div markdown="block" class="definition-list-wrapper">
   <div class="title">Columns</div>
   <dl markdown="block">
@@ -2296,7 +2316,7 @@ The response to the question, as a number
     <code>date</code>
   </dt>
   <dd markdown="block">
-Patient's date of birth, rounded to first of month.
+Patient's date of birth.
 
  * Always the first day of a month
  * Never `NULL`
@@ -2342,10 +2362,10 @@ Patient's date of death.
   </dt>
   <dd markdown="block">
 Patient's age as an integer, in whole elapsed calendar years, as it would be on
-the supplied date.
+the given date.
 
-Note that this takes no account of whether the patient is alive at the given
-date. In particular, it may return negative values if the date is before the
+This method takes no account of whether the patient is alive on the given date.
+In particular, it may return negative values if the given date is before the
 patient's date of birth.
     <details markdown="block">
     <summary>View method definition</summary>

--- a/ehrql/tables/beta/core.py
+++ b/ehrql/tables/beta/core.py
@@ -40,10 +40,10 @@ class patients(PatientFrame):
     def age_on(self, date):
         """
         Patient's age as an integer, in whole elapsed calendar years, as it would be on
-        the supplied date.
+        the given date.
 
-        Note that this takes no account of whether the patient is alive at the given
-        date. In particular, it may return negative values if the date is before the
+        This method takes no account of whether the patient is alive on the given date.
+        In particular, it may return negative values if the given date is before the
         patient's date of birth.
         """
         return (date - self.date_of_birth).years

--- a/ehrql/tables/beta/core.py
+++ b/ehrql/tables/beta/core.py
@@ -18,7 +18,7 @@ from ehrql.tables import Constraint, EventFrame, PatientFrame, Series, table
 class patients(PatientFrame):
     date_of_birth = Series(
         datetime.date,
-        description="Patient's date of birth, rounded to first of month.",
+        description="Patient's date of birth.",
         constraints=[Constraint.FirstOfMonth(), Constraint.NotNull()],
     )
     sex = Series(

--- a/ehrql/tables/beta/core.py
+++ b/ehrql/tables/beta/core.py
@@ -16,6 +16,30 @@ from ehrql.tables import Constraint, EventFrame, PatientFrame, Series, table
 
 @table
 class patients(PatientFrame):
+    """
+    Patients in primary care.
+
+    ### Representativeness
+
+    You can find out more about the representativeness of these data in the
+    OpenSAFELY-TPP backend in:
+
+    > The OpenSAFELY Collaborative, Colm D. Andrews, Anna Schultze, Helen J. Curtis, William J. Hulme, John Tazare, Stephen J. W. Evans, _et al._ 2022.
+    > "OpenSAFELY: Representativeness of Electronic Health Record Platform OpenSAFELY-TPP Data Compared to the Population of England."
+    > Wellcome Open Res 2022, 7:191.
+    > <https://doi.org/10.12688/wellcomeopenres.18010.1>
+
+
+    ### Orphan records
+
+    If a practice becomes aware that a patient has moved house,
+    then the practice _deducts_, or removes, the patient's records from their register.
+    If the patient doesn't register with a new practice within a given amount of time
+    (normally from four to eight weeks),
+    then the patient's records are permanently deducted and are _orphan records_.
+    There are roughly 1.6 million orphan records.
+    """
+
     date_of_birth = Series(
         datetime.date,
         description="Patient's date of birth.",


### PR DESCRIPTION
I checked cohort-extractor, but didn't find anything there that wasn't already here. I skimmed the linked-to paper, and am confident that it is relevant to the `patients` table specifically (rather than to other tables generally).

We don't have a mechanism for adding a backend-specific docstring to a core table, so if we want to link to the paper, which is about the OpenSAFELY-TPP backend, then we have to link to it from every backend (see the links, below). Nevertheless, it's reasonable to assume that a researcher might want to read the paper, regardless of the backend.

The information about orphan records comes from [this Slack thread][1].

* [`beta.core.patients` doc](https://iaindillingham-document-pati.databuilder.pages.dev/reference/schemas/beta.core/#patients)
* [`beta.tpp.patients` doc](https://iaindillingham-document-pati.databuilder.pages.dev/reference/schemas/beta.tpp/#patients)

Closes #1381 

[1]: https://bennettoxford.slack.com/archives/C02HJTL065A/p1689327065988359