### PR TITLE
Disable writing results to temporary database

### DIFF
--- a/ehrql/query_engines/mssql.py
+++ b/ehrql/query_engines/mssql.py
@@ -153,7 +153,12 @@ class MSSQLQueryEngine(BaseSQLQueryEngine):
         # Write results to a temporary table and select them from there. This allows us
         # to use more efficient/robust mechanisms to retrieve the results.
         table_name, schema = self.get_results_table_name_and_schema(
+            # This is a minimally invasive way to disable the persistent results table
+            # in case we want to re-enable it in a hurry. We need the toggle so that
+            # tests can use it to retain coverage.
             self.config.get("TEMP_DATABASE_NAME")
+            if self.config.get("PERSIST_RESULTS_TABLE")
+            else None
         )
         results_table = temporary_table_from_query(
             table_name, results_query, index_col="patient_id", schema=schema

--- a/tests/integration/query_engines/test_mssql.py
+++ b/tests/integration/query_engines/test_mssql.py
@@ -42,7 +42,10 @@ def test_get_results_using_temporary_database(mssql_engine, temp_database_name):
 
         results = mssql_engine.extract_qm(
             variable_definitions,
-            config=dict(TEMP_DATABASE_NAME=temp_database_name),
+            config=dict(
+                TEMP_DATABASE_NAME=temp_database_name,
+                PERSIST_RESULTS_TABLE="t",
+            ),
         )
 
         assert results == [


### PR DESCRIPTION
The only reason we were doing this was to give us robustness against connection errors (the dreaded "DBPROCESS is dead or not enabled"). Having the results in a persistent table allowed us to close the connection, reconnect, and continue downloading results in a way which wouldn't be possible with session-scoped temporary tables.

However, while we still see this error frequently with Cohort Extractor, we have never once seen it with ehrQL. I initially thought this might be luck, but ehrQL has seen enough use at this point that that seems extremely unlikely and instead that _something_ in the ehrQL's connection stack fixes the underlying issue. (We can speculate on what that might be in the comments.)

Apart from being unnecessary, writing results to the temporary database causes other problems: it acquires a global lock which means only one query at a time can compile its results; it bloats the transaction log on the temporary database such that if we work around the locking problem we end up filling the transaction log and blowing up.

While fixing this issue in ehrQL doesn't solve the problem for Cohort Extractor it still has benefits:
 * ehrQL jobs no longer compete with each other or with Cohort Extractor jobs for a shared lock;
 * writing results to a session-scoped table doesn't create the same transaction log pressure as writing to the temporary database and should generally place less load on the database.

Obviously making changes of this kind is likely to cause a certain nervousness. But this change doesn't involve doing a new sort of query – it just involves doing more of what we're doing already. And we've been happily writing massive amounts of data to session-scoped tables in parallel for years without issue.

Nevertheless, out of an abundance of caution/institutional scar tissue from when we tried to fix the locking problem, I'm only disabling the behaviour here and leaving all the supporting code and tests in place. The idea being that it will be easy to revert this change cleanly if we suddenly realise there's a problem.

A [follow-up PR][PR] which actually removes all the related code will be left in draft until we're confident things are working.

[PR]: https://github.com/opensafely-core/ehrql/pull/1524
