### PR TITLE
Reduce generative test example count

### DIFF
--- a/.github/workflows/generative-tests.yml
+++ b/.github/workflows/generative-tests.yml
@@ -17,7 +17,7 @@ jobs:
           install-just: true
           python-version: "3.11"
       - run: |
-          GENTEST_EXAMPLES=10000 \
+          GENTEST_EXAMPLES=5000 \
           GENTEST_RANDOMIZE=t \
           GENTEST_MAX_DEPTH=30 \
           GENTEST_DEBUG=t \

--- a/.github/workflows/generative-tests.yml
+++ b/.github/workflows/generative-tests.yml
@@ -25,7 +25,7 @@ jobs:
           just test-generative
 
       - name: "Notify Slack on Failure"
-        if: failure()
+        if: failure() && github.ref_name == 'main'
         uses: voxmedia/github-action-slack-notify-build@3665186a8c1a022b28a1dbe0954e73aa9081ea9e # v1.6.0
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}


### PR DESCRIPTION
My plan was to bisect my way to a value that actually completes. Halving from 10,000 to 5,000 allowed the tests to run correctly for long enough that they found an actual novel bug. Running with 7,500 died with the same error as before, so I've decided to stop at 5,000.

This obviously isn't ideal but, given that the tests we run are different each time, I think it's strictly better to be doing some generative testing every night even if it's less than we'd like.