### PR TITLE
Actually label the GitHub-built ehrQL Docker image

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -87,6 +87,11 @@ jobs:
         run: |
           /bin/false
 
+      - name: Install just
+        uses: opensafely-core/setup-action@v1
+        with:
+          install-just: true
+
       # This relies on the tag having a version of the form vX.Y.Z
       - name: Build image
         if: ${{ startsWith(steps.taggedcommit.outputs.tag, 'y') }}

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -101,8 +101,7 @@ jobs:
 
           echo "$PATCH" > ehrql/VERSION
 
-          DOCKER_BUILDKIT=1 docker build . --file Dockerfile \
-            --target ehrql \
+          just build-ehrql "ehrql" \
             --tag ${{ env.image }}:$MAJOR \
             --tag ${{ env.image }}:$MINOR \
             --tag ${{ env.image }}:$PATCH \

--- a/Justfile
+++ b/Justfile
@@ -125,7 +125,7 @@ fix: devenv
 
 
 # build the ehrql docker image
-build-ehrql:
+build-ehrql image_name="ehrql-dev" *args="":
     #!/usr/bin/env bash
     set -euo pipefail
 
@@ -133,7 +133,7 @@ build-ehrql:
     export GITREF=$(git rev-parse --short HEAD)
 
     [[ -v CI ]] && echo "::group::Build ehrql (click to view)" || echo "Build ehrql"
-    DOCKER_BUILDKIT=1 docker build --build-arg BUILD_DATE="$BUILD_DATE" --build-arg GITREF="$GITREF" . -t ehrql-dev
+    DOCKER_BUILDKIT=1 docker build --file Dockerfile --build-arg BUILD_DATE="$BUILD_DATE" --build-arg GITREF="$GITREF" --tag {{ image_name }} {{ args }}
     [[ -v CI ]] && echo "::endgroup::" || echo ""
 
 

--- a/Justfile
+++ b/Justfile
@@ -132,8 +132,8 @@ build-ehrql image_name="ehrql-dev" *args="":
     export BUILD_DATE=$(date -u +'%y-%m-%dT%H:%M:%SZ')
     export GITREF=$(git rev-parse --short HEAD)
 
-    [[ -v CI ]] && echo "::group::Build ehrql (click to view)" || echo "Build ehrql"
-    DOCKER_BUILDKIT=1 docker build --file Dockerfile --build-arg BUILD_DATE="$BUILD_DATE" --build-arg GITREF="$GITREF" --tag {{ image_name }} {{ args }}
+    [[ -v CI ]] && echo "::group::Build ehrql Docker image (click to view)" || echo "Build ehrql Docker image"
+    DOCKER_BUILDKIT=1 docker build . --build-arg BUILD_DATE="$BUILD_DATE" --build-arg GITREF="$GITREF" --tag {{ image_name }} {{ args }}
     [[ -v CI ]] && echo "::endgroup::" || echo ""
 
 


### PR DESCRIPTION
Fixes #1484.

This also reuses the Justfile recipe to build the Docker image. This is better than including similar commands in the GitHub Actions workflow.