### PR TITLE
Apply strict equality to frozensets

### DIFF
--- a/tests/unit/query_model/test_nodes.py
+++ b/tests/unit/query_model/test_nodes.py
@@ -457,8 +457,14 @@ def test_any_type_acts_as_an_escape_hatch():
     "lhs,cmp,rhs",
     [
         (10, "==", 10),
+        (10, "!=", 11),
         (10, "!=", 10.0),
+        (True, "==", True),
+        (True, "!=", False),
         (1, "!=", True),
+        (1.0, "!=", True),
+        (0, "!=", False),
+        (0.0, "!=", False),
     ],
 )
 def test_comparisons_between_value_nodes_are_strict(lhs, cmp, rhs):

--- a/tests/unit/query_model/test_nodes.py
+++ b/tests/unit/query_model/test_nodes.py
@@ -453,10 +453,24 @@ def test_any_type_acts_as_an_escape_hatch():
     assert SomeInternalOperation(value=mixed_set)
 
 
-def test_comparisons_between_value_nodes_are_strict():
-    assert Value(10) == Value(10)
-    assert Value(10) != Value(10.0)
-    assert Value(1) != Value(True)
+@pytest.mark.parametrize(
+    "lhs,cmp,rhs",
+    [
+        (10, "==", 10),
+        (10, "!=", 10.0),
+        (1, "!=", True),
+    ],
+)
+def test_comparisons_between_value_nodes_are_strict(lhs, cmp, rhs):
+    if cmp == "==":
+        assert Value(lhs) == Value(rhs)
+    elif cmp == "!=":
+        assert Value(lhs) != Value(rhs)
+    else:
+        assert False
+
+
+def test_value_nodes_are_not_equal_to_bare_values():
     assert Value(10) != 10
 
 


### PR DESCRIPTION
This extends the fix applied in #578 to frozensets to address #1562. We also get `Value` to reject any container types for which we haven't defined an equality method to prevent this issue reoccurring when we add new types.

Closes #1562