### PR TITLE
Allow ehrQL to run in the test backend

### DIFF
--- a/ehrql/__main__.py
+++ b/ehrql/__main__.py
@@ -501,10 +501,11 @@ def query_engine_from_id(str_id):
 
 def backend_from_id(str_id):
     # Workaround for the fact that Job Runner insists on setting OPENSAFELY_BACKEND to
-    # "expectations" when running locally. Cohort Extractor backends have a different
-    # meaning from ehrQL's, and the semantics of the "expectations" backend
-    # translate to "no backend at all" in ehrQL terms so that's how we treat it.
-    if str_id == "expectations":
+    # "expectations" when running locally, and that the test backend sets it to "test".
+    # Cohort Extractor backends have a different meaning from ehrQL's, and the semantics
+    # of these "expectations" and "test" backends translate to "no backend at all" in
+    # ehrQL terms so that's how we treat them.
+    if str_id in ("expectations", "test"):
         return None
 
     if "." not in str_id:

--- a/tests/unit/test___main__.py
+++ b/tests/unit/test___main__.py
@@ -245,3 +245,8 @@ def test_backend_from_id_missing_alias():
 def test_backend_from_id_wrong_type():
     with pytest.raises(ArgumentTypeError, match="is not a valid backend"):
         backend_from_id("pathlib.Path")
+
+
+@pytest.mark.parametrize("alias", ["expectations", "test"])
+def test_backend_from_id_special_case_aliases(alias):
+    assert backend_from_id(alias) is None


### PR DESCRIPTION
This is a backend for which jobs go through the real job-server but run using only dummy data. We haven't used it much recently which is why we didn't notice that ehrQL wouldn't run in it.