### PR TITLE
fix: Catch Trino exception for overly complex queries generated by hypothesis

### DIFF
--- a/tests/generative/test_query_model.py
+++ b/tests/generative/test_query_model.py
@@ -260,6 +260,14 @@ IGNORED_ERRORS = [
             ".+TrinoQueryError.+the query may have too many or too complex expressions.+"
         ),
     ),
+    # Another Trino error that appears to be due to overly complex queries - in this case
+    # when the variable strategy has many nested horizontal aggregations
+    (
+        sqlalchemy.exc.DBAPIError,
+        re.compile(
+            r".+TrinoQueryError.+Error compiling class: io\/trino\/\$gen\/JoinFilterFunction.+"
+        ),
+    ),
     (
         sqlalchemy.exc.ProgrammingError,
         re.compile(".+TrinoUserError.+QUERY_TEXT_TOO_LARGE.+"),


### PR DESCRIPTION
Overnight [generative tests failure](https://github.com/opensafely-core/ehrql/actions/runs/6117284557/job/16603681004)
With this error:
```
sqlalchemy.exc.DBAPIError: (trino.exceptions.TrinoQueryError) TrinoQueryError(type=INTERNAL_ERROR, name=GENERIC_INTERNAL_ERROR, message="io.airlift.bytecode.CompilationException: Error compiling class: io/trino/$gen/JoinFilterFunction_20230908_040709_2725", query_id=20230908_040455_07578_2uerr)
```

The most simplified version of this query that I could produce involved multiple nested horizonatal aggregations of strings (MaximumOf/MinimumOf) and a StringContains. Arbitrarily simplifying small parts of the query would allow it to pass, so the error appears to be related to the nestedness or complexity of the query, although not one that trino catches in any user-friendly way.

This is the "simplified" query. Removing e.g. one of the args from one of the MaximumOf nodes would make it pass. There might be a more simplified version that would still fail, but it does appear to be related to lots of horizontal aggregations (there were a load of inline patient tables, date arithmetics etc that I removed from the hypothesis-generated query which didn't appear to have an impact). 

```
schema = TableSchema(
    i1=Column(int, constraints=()),
    i2=Column(int, constraints=()),
    b1=Column(bool, constraints=()),
    b2=Column(bool, constraints=()),
    d1=Column(datetime.date, constraints=()),
    d2=Column(datetime.date, constraints=()),
    f1=Column(float, constraints=()),
    f2=Column(float, constraints=()),
    s1=Column(str, constraints=()),
    s2=Column(str, constraints=()),
)
e0 = SelectTable("e0", schema)

e0_s1 = SelectColumn(e0, "s1")

e0_s2 = SelectColumn(e0, "s2")

e1 = SelectTable("e1", schema)

p0 = SelectPatientTable("p0", schema)

p0_s1 = SelectColumn(p0, "s1")

p1 = SelectPatientTable("p1", schema)

p1_s1 = SelectColumn(p1, "s1")


variable = SelectColumn(
    PickOneRowPerPatient(
        Sort(
            Filter(
                e0,
                Function.StringContains(
                    Function.MinimumOf(
                        (
                            e0_s1,
                            e0_s2,
                            Function.MinimumOf(
                                (
                                    Function.MaximumOf(
                                        (
                                            Function.MaximumOf((e0_s1, e0_s2)),
                                            Function.MaximumOf(
                                                (e0_s2, p1_s1, e0_s1, e0_s1)
                                            ),
                                            Function.MinimumOf((e0_s2, e0_s1)),
                                            Function.MinimumOf((e0_s1, e0_s2, e0_s1)),
                                        )
                                    ),
                                    Function.MinimumOf(
                                        (
                                            Function.MaximumOf((e0_s1, p1_s1, e0_s2)),
                                            Function.MinimumOf((e0_s1,)),
                                            e0_s1,
                                        )
                                    ),
                                    Function.MaximumOf((e0_s1,)),
                                )
                            ),
                        )
                    ),
                    p0_s1,
                ),
            ),
            e0_s2,
        ),
        Position.FIRST,
    ),
    "s2",
)
```

It feels like this is a trino bug, in that it should catch it and raise a useful error message rather than the INTERNAL_ERROR one, but I couldn't get far enough into it to figure out where in trino it would be raised.