### PR TITLE
Pin Trino Docker image version

### DIFF
--- a/tests/lib/databases.py
+++ b/tests/lib/databases.py
@@ -252,7 +252,10 @@ def run_trino(container_name, containers, trino_port):  # pragma: no cover
     )
     containers.run_bg(
         name=container_name,
-        image="trinodb/trino",
+        # This is the version which happened to be current at the time of writing and is
+        # pinned for reproduciblity's sake rather than because there's anything
+        # significant about it
+        image="trinodb/trino:425",
         volumes={
             TRINO_SETUP_DIR: {"bind": "/trino", "mode": "ro"},
             f"{TRINO_SETUP_DIR}/catalog": {"bind": "/etc/trino/catalog", "mode": "ro"},

--- a/tests/lib/databases.py
+++ b/tests/lib/databases.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import sqlalchemy
 import sqlalchemy.exc
+from packaging.version import parse as version_parse
 from requests.exceptions import ConnectionError
 from sqlalchemy.dialects import registry
 from sqlalchemy.orm import sessionmaker
@@ -238,6 +239,17 @@ def make_trino_database(containers):
 
 
 def run_trino(container_name, containers, trino_port):  # pragma: no cover
+    # Note, I don't actually know that this is the minimum required version of Docker
+    # Engine. I do know that 20.10.5 is unsupported (because that's what I had
+    # installed) and that 20.10.16 is supported, according to this comment:
+    # https://github.com/adoptium/containers/issues/214#issuecomment-1139464798 which
+    # was linked from this issue: https://github.com/trinodb/trino/issues/14269
+    min_docker_version = "20.10.16"
+    docker_version = containers.get_engine_version()
+    assert version_parse(docker_version) >= version_parse(min_docker_version), (
+        f"The Trino Docker image requires Docker Engine v{min_docker_version}"
+        f" or above but you have v{docker_version}"
+    )
     containers.run_bg(
         name=container_name,
         image="trinodb/trino",

--- a/tests/lib/docker.py
+++ b/tests/lib/docker.py
@@ -8,6 +8,12 @@ class Containers:
     def __init__(self):
         self._docker = docker.from_env()
 
+    def get_engine_version(self):  # pragma: no cover
+        versions = self._docker.version()
+        engine_details = [c for c in versions["Components"] if c["Name"] == "Engine"]
+        assert len(engine_details) == 1
+        return engine_details[0]["Version"]
+
     def get_container(self, name):
         return self._docker.containers.get(name)
 


### PR DESCRIPTION
We don't want updates to the Trino image to unexpectedly break our tests.

For now, I've just pinned to version which happens to be the latest so nothing should change immediately. Ideally we'd pin to a version which matches what we expect to run in production. There's [a check](https://github.com/opensafely-core/cohort-extractor/blob/d1661ba1435469b27d77731af42ff3aed9e5e76a/.github/workflows/emis_trino_version_check.yaml) for this in Cohort Extractor, but that uses a different Docker image so we can't port it over directly.

I've also added a check for the version of Docker running locally because my version was sufficiently ancient that the Trino image wasn't supported but the error that resulted in was a bit cryptic.