### PR TITLE
docs: Explain each of Diátaxis modes

### DIFF
--- a/docs/explanation/index.md
+++ b/docs/explanation/index.md
@@ -1,0 +1,5 @@
+The [explanation](explanation/index.md) provides theoretical knowledge for studying ehrQL.
+
+* [ehrQL backend tables](explanation/backend-tables.md)
+* [ehrQL output formats](explanation/output-formats.md)
+* [Using ehrQL in OpenSAFELY projects](explanation/using-ehrql-in-opensafely-projects.md)

--- a/docs/how-to/index.md
+++ b/docs/how-to/index.md
@@ -1,0 +1,4 @@
+The [how-to guides](how-to/index.md) provide practical steps for working with ehrQL in your project.
+
+* [Using ehrQL to answer specific questions](how-to/examples.md)
+* [Resolving ehrQL errors](how-to/errors.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -44,10 +44,12 @@ starting with ["Using this documentation"](introduction/using-this-documentation
 The introduction will give you more information about ehrQL
 and this documentation.
 
-Next, work through the tutorial section in order,
-starting with ["Installation and setup"](tutorial/installation-and-setup.md).
+ehrQL's documentation has four main sections:
 
-The tutorial will guide you through:
+1. The [tutorial](tutorial/index.md) provides practical steps for studying ehrQL.
 
-* setting up and running ehrQL on your own computer
-* writing ehrQL queries (known as *dataset definitions*)
+1. The [how-to guides](how-to/index.md) provide practical steps for working with ehrQL in your project.
+
+1. The [reference](reference/index.md) provides theoretical knowledge for working with ehrQL in your project.
+
+1. The [explanation](explanation/index.md) provides theoretical knowledge for studying ehrQL.

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,0 +1,7 @@
+The [reference](reference/index.md) provides theoretical knowledge for working with ehrQL in your project.
+
+* [ehrQL language](reference/language.md)
+* [ehrQL language features](reference/features.md)
+* [ehrQL backends](reference/backends.md)
+* [ehrQL schemas](reference/schemas.md)
+* [ehrQL command line interface](reference/cli.md)

--- a/docs/tutorial/index.md
+++ b/docs/tutorial/index.md
@@ -1,0 +1,5 @@
+The [tutorial](tutorial/index.md) provides practical steps for studying ehrQL.
+
+* [Installation and setup of ehrQL](tutorial/installation-and-setup.md)
+* [Running ehrQL](tutorial/running-ehrql.md)
+* [ehrQL concepts in depth](tutorial/dataset-definition-concepts.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -18,19 +18,23 @@ nav:
     - Guidance for existing cohort-extractor users: introduction/guidance-for-existing-cohort-extractor-users.md
     - Introduction to ehrQL concepts: introduction/introduction-to-concepts.md
   - Tutorial:
+    - Tutorial: tutorial/index.md
     - Installation and setup of ehrQL: tutorial/installation-and-setup.md
     - Running ehrQL: tutorial/running-ehrql.md
     - ehrQL concepts in depth: tutorial/dataset-definition-concepts.md
   - How-to guides:
+    - How-to guides: how-to/index.md
     - Using ehrQL to answer specific questions: how-to/examples.md
     - Resolving ehrQL errors: how-to/errors.md
   - Reference:
+    - Reference: reference/index.md
     - ehrQL language: reference/language.md
     - ehrQL language features: reference/features.md
     - ehrQL backends: reference/backends.md
     - ehrQL schemas: reference/schemas.md
     - ehrQL command line interface: reference/cli.md
   - Explanation:
+    - Explanation: explanation/index.md
     - ehrQL backend tables: explanation/backend-tables.md
     - ehrQL output formats: explanation/output-formats.md
     - Using ehrQL in OpenSAFELY projects: explanation/using-ehrql-in-opensafely-projects.md


### PR DESCRIPTION
Diátaxis has four modes of documentation. Here, we give each mode its own landing page, which we link to from ehrQL's landing page. In each case, we explain the mode of documentation. We are careful to distinguish "studying" from "working with"; and "practical steps" from "theoretical knowledge".

Notice that the navigation panel has become slightly more user-friendly: clicking "Tutorial" now takes the user to the tutorial's landing page, for example. The landing pages don't, at present, do more than mirror the navigation panel. This is intentional and will change in time.

We don't touch the introduction. Again, this is intentional.