### PR TITLE
docs: Remove construction warnings

### DIFF
--- a/docs/explanation/backend-tables.md
+++ b/docs/explanation/backend-tables.md
@@ -42,9 +42,6 @@ to answer the research question of interest.
 :warning: When using backend-specific tables in a dataset definition,
 your dataset definition will be only compatible with that backend.
 
-:construction: TPP is the most fully developed backend,
-offering several data tables.
-
 :notepad_spiral: Implementation of other backends is still in development.
 But all data in the EMIS OpenSAFELY backend is available via cohort-extractor.
 

--- a/docs/how-to/errors.md
+++ b/docs/how-to/errors.md
@@ -100,10 +100,6 @@ In this example: `you defined a variable '_age'`.
 
 ### Examples currently use the TPP backend
 
-:construction: For consistency throughout the examples,
-and to make it possible to use [backend-specific tables in addition to core tables](../reference/backends.md),
-the example dataset definitions here all use the TPP backend.
-
 ## Python syntax errors
 
 These can occur because Python has its own syntactic rules

--- a/docs/how-to/examples.md
+++ b/docs/how-to/examples.md
@@ -9,13 +9,7 @@ and then jump to a specific example of interest.
 
 ### Examples in this page all use the TPP backend
 
-:construction: For consistency throughout the examples,
-and to make it possible to use [backend-specific tables in addition to core tables](../reference/backends.md),
-the example dataset definitions here all use the TPP backend.
-
 ### Some examples using `codelist_from_csv()`
-
-:construction: This guidance should be improved in future.
 
 :warning: Some examples refer to CSV codelists using the
 `codelist_from_csv` function,
@@ -158,8 +152,6 @@ dataset.sex = patients.sex
 The possible values are "female", "male", "intersex", and "unknown".
 
 ### Finding each patient's ethnicity
-
-:construction: Ethnicity is incompletely coded within primary care. More detail will be added in the future on how to improve ethnicity capture by incorporating data from secondary care.
 
 Ethnicity can be defined using a codelist. There are a lot of individual codes that can used to indicate a patients' fine-grained ethnicity. To make analysis more manageable, ethnicity is therefore commonly grouped into higher level categories. Above, we described how you can [import codelists that have a category column](#some-examples-using-codelist_from_csv). You can use a codelist with a category column to map clinical event codes for ethnicity to higher level categories as in this example:
 

--- a/docs/introduction/getting-help.md
+++ b/docs/introduction/getting-help.md
@@ -1,6 +1,3 @@
-:construction: We're still working on ehrQL and its documentation:
-**hearing what you find tricky to do or understand will help us improve ehrQL**.
-
 If you are confused or stuck, muddled, addled, befuddled or bemused,
 and cannot easily find what you are looking for in this documentation, then:
 

--- a/docs/introduction/guidance-for-existing-cohort-extractor-users.md
+++ b/docs/introduction/guidance-for-existing-cohort-extractor-users.md
@@ -36,8 +36,5 @@ the content here may be less relevant for you.
 
 ## How do I replicate a certain data query pattern from cohort-extractor in ehrQL, or migrate my study definition to a dataset definition?
 
-* :construction: We intend to add examples of certain cohort-extractor patterns
-  and their ehrQL analogues
-  to the ehrQL documentation.
 * For now, consult the [ehrQL examples](../how-to/examples.md) which may cover what you want to do.
 * You can also [ask us for help](getting-help.md).

--- a/docs/introduction/using-this-documentation.md
+++ b/docs/introduction/using-this-documentation.md
@@ -17,8 +17,6 @@ though you may find it useful to skim through to get a feel for how ehrQL works.
 
 We use the following emoji in the ehrQL documentation section to indicate:
 
-* :construction: *sections of the documentation
-  or ehrQL features that still require further work*
 * :computer: *steps that you should carry out on the computer
   that you are using for working with ehrQL*
 * :notepad_spiral: *extra explanatory information*


### PR DESCRIPTION
Anecdotally, we know that construction warnings worry users: "What does 'construction' mean?", "Is everything going to break?" Furthermore, they fall into two categories:

* TODOs ("This will be improved in the future")
* TPP-specific examples

Arguably, we see little benefit from either category. The second is often redundant, as adjacent headings signal that examples are TPP-specific.