### PR TITLE
fix: Increase number of examples used in generative tests comprehensive check

### DIFF
--- a/tests/generative/test_query_model.py
+++ b/tests/generative/test_query_model.py
@@ -102,7 +102,7 @@ def test_variable_strategy_is_comprehensive():
     operations_seen = set()
 
     # This uses a fixed seed and no example database to make it deterministic
-    @hyp.settings(max_examples=150, database=None, deadline=None)
+    @hyp.settings(max_examples=250, database=None, deadline=None)
     @hyp.seed(123456)
     @hyp.given(variable=variable_strategy)
     def record_operations_seen(variable):


### PR DESCRIPTION
The previous number of examples was mostly allowing this comprehensive check to pass, but it was quite close to the minimum needed, so would fail on the occasional local run. Increasing it to 250 adds around 1.5s to the time the tests take to run, but should make the test more robust.