### PR TITLE
Log MSSQL queries along with timing and IO stats

### DIFF
--- a/ehrql/query_engines/mssql.py
+++ b/ehrql/query_engines/mssql.py
@@ -6,6 +6,7 @@ from sqlalchemy.sql.functions import Function as SQLFunction
 
 from ehrql.query_engines.base_sql import BaseSQLQueryEngine, apply_patient_joins
 from ehrql.query_engines.mssql_dialect import MSSQLDialect, SelectStarInto
+from ehrql.utils.mssql_log_utils import execute_with_log
 from ehrql.utils.sqlalchemy_exec_utils import (
     ReconnectableConnection,
     execute_with_retry_factory,
@@ -205,7 +206,7 @@ class MSSQLQueryEngine(BaseSQLQueryEngine):
         with ReconnectableConnection(autocommit_engine) as connection:
             for i, setup_query in enumerate(setup_queries, start=1):
                 log.info(f"Running setup query {i:03} / {len(setup_queries):03}")
-                connection.execute(setup_query)
+                execute_with_log(connection, setup_query, log.info)
 
             # Re-establishing the database connection after an error allows us to
             # recover from a wider range of failure modes. But we can only do this if
@@ -236,7 +237,7 @@ class MSSQLQueryEngine(BaseSQLQueryEngine):
 
             for i, cleanup_query in enumerate(cleanup_queries, start=1):
                 log.info(f"Running cleanup query {i:03} / {len(cleanup_queries):03}")
-                connection.execute(cleanup_query)
+                execute_with_log(connection, cleanup_query, log.info)
 
     # implement the "table value constructor trick"
     # https://stackoverflow.com/questions/71022/sql-max-of-multiple-columns/6871572#6871572

--- a/ehrql/query_engines/mssql.py
+++ b/ehrql/query_engines/mssql.py
@@ -205,8 +205,9 @@ class MSSQLQueryEngine(BaseSQLQueryEngine):
 
         with ReconnectableConnection(autocommit_engine) as connection:
             for i, setup_query in enumerate(setup_queries, start=1):
-                log.info(f"Running setup query {i:03} / {len(setup_queries):03}")
-                execute_with_log(connection, setup_query, log.info)
+                query_id = f"setup query {i:03} / {len(setup_queries):03}"
+                log.info(f"Running {query_id}")
+                execute_with_log(connection, setup_query, log.info, query_id=query_id)
 
             # Re-establishing the database connection after an error allows us to
             # recover from a wider range of failure modes. But we can only do this if
@@ -236,8 +237,9 @@ class MSSQLQueryEngine(BaseSQLQueryEngine):
             )
 
             for i, cleanup_query in enumerate(cleanup_queries, start=1):
-                log.info(f"Running cleanup query {i:03} / {len(cleanup_queries):03}")
-                execute_with_log(connection, cleanup_query, log.info)
+                query_id = f"cleanup query {i:03} / {len(cleanup_queries):03}"
+                log.info(f"Running {query_id}")
+                execute_with_log(connection, cleanup_query, log.info, query_id=query_id)
 
     # implement the "table value constructor trick"
     # https://stackoverflow.com/questions/71022/sql-max-of-multiple-columns/6871572#6871572

--- a/ehrql/utils/log_utils.py
+++ b/ehrql/utils/log_utils.py
@@ -14,7 +14,6 @@ structlog.configure(
     processors=[
         structlog.stdlib.filter_by_level,
         structlog.processors.TimeStamper(fmt="%Y-%m-%d %H:%M:%S"),
-        structlog.stdlib.add_logger_name,
         structlog.stdlib.add_log_level,
         structlog.stdlib.PositionalArgumentsFormatter(),
         structlog.processors.StackInfoRenderer(),
@@ -36,7 +35,9 @@ def init_logging():
             "formatters": {
                 "formatter": {
                     "()": structlog.stdlib.ProcessorFormatter,
-                    "processor": structlog.dev.ConsoleRenderer(),
+                    "processor": structlog.dev.ConsoleRenderer(
+                        pad_event=0, sort_keys=False
+                    ),
                     "foreign_pre_chain": pre_chain,
                 }
             },

--- a/ehrql/utils/mssql_log_utils.py
+++ b/ehrql/utils/mssql_log_utils.py
@@ -11,7 +11,7 @@ import sqlalchemy
 LOG_INDENT = " " * 32
 
 
-def execute_with_log(connection, query, log):
+def execute_with_log(connection, query, log, query_id=None):
     """
     Execute `query` with `connection` while logging SQL, timing and IO information
 
@@ -41,6 +41,10 @@ def execute_with_log(connection, query, log):
 
     if table_io:
         log(indent(format_table_io(table_io)))
+
+    # For easier greppability we optionally append a query to ID to the timings line
+    if query_id is not None:
+        timings["query_id"] = query_id
     # In order to make the logs visually parseable rather than just a wall of text we
     # want some visual space between logs for each query. The simplest way to achieve
     # this is to append some newlines to the last thing we log here.

--- a/ehrql/utils/mssql_log_utils.py
+++ b/ehrql/utils/mssql_log_utils.py
@@ -1,0 +1,150 @@
+import re
+import textwrap
+import time
+from collections import defaultdict
+
+import sqlalchemy
+
+
+# It's not great that our logging utilities need to know about how the logs get
+# formatted, but this makes a big difference to the readability of the logs.
+LOG_INDENT = " " * 32
+
+
+def execute_with_log(connection, query, log):
+    """
+    Execute `query` with `connection` while logging SQL, timing and IO information
+
+    Note this can only be used with queries which don't need to return results.
+    """
+    # Compile the SQL so we can log it
+    sql_string = str(query.compile(dialect=connection.engine.dialect)).strip()
+    log(indent(f"SQL:\n{sql_string}"))
+
+    # https://pymssql.readthedocs.io/en/stable/ref/_mssql.html#_mssql.MSSQLConnection.set_msghandler
+    messages = []
+    connection.connection._conn.set_msghandler(lambda *args: messages.append(args[-1]))
+    connection.execute(sqlalchemy.text("SET STATISTICS TIME ON"))
+    connection.execute(sqlalchemy.text("SET STATISTICS IO ON"))
+    start = time.monotonic()
+
+    # Actually run the query
+    connection.execute(query)
+
+    duration = time.monotonic() - start
+    connection.execute(sqlalchemy.text("SET STATISTICS IO OFF"))
+    connection.execute(sqlalchemy.text("SET STATISTICS TIME OFF"))
+    # There's no documented way of removing the handler, but I've checked the pymssql
+    # code and this is the way to do it
+    connection.connection._conn.set_msghandler(None)
+    timings, table_io = parse_statistics_messages(messages)
+
+    if table_io:
+        log(indent(format_table_io(table_io)))
+    # In order to make the logs visually parseable rather than just a wall of text we
+    # want some visual space between logs for each query. The simplest way to achieve
+    # this is to append some newlines to the last thing we log here.
+    append_str_to_last_value(timings, "\n\n")
+    log(f"{int(duration)} seconds:", **timings)
+
+
+SQLSERVER_STATISTICS_REGEX = re.compile(
+    rb"""
+    .* (
+
+    # Regex to match timing statistics messages
+
+    SQL\sServer\s
+      (?P<timing_type>parse\sand\scompile\stime|Execution\sTime)
+    .* CPU\stime\s=\s(?P<cpu_ms>\d+)\sms
+    .* elapsed\stime\s=\s(?P<elapsed_ms>\d+)\sms
+
+    |
+
+    # Regex to match IO statistics messages
+
+    Table\s'(?P<table>[^']+)'. \s+
+    Scan\scount\s (?P<scans>\d+), \s+
+    logical\sreads\s (?P<logical>\d+), \s+
+    physical\sreads\s (?P<physical>\d+), \s+
+    read-ahead\sreads\s (?P<read_ahead>\d+), \s+
+    lob\slogical\sreads\s (?P<lob_logical>\d+), \s+
+    lob\sphysical\sreads\s (?P<lob_physical>\d+), \s+
+    lob\sread-ahead\sreads\s (?P<lob_read_ahead>\d+)
+
+    ) .*
+    """,
+    flags=re.DOTALL | re.VERBOSE,
+)
+
+
+def parse_statistics_messages(messages):
+    """
+    Accepts a list of MSSQL statistics messages and returns a dict of cumulative timing
+    stats and a dict of cumulative table IO stats
+    """
+    timings = {
+        "exec_cpu_ms": 0,
+        "exec_elapsed_ms": 0,
+        "parse_cpu_ms": 0,
+        "parse_elapsed_ms": 0,
+    }
+    table_io = defaultdict(
+        lambda: {
+            "scans": 0,
+            "logical": 0,
+            "physical": 0,
+            "read_ahead": 0,
+            "lob_logical": 0,
+            "lob_physical": 0,
+            "lob_read_ahead": 0,
+        }
+    )
+    timing_types = {b"parse and compile time": "parse", b"Execution Time": "exec"}
+    for message in messages:
+        if match := SQLSERVER_STATISTICS_REGEX.match(message):
+            if timing_type := match["timing_type"]:
+                prefix = timing_types[timing_type]
+                timings[f"{prefix}_cpu_ms"] += int(match["cpu_ms"])
+                timings[f"{prefix}_elapsed_ms"] += int(match["elapsed_ms"])
+            elif table := match["table"]:
+                table = table.decode(errors="ignore")
+                # Temporary table names are, internally to MSSQL, made globally unique
+                # by padding with underscores and appending a unique suffix. We need to
+                # restore the original name so our stats make sense. If you've got an
+                # actual temp table name with 5 underscores in it you deserve everything
+                # you get.
+                if table.startswith("#"):
+                    table = table.partition("_____")[0]
+                stats = table_io[table]
+                for key in stats.keys():
+                    stats[key] += int(match[key])
+            else:
+                # Given the structure of the regex it shouldn't be possible to get here,
+                # but if somehow we did I'd rather drop the stats message than blow up
+                pass  # pragma: no cover
+    return timings, table_io
+
+
+def format_table_io(table_io):
+    headers = list(table_io.values())[0].keys()
+    output = [[*headers, "table"]]
+    for table_name, stats in table_io.items():
+        row = [str(stats[header]).ljust(len(header)) for header in headers]
+        row.append(table_name)
+        output.append(row)
+    return "\n".join(" ".join(row) for row in output)
+
+
+def indent(s, prefix=LOG_INDENT):
+    """
+    Indent subsequent lines so they align correctly given the length of the log line
+    prefix
+    """
+    first_line, sep, rest = s.partition("\n")
+    return first_line + sep + textwrap.indent(rest, prefix)
+
+
+def append_str_to_last_value(dictionary, suffix):
+    last_key, last_value = list(dictionary.items())[-1]
+    dictionary[last_key] = f"{last_value}{suffix}"

--- a/ehrql/utils/mssql_log_utils.py
+++ b/ehrql/utils/mssql_log_utils.py
@@ -90,6 +90,7 @@ def parse_statistics_messages(messages):
     timings = {
         "exec_cpu_ms": 0,
         "exec_elapsed_ms": 0,
+        "exec_cpu_ratio": 0.0,
         "parse_cpu_ms": 0,
         "parse_elapsed_ms": 0,
     }
@@ -127,6 +128,10 @@ def parse_statistics_messages(messages):
                 # Given the structure of the regex it shouldn't be possible to get here,
                 # but if somehow we did I'd rather drop the stats message than blow up
                 pass  # pragma: no cover
+    if timings["exec_elapsed_ms"] != 0:
+        timings["exec_cpu_ratio"] = round(
+            timings["exec_cpu_ms"] / timings["exec_elapsed_ms"], 2
+        )
     return timings, table_io
 
 

--- a/ehrql/utils/sqlalchemy_exec_utils.py
+++ b/ehrql/utils/sqlalchemy_exec_utils.py
@@ -126,3 +126,10 @@ class ReconnectableConnection:
         self._connection.detach()
         self._connection.close()
         self._connection = None
+
+    # SQLAlchemy Connection objects have a `.connection` attribute which provides access
+    # to the underlying DB-API connection so we provide the same here. See:
+    # https://docs.sqlalchemy.org/en/20/core/connections.html#sqlalchemy.engine.Connection.connection
+    @property
+    def connection(self):
+        return self._get_connection().connection

--- a/tests/integration/utils/test_mssql_log_utils.py
+++ b/tests/integration/utils/test_mssql_log_utils.py
@@ -1,0 +1,91 @@
+import re
+
+import sqlalchemy
+from sqlalchemy.orm import DeclarativeBase, mapped_column
+
+from ehrql.query_engines.mssql_dialect import SelectStarInto
+from ehrql.utils.mssql_log_utils import execute_with_log
+
+
+class Base(DeclarativeBase):
+    ...
+
+
+class TableA(Base):
+    __tablename__ = "table_a"
+    pk = mapped_column(sqlalchemy.Integer, primary_key=True)
+
+
+class TableB(Base):
+    __tablename__ = "table_b"
+    pk = mapped_column(sqlalchemy.Integer, primary_key=True)
+
+
+def test_execute_with_log(mssql_database):
+    log_lines = []
+
+    # Simulate approximately how structlog will format our logs
+    def log(event, **kwargs):
+        attrs = " ".join(f"{k}={v}" for k, v in kwargs.items())
+        log_lines.append(
+            f"2023-01-01 10:00:00 [info     ] {event}{' ' if attrs else ''}{attrs}"
+        )
+
+    mssql_database.setup(
+        TableA(pk=1),
+        TableA(pk=6),
+        TableB(pk=3),
+        TableB(pk=8),
+    )
+
+    select_a = sqlalchemy.select(TableA.pk).where(TableA.pk < 5)
+    select_b = sqlalchemy.select(TableB.pk).where(TableB.pk < 5)
+    select_all = select_a.union_all(select_b)
+
+    # `execute_with_log` can't return results so to check it's done the right thing we
+    # need to write the results to a temporary table and read them from there
+    tmp_table = sqlalchemy.Table(
+        "#tmp_table", sqlalchemy.MetaData(), sqlalchemy.Column("pk", sqlalchemy.Integer)
+    )
+    query = SelectStarInto(tmp_table, select_all.alias())
+
+    with mssql_database.engine().connect() as connection:
+        # Execute a query that does no IO to check we handle that correctly
+        execute_with_log(connection, sqlalchemy.text("SELECT 1"), log)
+        # Execute the main query
+        execute_with_log(connection, query, log)
+        # Retrive results from temporary table
+        response = connection.execute(sqlalchemy.select(tmp_table.c.pk))
+        results = list(response)
+
+    assert results == [(1,), (3,)]
+
+    assert log_lines[0] == (
+        "2023-01-01 10:00:00 [info     ] SQL:\n"
+        "                                SELECT 1"
+    )
+
+    assert log_lines[1] == (
+        "2023-01-01 10:00:00 [info     ] 0 seconds: exec_cpu_ms=0 exec_elapsed_ms=0 parse_cpu_ms=0 parse_elapsed_ms=0\n"
+        "\n"
+    )
+
+    assert log_lines[2] == (
+        "2023-01-01 10:00:00 [info     ] SQL:\n"
+        "                                SELECT * INTO [#tmp_table] FROM (SELECT table_a.pk AS pk \n"
+        "                                FROM table_a \n"
+        "                                WHERE table_a.pk < %(pk_1)s UNION ALL SELECT table_b.pk AS pk \n"
+        "                                FROM table_b \n"
+        "                                WHERE table_b.pk < %(pk_2)s) AS anon_1"
+    )
+
+    assert log_lines[3] == (
+        "2023-01-01 10:00:00 [info     ] scans logical physical read_ahead lob_logical lob_physical lob_read_ahead table\n"
+        "                                1     2       0        0          0           0            0              table_b\n"
+        "                                1     2       0        0          0           0            0              table_a"
+    )
+
+    assert re.search(
+        r"\d+ seconds: exec_cpu_ms=\d+ exec_elapsed_ms=\d+ parse_cpu_ms=\d+ parse_elapsed_ms=\d+",
+        log_lines[4],
+    )

--- a/tests/integration/utils/test_mssql_log_utils.py
+++ b/tests/integration/utils/test_mssql_log_utils.py
@@ -53,7 +53,7 @@ def test_execute_with_log(mssql_database):
         # Execute a query that does no IO to check we handle that correctly
         execute_with_log(connection, sqlalchemy.text("SELECT 1"), log)
         # Execute the main query
-        execute_with_log(connection, query, log)
+        execute_with_log(connection, query, log, query_id="test_query")
         # Retrive results from temporary table
         response = connection.execute(sqlalchemy.select(tmp_table.c.pk))
         results = list(response)
@@ -86,6 +86,6 @@ def test_execute_with_log(mssql_database):
     )
 
     assert re.search(
-        r"\d+ seconds: exec_cpu_ms=\d+ exec_elapsed_ms=\d+ parse_cpu_ms=\d+ parse_elapsed_ms=\d+",
+        r"\d+ seconds: exec_cpu_ms=\d+ exec_elapsed_ms=\d+ parse_cpu_ms=\d+ parse_elapsed_ms=\d+ query_id=test_query",
         log_lines[4],
     )

--- a/tests/integration/utils/test_mssql_log_utils.py
+++ b/tests/integration/utils/test_mssql_log_utils.py
@@ -66,7 +66,7 @@ def test_execute_with_log(mssql_database):
     )
 
     assert log_lines[1] == (
-        "2023-01-01 10:00:00 [info     ] 0 seconds: exec_cpu_ms=0 exec_elapsed_ms=0 parse_cpu_ms=0 parse_elapsed_ms=0\n"
+        "2023-01-01 10:00:00 [info     ] 0 seconds: exec_cpu_ms=0 exec_elapsed_ms=0 exec_cpu_ratio=0.0 parse_cpu_ms=0 parse_elapsed_ms=0\n"
         "\n"
     )
 
@@ -86,6 +86,6 @@ def test_execute_with_log(mssql_database):
     )
 
     assert re.search(
-        r"\d+ seconds: exec_cpu_ms=\d+ exec_elapsed_ms=\d+ parse_cpu_ms=\d+ parse_elapsed_ms=\d+ query_id=test_query",
+        r"\d+ seconds: exec_cpu_ms=\d+ exec_elapsed_ms=\d+ exec_cpu_ratio=[\d\.]+ parse_cpu_ms=\d+ parse_elapsed_ms=\d+ query_id=test_query",
         log_lines[4],
     )

--- a/tests/unit/utils/test_mssql_log_utils.py
+++ b/tests/unit/utils/test_mssql_log_utils.py
@@ -1,0 +1,155 @@
+from ehrql.utils.mssql_log_utils import (
+    append_str_to_last_value,
+    format_table_io,
+    indent,
+    parse_statistics_messages,
+)
+
+
+def test_parse_statistics_messages():
+    messages = [
+        b"This message will not be parseable and should be ignored",
+        (
+            b"SQL Server parse and compile time: \n"
+            b"   CPU time = 10 ms, elapsed time = 5 ms."
+        ),
+        (
+            b"\n SQL Server Execution Times:\n"
+            b"   CPU time = 100 ms,  elapsed time = 200 ms."
+        ),
+        (
+            b"SQL Server parse and compile time: \n"
+            b"   CPU time = 50 ms, elapsed time = 16 ms."
+        ),
+        (
+            b"\n SQL Server Execution Times:\n"
+            b"   CPU time = 123 ms,  elapsed time = 456 ms."
+        ),
+        (
+            b"Table 'Workfile'. Scan count 1, logical reads 2, physical reads 3,"
+            b" read-ahead reads 4, lob logical reads 5, lob physical reads 6,"
+            b" lob read-ahead reads 7."
+        ),
+        (
+            b"Table 'Worktable'. Scan count 0, logical reads 0, physical reads 0,"
+            b" read-ahead reads 0, lob logical reads 0, lob physical reads 0,"
+            b" lob read-ahead reads 0."
+        ),
+        (
+            b"Table '#inline_data_1______________________________________________________________________________________________________00000000149B'."
+            b" Scan count 1, logical reads 7, physical reads 0, read-ahead reads 0,"
+            b" lob logical reads 0, lob physical reads 0, lob read-ahead reads 0."
+        ),
+        (
+            b"Table '#tmp_1______________________________________________________________________________________________________________0000000014D9'."
+            b" Scan count 1, logical reads 4, physical reads 0, read-ahead reads 0,"
+            b" lob logical reads 0, lob physical reads 0, lob read-ahead reads 0."
+        ),
+        (
+            b"Table '#tmp_1______________________________________________________________________________________________________________0000000014B1'."
+            b" Scan count 1, logical reads 0, physical reads 0, read-ahead reads 0,"
+            b" lob logical reads 0, lob physical reads 0, lob read-ahead reads 0."
+        ),
+        (
+            b"Table '#tmp_1______________________________________________________________________________________________________________000000001517'."
+            b" Scan count 1, logical reads 0, physical reads 0, read-ahead reads 0, "
+            b"lob logical reads 0, lob physical reads 0, lob read-ahead reads 0."
+        ),
+    ]
+
+    timings, table_io = parse_statistics_messages(messages)
+
+    assert timings == {
+        "exec_cpu_ms": 223,
+        "exec_elapsed_ms": 656,
+        "parse_cpu_ms": 60,
+        "parse_elapsed_ms": 21,
+    }
+    assert table_io == {
+        "Workfile": {
+            "lob_logical": 5,
+            "lob_physical": 6,
+            "lob_read_ahead": 7,
+            "logical": 2,
+            "physical": 3,
+            "read_ahead": 4,
+            "scans": 1,
+        },
+        "Worktable": {
+            "lob_logical": 0,
+            "lob_physical": 0,
+            "lob_read_ahead": 0,
+            "logical": 0,
+            "physical": 0,
+            "read_ahead": 0,
+            "scans": 0,
+        },
+        "#inline_data_1": {
+            "lob_logical": 0,
+            "lob_physical": 0,
+            "lob_read_ahead": 0,
+            "logical": 7,
+            "physical": 0,
+            "read_ahead": 0,
+            "scans": 1,
+        },
+        "#tmp_1": {
+            "lob_logical": 0,
+            "lob_physical": 0,
+            "lob_read_ahead": 0,
+            "logical": 4,
+            "physical": 0,
+            "read_ahead": 0,
+            "scans": 3,
+        },
+    }
+
+
+def test_format_table_io():
+    table_io = {
+        "Workfile": {
+            "lob_logical": 5,
+            "lob_physical": 6,
+            "lob_read_ahead": 7,
+            "logical": 2,
+            "physical": 3,
+            "read_ahead": 4,
+            "scans": 1,
+        },
+        "Worktable": {
+            "lob_logical": 0,
+            "lob_physical": 0,
+            "lob_read_ahead": 0,
+            "logical": 0,
+            "physical": 0,
+            "read_ahead": 0,
+            "scans": 0,
+        },
+    }
+    output = format_table_io(table_io)
+    assert output == (
+        "lob_logical lob_physical lob_read_ahead logical physical read_ahead scans table\n"
+        "5           6            7              2       3        4          1     Workfile\n"
+        "0           0            0              0       0        0          0     Worktable"
+    )
+
+
+def test_indent():
+    lines = (
+        "Lorem ipsum dolor sit amet, consectetur adipiscing\n"
+        "elit, sed do eiusmod tempor incididunt ut labore et\n"
+        "dolore magna aliqua."
+    )
+    expected = (
+        "Lorem ipsum dolor sit amet, consectetur adipiscing\n"
+        "    elit, sed do eiusmod tempor incididunt ut labore et\n"
+        "    dolore magna aliqua."
+    )
+
+    assert indent(lines, prefix="    ") == expected
+
+
+def test_append_str_to_last_value():
+    d = {"a": "foo", "b": "bar", "c": 123}
+    append_str_to_last_value(d, "\n")
+    assert d == {"a": "foo", "b": "bar", "c": "123\n"}

--- a/tests/unit/utils/test_mssql_log_utils.py
+++ b/tests/unit/utils/test_mssql_log_utils.py
@@ -62,6 +62,7 @@ def test_parse_statistics_messages():
     assert timings == {
         "exec_cpu_ms": 223,
         "exec_elapsed_ms": 656,
+        "exec_cpu_ratio": 0.34,
         "parse_cpu_ms": 60,
         "parse_elapsed_ms": 21,
     }

--- a/tests/unit/utils/test_sqlalchemy_exec_utils.py
+++ b/tests/unit/utils/test_sqlalchemy_exec_utils.py
@@ -136,3 +136,9 @@ def test_reconnectable_connection_explicit_disconnect():
 
     # Exiting the context does not call `close()` either
     assert engine.connect.return_value.close.call_count == 1
+
+
+def test_reconnectable_connection_proxies_connection_attr():
+    engine = mock.Mock(spec=Engine)
+    with ReconnectableConnection(engine) as conn:
+        assert conn.connection is conn._get_connection().connection

--- a/tests/unit/utils/test_sqlalchemy_query_utils.py
+++ b/tests/unit/utils/test_sqlalchemy_query_utils.py
@@ -159,6 +159,26 @@ def test_clause_as_str_with_insert_many():
     )
 
 
+def test_insert_many_compile():
+    table = sqlalchemy.Table(
+        "t",
+        sqlalchemy.MetaData(),
+        sqlalchemy.Column("i", sqlalchemy.Integer()),
+        sqlalchemy.Column("s", sqlalchemy.String()),
+    )
+    statement = InsertMany(
+        table,
+        [
+            (1, "a"),
+            (2, "b"),
+            (3, "c"),
+        ],
+    )
+
+    query_str = statement.compile(dialect=DefaultDialect())
+    assert str(query_str).strip() == "INSERT INTO t (i, s) VALUES (:i, :s)"
+
+
 def test_get_setup_and_cleanup_queries_with_insert_many():
     # Confirm that the InsertMany class acts enough like a SQLAlchemy ClauseElement for
     # our setup/cleanup code to work with it


### PR DESCRIPTION
This logs each setup/cleanup query executed by the MSSQL engine, along with total query time and stats gathered using `SET STATISTICS TIME/IO ON`.

Note that while we log the query we choose not to log the parameters at this stage for a few reasons:
 * there's a risk of leaking patient data into the logs;
 * the parameters can be _very_ verbose;
 * the structure of the query is generally the most interesting thing;
 * the full query is always recoverable afterwards using `dump-dataset-sql` locally.

We can revisit this if necessary later.

I have tried to make the logs as easy as possible to parse visually (for the stressed support person looking for smoking guns) while making sure they're reasonably easy to parse programmatically if we want to gather aggregate timing data or something like that.

Example below (though the timings are all zero because its from an empty local db):

![Screenshot from 2023-08-18 10-57-00](https://github.com/opensafely-core/ehrql/assets/19630/16610165-da23-4df1-8d3e-22c324ce6d63)

Closes #1451 #1444