### PR TITLE
Add `just create-tpp-test-db` command

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -147,6 +147,11 @@ build-ehrql-for-os-cli: build-ehrql
 remove-database-containers:
     docker rm --force ehrql-mssql
 
+# Create an MSSQL docker container with the TPP database schema and print
+# connection strings
+create-tpp-test-db: devenv
+    $BIN/python -m pytest -o python_functions=create tests/lib/create_tpp_test_db.py
+
 # open an interactive SQL Server shell running against MSSQL
 connect-to-mssql:
     docker exec -it ehrql-mssql /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P 'Your_password123!'

--- a/tests/lib/create_tpp_test_db.py
+++ b/tests/lib/create_tpp_test_db.py
@@ -1,0 +1,31 @@
+"""
+Run this using:
+
+    pytest -o python_functions=create tests/lib/create_tpp_test_db.py
+
+It will start an MSSQL Docker container, create all the tables in the TPP schema, and
+output the connection string needed to talk to this database.
+"""
+from .tpp_schema import Base  # pragma: no cover
+
+
+# This is not a test, but we can get pytest to run it as a test so we can re-use all the
+# fixture machinery. Because neither this file not this function are named appropriately
+# they avoid being discovered and executed during the normal test run. But we can run it
+# by passing the path and function name directly to pytest
+def create(request, mssql_database_with_session_scope):  # pragma: no cover
+    db = mssql_database_with_session_scope
+    db.setup(metadata=Base.metadata)
+    capturemanager = request.config.pluginmanager.getplugin("capturemanager")
+    with capturemanager.global_and_fixture_disabled():
+        print("\n\n=> Created TPP tables in test database")
+        print()
+        print("DSN for ehrQL:")
+        print(f"  DATABASE_URL='{db.host_url()}'")
+        print()
+        print("Connection string for VSCode MSSQL Extension:")
+        print(
+            f"  Server={db.host_from_host},{db.port_from_host};Database={db.db_name};"
+            f"User Id={db.username};Password={db.password};"
+        )
+        print()


### PR DESCRIPTION
This makes sure the MSSQL docker container is started, creates all the tables in the TPP schema and then prints the database connection strings both for ehrQL and for the VSCode MSSQL extension.

This makes it easier to experiment interactively with SQL queries, and to run ehrql against a real (albeit empty) database.

This works by abusing the pytest machinery in a way that is both terrible and slightly pleasing.

Example output:
```console
$ just create-tpp-test-db
/home/dave/.local/bin/just _compile pyproject.toml requirements.prod.txt
/home/dave/.local/bin/just _compile requirements.dev.in requirements.dev.txt
$BIN/python -m pytest tests/lib/create_tpp_test_db.py
============================ test session starts ============================
platform linux -- Python 3.11.4, pytest-7.4.0, pluggy-1.0.0
rootdir: /home/dave/projects/ebmdatalab/ehrql
configfile: pyproject.toml
plugins: icdiff-0.6, env-0.8.2, cov-4.1.0, xdist-3.3.1, hypothesis-6.82.4, mock-3.11.1
collected 1 item

tests/lib/create_tpp_test_db.py

=> Created TPP tables in test database

DSN for ehrQL:
  DATABASE_URL='mssql://sa:Your_password123!@localhost:49154/test'

Connection string for VSCode MSSQL Extension:
  Server=localhost,49154;Database=test;User Id=sa;Password=Your_password123!;
```