### PR TITLE
Generative test improvements

### DIFF
--- a/.github/workflows/generative-tests.yml
+++ b/.github/workflows/generative-tests.yml
@@ -18,7 +18,6 @@ jobs:
           python-version: "3.11"
       - run: |
           GENTEST_EXAMPLES=10000 \
-          GENTEST_COMPREHENSIVE=t \
           GENTEST_DEBUG=t \
           GENTEST_CHECK_IGNORED_ERRORS=t \
           just test-generative

--- a/.github/workflows/generative-tests.yml
+++ b/.github/workflows/generative-tests.yml
@@ -18,6 +18,7 @@ jobs:
           python-version: "3.11"
       - run: |
           GENTEST_EXAMPLES=10000 \
+          GENTEST_RANDOMIZE=t \
           GENTEST_MAX_DEPTH=30 \
           GENTEST_DEBUG=t \
           GENTEST_CHECK_IGNORED_ERRORS=t \

--- a/.github/workflows/generative-tests.yml
+++ b/.github/workflows/generative-tests.yml
@@ -18,6 +18,7 @@ jobs:
           python-version: "3.11"
       - run: |
           GENTEST_EXAMPLES=10000 \
+          GENTEST_MAX_DEPTH=30 \
           GENTEST_DEBUG=t \
           GENTEST_CHECK_IGNORED_ERRORS=t \
           just test-generative

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -33,8 +33,7 @@ example `just test-unit`).
 
 ### Running tests
 
-To run all tests, as they're run in CI (with code coverage, and the comprehensive
-check for [generative tests](#generative-tests)):
+To run all tests, as they're run in CI with code coverage):
 ```
 just test-all
 ```
@@ -94,17 +93,6 @@ When debugging a failure you'll probably want to reproduce it.
  * The output from the failing test includes the examples in a form where they can be copy-pasted into the test code as arguments to a `@hyp.example()` decorator for the test.
    (You'll need to add some imports to get it to run.) This allows you to get the failure case running in a debugger
    (and also to get the example nicely formatted to help understand it).
-
-Since the variable generation strategies are quite complex, it's hard to convince yourself that they give good coverage of the query space.
-To help with this there is an optional assertion that the generative tests have included every query model operation at least once.
-To enable this assertion set `GENTEST_COMPREHENSIVE=t`, like this:
-
-```
-GENTEST_COMPREHENSIVE=t GENTEST_EXAMPLES=200 just test-generative
-```
-
-Note that you need approximately 200 examples to have any chance of this passing.
-`just test-all` runs with these parameters (unless passed a different value for `GENTEST_EXAMPLES`).
 
 Hypothesis can generate query graphs that are very deeply nested; after 100 draws in a test example, hypothesis will return the example as invalid.  In order to avoid this, the
 variable strategies check for a maximum depth and return a terminal node if the maximum depth is exceeded (A `SelectColumn` node for a series strategy, and a `SelectTable` or `SelectPatientTable` for a table strategy). The max depth defaults to 30 and can be overridden with environment variable `GENTEST_MAX_DEPTH`.

--- a/Justfile
+++ b/Justfile
@@ -204,7 +204,7 @@ test-generative *ARGS: devenv
 
     examples=${GENTEST_EXAMPLES:-200}
     [[ -v CI ]] && echo "::group::Run tests (click to view)" || echo "Run tests"
-    GENTEST_EXAMPLES=$examples GENTEST_COMPREHENSIVE=t $BIN/python -m pytest \
+    GENTEST_EXAMPLES=$examples $BIN/python -m pytest \
         --cov=ehrql \
         --cov=tests \
         --cov-report=html \

--- a/Justfile
+++ b/Justfile
@@ -197,6 +197,7 @@ test-unit *ARGS: devenv
 # Set GENTEST_MAX_DEPTH to change the depth of generated query trees.
 test-generative *ARGS: devenv
     GENTEST_EXAMPLES=${GENTEST_EXAMPLES:-200} \
+    GENTEST_RANDOMIZE=${GENTEST_RANDOMIZE:t} \
       $BIN/python -m pytest tests/generative {{ ARGS }}
 
 # Run by CI. Run all tests, checking code coverage. Optional args are passed to pytest.
@@ -212,7 +213,6 @@ test-generative *ARGS: devenv
         --cov=tests \
         --cov-report=html \
         --cov-report=term-missing:skip-covered \
-        --hypothesis-seed=1234 \
         {{ ARGS }}
     $BIN/python -m pytest --doctest-modules ehrql
     [[ -v CI ]]  && echo "::endgroup::" || echo ""

--- a/Justfile
+++ b/Justfile
@@ -193,6 +193,7 @@ test-unit *ARGS: devenv
 #
 # Set GENTEST_DEBUG env var to see stats.
 # Set GENTEST_EXAMPLES to change the number of examples generated.
+# Set GENTEST_MAX_DEPTH to change the depth of generated query trees.
 test-generative *ARGS: devenv
     $BIN/python -m pytest tests/generative {{ ARGS }}
 

--- a/Justfile
+++ b/Justfile
@@ -189,13 +189,15 @@ test-unit *ARGS: devenv
     $BIN/python -m pytest tests/unit {{ ARGS }}
     $BIN/python -m pytest --doctest-modules ehrql
 
-# Run the generative tests only. Optional args are passed to pytest.
+# Run the generative tests only, configured to use more than the tiny default
+# number of examples. Optional args are passed to pytest.
 #
 # Set GENTEST_DEBUG env var to see stats.
 # Set GENTEST_EXAMPLES to change the number of examples generated.
 # Set GENTEST_MAX_DEPTH to change the depth of generated query trees.
 test-generative *ARGS: devenv
-    $BIN/python -m pytest tests/generative {{ ARGS }}
+    GENTEST_EXAMPLES=${GENTEST_EXAMPLES:-200} \
+      $BIN/python -m pytest tests/generative {{ ARGS }}
 
 # Run by CI. Run all tests, checking code coverage. Optional args are passed to pytest.
 # (The `@` prefix means that the script is echoed first for debugging purposes.)
@@ -203,9 +205,9 @@ test-generative *ARGS: devenv
     #!/usr/bin/env bash
     set -euo pipefail
 
-    examples=${GENTEST_EXAMPLES:-200}
     [[ -v CI ]] && echo "::group::Run tests (click to view)" || echo "Run tests"
-    GENTEST_EXAMPLES=$examples $BIN/python -m pytest \
+    GENTEST_EXAMPLES=${GENTEST_EXAMPLES:-100} \
+      $BIN/python -m pytest \
         --cov=ehrql \
         --cov=tests \
         --cov-report=html \

--- a/tests/generative/recording.py
+++ b/tests/generative/recording.py
@@ -6,8 +6,6 @@ import pytest
 
 from ehrql.query_model.nodes import count_nodes, node_types
 
-from . import variable_strategies
-
 
 class Recorder:
     _inputs = set()
@@ -53,19 +51,11 @@ def recorder(request):  # pragma: no cover
 
     yield recorder_
 
-    if "GENTEST_COMPREHENSIVE" in os.environ:
-        check_comprehensive(recorder_)
-
     if "GENTEST_DEBUG" in os.environ:
         with output_enabled(request):
             show_input_summary(recorder_)
 
     check_not_too_many_ignored_errors(recorder_)
-
-
-def check_comprehensive(recorder):  # pragma: no cover
-    operations_seen = {o for v in recorder.variables for o in node_types(v)}
-    variable_strategies.assert_includes_all_operations(operations_seen)
 
 
 def check_not_too_many_ignored_errors(recorder):

--- a/tests/generative/test_data_setup.py
+++ b/tests/generative/test_data_setup.py
@@ -20,7 +20,7 @@ def test_data_strategy_examples_round_trip(example):
     hyp.assume(len(example) > 0)
     # `pretty` is the formatter Hypothesis uses for examples
     example_repr = pretty(example)
-    # Evaluate it in the context of the `text_query_model` module, which is where
+    # Evaluate it in the context of the `test_query_model` module, which is where
     # examples will get pasted
     evaled = eval(example_repr, globals(), vars(test_query_model))
     assert evaled == example

--- a/tests/generative/test_query_model.py
+++ b/tests/generative/test_query_model.py
@@ -10,13 +10,17 @@ import sqlalchemy.exc
 
 from ehrql.dummy_data import DummyDataGenerator
 from ehrql.query_model.nodes import (
+    AggregateByPatient,
     Column,
     Function,
+    Parameter,
     SelectColumn,
     SelectPatientTable,
     TableSchema,
     Value,
+    node_types,
 )
+from tests.lib.query_model_utils import get_all_operations
 
 from ..conftest import QUERY_ENGINE_NAMES, engine_factory
 from . import data_setup, data_strategies, variable_strategies
@@ -88,6 +92,35 @@ def query_engines(request):
         name: engine_factory(request, name, with_session_scope=True)
         for name in QUERY_ENGINE_NAMES
     }
+
+
+# This is "meta test" i.e. a test of our test generating strategy, rather than a test of
+# the system _using_ the test strategy. We want to ensure that we don't add new query
+# model nodes without adding an appropriate strategy for them.
+def test_variable_strategy_is_comprehensive():
+    operations_seen = set()
+
+    # This uses a fixed seed and no example database to make it deterministic
+    @hyp.settings(max_examples=150, database=None, deadline=None)
+    @hyp.seed(123456)
+    @hyp.given(variable=variable_strategy)
+    def record_operations_seen(variable):
+        operations_seen.update(node_types(variable))
+
+    record_operations_seen()
+
+    known_missing_operations = {
+        AggregateByPatient.CombineAsSet,
+        # Parameters don't themselves form part of valid queries: they are placeholders
+        # which must all be replaced with Values before the query can be executed.
+        Parameter,
+    }
+    all_operations = set(get_all_operations())
+    unexpected_missing = all_operations - known_missing_operations - operations_seen
+    unexpected_present = known_missing_operations & operations_seen
+
+    assert not unexpected_missing, f"unseen operations: {unexpected_missing}"
+    assert not unexpected_present, f"unexpectedly seen operations: {unexpected_present}"
 
 
 @hyp.given(variable=variable_strategy, data=data_strategy)

--- a/tests/generative/test_query_model.py
+++ b/tests/generative/test_query_model.py
@@ -74,6 +74,7 @@ data_strategy = data_strategies.data(
 settings = dict(
     max_examples=(int(os.environ.get("GENTEST_EXAMPLES", 10))),
     deadline=None,
+    derandomize=not os.environ.get("GENTEST_RANDOMIZE"),
 )
 
 ENGINE_CONFIG = {

--- a/tests/generative/variable_strategies.py
+++ b/tests/generative/variable_strategies.py
@@ -21,7 +21,7 @@ from ehrql.query_model.nodes import (
 )
 
 
-MAX_DEPTH = int(environ.get("GENTEST_MAX_DEPTH", 30))
+MAX_DEPTH = int(environ.get("GENTEST_MAX_DEPTH", 15))
 
 # This module defines a set of recursive Hypothesis strategies for generating query model graphs.
 #

--- a/tests/generative/variable_strategies.py
+++ b/tests/generative/variable_strategies.py
@@ -11,7 +11,6 @@ from ehrql.query_model.nodes import (
     Function,
     InlinePatientTable,
     IterWrapper,
-    Parameter,
     PickOneRowPerPatient,
     Position,
     SelectColumn,
@@ -20,7 +19,6 @@ from ehrql.query_model.nodes import (
     Sort,
     Value,
 )
-from tests.lib.query_model_utils import get_all_operations
 
 
 MAX_DEPTH = int(environ.get("GENTEST_MAX_DEPTH", 30))
@@ -533,28 +531,6 @@ def variable(patient_tables, event_tables, schema, value_strategies):
         return draw(series(type_, frame))
 
     return valid_variable()
-
-
-known_missing_operations = {
-    AggregateByPatient.CombineAsSet,
-    # Parameters don't themselves form part of valid queries: they are placeholders
-    # which must all be replaced with Values before the query can be executed.
-    Parameter,
-}
-
-
-def assert_includes_all_operations(operations):  # pragma: no cover
-    all_operations = set(get_all_operations())
-
-    unexpected_missing = all_operations - known_missing_operations - operations
-    assert (
-        not unexpected_missing
-    ), f"unseen operations: {[o.__name__ for o in unexpected_missing]}"
-
-    unexpected_present = known_missing_operations & operations
-    assert (
-        not unexpected_present
-    ), f"unexpectedly seen operations: {[o.__name__ for o in unexpected_present]}"
 
 
 def is_one_row_per_patient_frame(frame):

--- a/tests/lib/query_model_utils.py
+++ b/tests/lib/query_model_utils.py
@@ -3,10 +3,6 @@ import dataclasses
 from ehrql.query_model import nodes as query_model
 
 
-# These are only exercised during the long-running generative tests when
-# GENTEST_COMPREHENSIVE is enabled
-
-
 def get_all_operations():  # pragma: no cover
     "Return every operation defined in the query model"
     return [cls for cls in iterate_query_model_namespace() if is_operation(cls)]

--- a/tests/lib/query_model_utils.py
+++ b/tests/lib/query_model_utils.py
@@ -3,12 +3,12 @@ import dataclasses
 from ehrql.query_model import nodes as query_model
 
 
-def get_all_operations():  # pragma: no cover
+def get_all_operations():
     "Return every operation defined in the query model"
     return [cls for cls in iterate_query_model_namespace() if is_operation(cls)]
 
 
-def is_operation(cls):  # pragma: no cover
+def is_operation(cls):
     "Return whether an arbitrary value is a query model operation class"
     # We need to check this first or the `issubclass` check can fail
     if not isinstance(cls, type):
@@ -21,7 +21,7 @@ def is_operation(cls):  # pragma: no cover
     return len(dataclasses.fields(cls)) > 0
 
 
-def iterate_query_model_namespace():  # pragma: no cover
+def iterate_query_model_namespace():
     "Yield every value in the query_model module"
     yield from vars(query_model).values()
     yield from vars(query_model.Function).values()


### PR DESCRIPTION
This PR separates out checking that we can generate examples for every query model operation from actually running tests using those examples. This means that the comprehensiveness check is now fast enough (2 seconds) to run locally by default and, as a bonus, it now shows up as a normal test failure rather than a weird error in the teardown phase.

We also reduce the default maximum depth of the query tree in generated examples as this makes a huge difference to how long test generation takes. The scheduled workflow, where the serious generative testing happens, restores the depth to its original value.

We also make derandomisation the default setting, which gives better parity between CI and local tests, and then explicitly opt in to randomisation in `just generative-tests` and in the scheduled workflow.

(As an aside, I think we might want to look at lowering the max depth value somewhat even in the scheduled tests. The kinds of high-depth examples Hypothesis generates tend not to be very interesting (e.g. massive stacks of nested date operations). What we really want it to do is generate as many different compositions of types of operation as possible; and it may be that a larger number of lower-depth examples would achieve that better.)

Closes #1458