### PR TITLE
Rework ehrQL's landing page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -6,21 +6,21 @@ and execute them with the command line interface to generate **one row per patie
 ehrQL allows researchers to access data sources from primary and secondary care,
 as well as from organisations such as the Office for National Statistics (ONS).
 
-!!! info
+## ehrQL replaces cohort-extractor
 
-    ehrQL is a replacement for OpenSAFELY's cohort-extractor.
+ehrQL is a replacement for OpenSAFELY's cohort-extractor.
 
-    cohort-extractor will continue to work
-    and be supported for OpenSAFELY projects
-    created before June 2023.
+cohort-extractor will continue to work
+and be supported for OpenSAFELY projects
+created before June 2023.
 
-    However, *new* projects should use ehrQL to query data available in OpenSAFELY.
-    Please [get in touch with us before you start using ehrQL](introduction/getting-help.md)
-    and we can help you get started.
+However, *new* projects should use ehrQL to query data available in OpenSAFELY.
+Please [get in touch with us before you start using ehrQL](introduction/getting-help.md)
+and we can help you get started.
 
-    For more details,
-    read our [explanation on what this change means](introduction/guidance-for-existing-cohort-extractor-users.md)
-    for existing cohort-extractor users.
+For more details,
+read our [explanation on what this change means](introduction/guidance-for-existing-cohort-extractor-users.md)
+for existing cohort-extractor users.
 
 ## How to start learning ehrQL
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,7 @@ and execute them with the command line interface to generate **one row per patie
 ehrQL allows researchers to access data sources from primary and secondary care,
 as well as from organisations such as the Office for National Statistics (ONS).
 
-## How to start learning ehrQL
+## ehrQL's documentation
 
 We suggest that you first read through the introduction section in order,
 starting with ["Using this documentation"](introduction/using-this-documentation.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,22 +6,6 @@ and execute them with the command line interface to generate **one row per patie
 ehrQL allows researchers to access data sources from primary and secondary care,
 as well as from organisations such as the Office for National Statistics (ONS).
 
-## ehrQL replaces cohort-extractor
-
-ehrQL is a replacement for OpenSAFELY's cohort-extractor.
-
-cohort-extractor will continue to work
-and be supported for OpenSAFELY projects
-created before June 2023.
-
-However, *new* projects should use ehrQL to query data available in OpenSAFELY.
-Please [get in touch with us before you start using ehrQL](introduction/getting-help.md)
-and we can help you get started.
-
-For more details,
-read our [explanation on what this change means](introduction/guidance-for-existing-cohort-extractor-users.md)
-for existing cohort-extractor users.
-
 ## How to start learning ehrQL
 
 We suggest that you first read through the introduction section in order,
@@ -39,3 +23,19 @@ ehrQL's documentation has four main sections:
 1. The [reference](reference/index.md) provides theoretical knowledge for working with ehrQL in your project.
 
 1. The [explanation](explanation/index.md) provides theoretical knowledge for studying ehrQL.
+
+## ehrQL replaces cohort-extractor
+
+ehrQL is a replacement for OpenSAFELY's cohort-extractor.
+
+cohort-extractor will continue to work
+and be supported for OpenSAFELY projects
+created before June 2023.
+
+However, *new* projects should use ehrQL to query data available in OpenSAFELY.
+Please [get in touch with us before you start using ehrQL](introduction/getting-help.md)
+and we can help you get started.
+
+For more details,
+read our [explanation on what this change means](introduction/guidance-for-existing-cohort-extractor-users.md)
+for existing cohort-extractor users.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,11 +1,10 @@
-* ehrQL is a query language for electronic health record (EHR) data.
-* You run ehrQL in OpenSAFELY to query data.
-* The result of an ehrQL query is an output file with one row per patient
-  and one column per feature of interest.
-* Columns might be features such as:
-    * age
-    * BMI
-    * number of prescriptions of a particular drug
+*ehrQL* (*err-kul*), the **Electronic Health Records Query Language**,
+is a programming language and command line interface designed for the specific application domain of EHR data.
+Researchers create **dataset definitions** with the programming language
+and execute them with the command line interface to generate **one row per patient datasets**.
+
+ehrQL allows researchers to access data sources from primary and secondary care,
+as well as from organisations such as the Office for National Statistics (ONS).
 
 !!! info
 
@@ -22,19 +21,6 @@
     For more details,
     read our [explanation on what this change means](introduction/guidance-for-existing-cohort-extractor-users.md)
     for existing cohort-extractor users.
-
-## ehrQL provides access to several data sources
-
-Data sources that you can query include:
-
-* Primary care EHR data such as:
-    * patient demographics
-    * medication events
-    * other clinical events
-* Some data from secondary care
-* External data sets such as death data from ONS
-
-:bulb: Refer to the [list of datasets available through OpenSAFELY](https://docs.opensafely.org/data-sources/).
 
 ## How to start learning ehrQL
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,16 +26,9 @@ ehrQL's documentation has four main sections:
 
 ## ehrQL replaces cohort-extractor
 
-ehrQL is a replacement for OpenSAFELY's cohort-extractor.
-
-cohort-extractor will continue to work
-and be supported for OpenSAFELY projects
-created before June 2023.
-
-However, *new* projects should use ehrQL to query data available in OpenSAFELY.
+Whilst cohort-extractor will be supported for projects created before June 2023,
+new projects should use ehrQL.
 Please [get in touch with us before you start using ehrQL](introduction/getting-help.md)
 and we can help you get started.
-
-For more details,
-read our [explanation on what this change means](introduction/guidance-for-existing-cohort-extractor-users.md)
-for existing cohort-extractor users.
+For more information,
+read the [guidance for existing cohort-extractor users](introduction/guidance-for-existing-cohort-extractor-users.md).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,7 +11,7 @@ repo_url: https://github.com/opensafely-core/ehrql
 docs_dir: docs
 
 nav:
-  - ehrQL overview: index.md
+  - ehrQL: index.md
   - Introduction:
     - Using this documentation: introduction/using-this-documentation.md
     - Getting help: introduction/getting-help.md


### PR DESCRIPTION
This reworks ehrQL's landing page (<https://docs.opensafely.org/ehrql/>). We aim to place more emphasis on ehrQL's documentation, and less emphasis on the relationship between ehrQL and cohort-extractor. We avoid single sentence paragraphs; we reuse existing content from GLOSSARY.md.

We're gently edging out the introduction, which is intentional. It will have a place elsewhere.

