### PR TITLE
Fix subtle source of indeterminism in generative tests

### DIFF
--- a/tests/generative/variable_strategies.py
+++ b/tests/generative/variable_strategies.py
@@ -83,6 +83,8 @@ def variable(patient_tables, event_tables, schema, value_strategies):
         ctx = current_build_context()
         return ctx.data.depth > MAX_DEPTH
 
+    COMPARABLE_TYPES = [t for t in value_strategies.keys() if t is not bool]
+
     @st.composite
     def series(draw, type_, frame):
         if depth_exceeded():  # pragma: no cover
@@ -99,8 +101,8 @@ def variable(patient_tables, event_tables, schema, value_strategies):
             exists: ({bool}, DomainConstraint.PATIENT),
             count: ({int}, DomainConstraint.PATIENT),
             count_distinct: ({int}, DomainConstraint.PATIENT),
-            min_: (comparable_types(), DomainConstraint.PATIENT),
-            max_: (comparable_types(), DomainConstraint.PATIENT),
+            min_: (COMPARABLE_TYPES, DomainConstraint.PATIENT),
+            max_: (COMPARABLE_TYPES, DomainConstraint.PATIENT),
             sum_: ({int, float}, DomainConstraint.PATIENT),
             mean: ({float}, DomainConstraint.PATIENT),
             is_null: ({bool}, DomainConstraint.ANY),
@@ -135,8 +137,8 @@ def variable(patient_tables, event_tables, schema, value_strategies):
             date_difference_in_months: ({int}, DomainConstraint.ANY),
             date_difference_in_days: ({int}, DomainConstraint.ANY),
             case: ({int, float, bool, datetime.date}, DomainConstraint.ANY),
-            maximum_of: (comparable_types(), DomainConstraint.ANY),
-            minimum_of: (comparable_types(), DomainConstraint.ANY),
+            maximum_of: (COMPARABLE_TYPES, DomainConstraint.ANY),
+            minimum_of: (COMPARABLE_TYPES, DomainConstraint.ANY),
         }
         series_types = series_constraints.keys()
 
@@ -416,11 +418,8 @@ def variable(patient_tables, event_tables, schema, value_strategies):
     def any_numeric_type():
         return st.sampled_from([int, float])
 
-    def comparable_types():
-        return set(value_strategies.keys()) - {bool}
-
     def any_comparable_type():
-        return st.sampled_from(list(comparable_types()))
+        return st.sampled_from(COMPARABLE_TYPES)
 
     # Frame strategies
     #


### PR DESCRIPTION
We have a test which ensures that the generative tests can produce an example of every operation in the query model, which it does by generating a large-ish number of examples and checking that every operation appears at least once. In order for this test to not randomly fail sometimes we want to generate the same sequence of examples each time, which we do by setting the Hypothesis seed.

However, while this would produce consistent examples _within_ a given execution environment (i.e. specific installation of Python) it would produce different examples _across_ execution environments. The effect of this is that the test would pass reliably in CI and on some developers' machines but fail reliably on others.

Some heroic sleuthing work on the part of @inglesp tracked this down to a list of Python types that was being passed through a `set()` in order to remove an item. We had already [disabled](https://github.com/opensafely-core/ehrql/pull/1390) hash seed randomisation in an attempt to get consistent set iteration orders. But the hash of type objects depends on their `id()` which depends on their location in memory, and this varies between builds of Python, even if the Python version is identical.

The specific fix here is just not to use a set for this purpose. I'm not sure there's much we can do to ensure that we never hit this kind of issue again, but at least we'll be a bit more primed as to what to look for next time.
