### PR TITLE
Re-work logging setup

### DIFF
--- a/ehrql/__init__.py
+++ b/ehrql/__init__.py
@@ -1,4 +1,3 @@
-import os
 from pathlib import Path
 
 from ehrql.codes import codelist_from_csv
@@ -17,13 +16,6 @@ from ehrql.query_language import (
 from ehrql.utils.log_utils import init_logging
 
 
-if os.getenv("LOG_SQL"):  # pragma: no cover
-    # Logging is very verbose in tests, so we disable it  unless specifically requested
-    # with the use of the `LOG_SQL` environment variable.
-    # By defalt, logging is initiated in __main__.py, so it's only enabled when running
-    # ehrql from the command line.
-    init_logging()
-
 __version__ = Path(__file__).parent.joinpath("VERSION").read_text().strip()
 
 
@@ -41,3 +33,5 @@ __all__ = [
     "when",
     "years",
 ]
+
+init_logging()

--- a/ehrql/__main__.py
+++ b/ehrql/__main__.py
@@ -1,4 +1,5 @@
 import importlib
+import logging
 import os
 import sys
 import warnings
@@ -7,7 +8,6 @@ from pathlib import Path
 
 from ehrql import __version__
 from ehrql.file_formats import FILE_FORMATS, get_file_extension
-from ehrql.utils.log_utils import init_logging
 from ehrql.utils.string_utils import strip_indent
 
 from .main import (
@@ -75,16 +75,21 @@ def main(args, environ=None):
 
     parser = create_parser(user_args, environ)
 
-    init_logging()
-
     kwargs = vars(parser.parse_args(args))
     function = kwargs.pop("function")
+
+    # Set log level to INFO, if it isn't lower already
+    root_logger = logging.getLogger()
+    orig_log_level = root_logger.level
+    root_logger.setLevel(min(orig_log_level, logging.INFO))
 
     try:
         function(**kwargs)
     except CommandError as e:
         print(str(e), file=sys.stderr)
         sys.exit(1)
+    finally:
+        root_logger.setLevel(orig_log_level)
 
 
 def create_parser(user_args, environ):

--- a/ehrql/utils/log_utils.py
+++ b/ehrql/utils/log_utils.py
@@ -49,13 +49,11 @@ def init_logging():
             },
             "root": {
                 "handlers": ["console"],
-                "level": os.getenv("LOG_LEVEL", "INFO"),
+                "level": os.getenv("LOG_LEVEL", "CRITICAL"),
             },
             "loggers": {
                 "sqlalchemy.engine": {
-                    "handlers": ["console"],
                     "level": "INFO" if os.getenv("LOG_SQL") else "WARN",
-                    "propagate": False,
                 },
             },
         }

--- a/ehrql/utils/log_utils.py
+++ b/ehrql/utils/log_utils.py
@@ -57,11 +57,6 @@ def init_logging():
                     "level": "INFO" if os.getenv("LOG_SQL") else "WARN",
                     "propagate": False,
                 },
-                "pyhive": {
-                    "handlers": ["console"],
-                    "level": "INFO" if os.getenv("LOG_SQL") else "WARN",
-                    "propagate": False,
-                },
             },
         }
     )


### PR DESCRIPTION
This takes a different approach to configuring logging. We now always configure logging on initialisation, but by default set the root logger level to `CRITICAL` (i.e. basically never log).

While running commands we temporarily set the log level to `INFO` and then restore its previous level when we're done.

This means that setting the `LOG_LEVEL` environment variable always takes effect, regardless of which bit of code you're executing or how you've invoked it.

It also means that we don't accidentally enable verbose logging just because a test has exercised `__main__.main()` (see https://github.com/opensafely-core/ehrql/issues/1304).

Fixes https://github.com/opensafely-core/ehrql/issues/1304