### PR TITLE
Automatically apply T1OO exclusions

### DIFF
--- a/tests/lib/tpp_schema.py
+++ b/tests/lib/tpp_schema.py
@@ -3154,6 +3154,13 @@ class PatientAddress(Base):
     StartDate = mapped_column(t.DateTime)
 
 
+class PatientsWithTypeOneDissent(Base):
+    __tablename__ = "PatientsWithTypeOneDissent"
+    _pk = mapped_column(t.Integer, primary_key=True)
+
+    Patient_ID = mapped_column(t.BIGINT)
+
+
 class PotentialCareHomeAddress(Base):
     __tablename__ = "PotentialCareHomeAddress"
     _pk = mapped_column(t.Integer, primary_key=True)

--- a/tests/lib/update_tpp_schema.py
+++ b/tests/lib/update_tpp_schema.py
@@ -139,6 +139,13 @@ def apply_schema_modifications(by_table):
         collation="Latin1_General_CI_AS",
     )
 
+    # TODO: We're waiting for the updated schema to be published which should include
+    # this table
+    assert "PatientsWithTypeOneDissent" not in by_table
+    by_table["PatientsWithTypeOneDissent"] = [
+        {"ColumnName": "Patient_ID", "ColumnType": "bigint"},
+    ]
+
 
 def write_schema(lines):
     lines[:0] = [HEADER.strip()]

--- a/tests/unit/backends/test_tpp.py
+++ b/tests/unit/backends/test_tpp.py
@@ -1,0 +1,57 @@
+import pytest
+
+from ehrql.backends.tpp import TPPBackend
+
+
+@pytest.mark.parametrize(
+    "dsn_in,dsn_out,t1oo_status",
+    [
+        (
+            "mssql://user:pass@localhost:4321/db",
+            "mssql://user:pass@localhost:4321/db",
+            True,
+        ),
+        (
+            "mssql://user:pass@localhost:4321/db?param1=one&param2&param1=three",
+            "mssql://user:pass@localhost:4321/db?param1=one&param1=three&param2=",
+            True,
+        ),
+        (
+            "mssql://user:pass@localhost:4321/db?opensafely_include_t1oo&param2=two",
+            "mssql://user:pass@localhost:4321/db?param2=two",
+            False,
+        ),
+        (
+            "mssql://user:pass@localhost:4321/db?opensafely_include_t1oo=false",
+            "mssql://user:pass@localhost:4321/db",
+            False,
+        ),
+        (
+            "mssql://user:pass@localhost:4321/db?opensafely_include_t1oo=true",
+            "mssql://user:pass@localhost:4321/db",
+            True,
+        ),
+        (
+            "mssql://user:pass@localhost:4321/db?opensafely_include_t1oo=True",
+            "mssql://user:pass@localhost:4321/db",
+            True,
+        ),
+    ],
+)
+def test_tpp_backend_modify_dsn(dsn_in, dsn_out, t1oo_status):
+    backend = TPPBackend()
+    assert backend.modify_dsn(dsn_in) == dsn_out
+    assert backend.include_t1oo == t1oo_status
+
+
+@pytest.mark.parametrize(
+    "dsn",
+    [
+        "mssql://user:pass@localhost:4321/db?opensafely_include_t1oo=false&opensafely_include_t1oo=false",
+        "mssql://user:pass@localhost:4321/db?opensafely_include_t1oo=false&opensafely_include_t1oo",
+    ],
+)
+def test_tpp_backend_modify_dsn_rejects_duplicate_params(dsn):
+    backend = TPPBackend()
+    with pytest.raises(ValueError, match="must not be supplied more than once"):
+        backend.modify_dsn(dsn)


### PR DESCRIPTION
To facilitate deployment we temporarily set the default configuration to `True`. A subsequent PR reverses this:
 * https://github.com/opensafely-core/ehrql/pull/1588