### PR TITLE
Configure Just to read `.env` file

### DIFF
--- a/.env
+++ b/.env
@@ -1,7 +1,15 @@
 # This file defines environment variables we want to be set in development
-# environments.  Commands run via Just should have these set already but we
-# want to support other invocation mechanisms. We use a `.env` file as VSCode's
-# Python extension (but not the terminal) should pick these up by default, see:
+# environments. The Just command runner and VSCode's Python extension (but not
+# the terminal) should pick these up automatically, see:
+# https://github.com/casey/just#dotenv-load
 # https://code.visualstudio.com/docs/python/environments#_environment-variables
+#
+# You can load these manually in bash using something like:
+#
+#     set -o allexport; source .env; set +o allexport
+#
 
+# Disable hash randomisation. The kinds of DoS attacks hash seed randomisation
+# is designed to protect against don't apply to ehrQL, and having consistent
+# output makes debugging much easier
 PYTHONHASHSEED=0

--- a/Justfile
+++ b/Justfile
@@ -1,3 +1,6 @@
+# Load environment variables from `.env` file
+set dotenv-load := true
+
 # just has no idiom for setting a default value for an environment variable
 # so we shell out, as we need VIRTUAL_ENV in the justfile environment
 export VIRTUAL_ENV  := `echo ${VIRTUAL_ENV:-.venv}`
@@ -7,11 +10,6 @@ export BIN := VIRTUAL_ENV + "/bin"
 export PIP := BIN + "/python -m pip"
 # enforce our chosen pip compile flags
 export COMPILE := BIN + "/pip-compile --allow-unsafe --generate-hashes"
-# Disable hash randomisation. The kinds of DoS attacks hash seed randomisation
-# is designed to protect against don't apply to ehrQL, and having consistent
-# output makes debugging much easier
-export PYTHONHASHSEED := "0"
-
 
 alias help := list
 


### PR DESCRIPTION
It actually does this by default anyway, but it emits a big shouty warning that this behaviour is deprecated and you need to explictly opt either in or out of this behaviour.