### PR TITLE
feat: Expose OPA table

### DIFF
--- a/docs/includes/generated_docs/schemas/beta.tpp.md
+++ b/docs/includes/generated_docs/schemas/beta.tpp.md
@@ -20,6 +20,7 @@ from ehrql.tables.beta.tpp import (
     medications,
     occupation_on_covid_vaccine_record,
     ons_deaths,
+    opa,
     opa_cost,
     opa_diag,
     opa_proc,
@@ -1903,6 +1904,90 @@ Patient's date of death. Only deaths registered from February 2019 are recorded.
   </dt>
   <dd markdown="block">
 
+
+  </dd>
+</div>
+
+  </dl>
+</div>
+
+
+<p class="dimension-indicator"><code>many rows per patient</code></p>
+## opa
+
+
+<div markdown="block" class="definition-list-wrapper">
+  <div class="title">Columns</div>
+  <dl markdown="block">
+<div markdown="block">
+  <dt id="opa.opa_ident">
+    <strong>opa_ident</strong>
+    <a class="headerlink" href="#opa.opa_ident" title="Permanent link">🔗</a>
+    <code>integer</code>
+  </dt>
+  <dd markdown="block">
+TODO
+
+ * Never `NULL`
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="opa.appointment_date">
+    <strong>appointment_date</strong>
+    <a class="headerlink" href="#opa.appointment_date" title="Permanent link">🔗</a>
+    <code>date</code>
+  </dt>
+  <dd markdown="block">
+TODO
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="opa.attendance_status">
+    <strong>attendance_status</strong>
+    <a class="headerlink" href="#opa.attendance_status" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+TODO
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="opa.consultation_medium_used">
+    <strong>consultation_medium_used</strong>
+    <a class="headerlink" href="#opa.consultation_medium_used" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+TODO
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="opa.first_attendance">
+    <strong>first_attendance</strong>
+    <a class="headerlink" href="#opa.first_attendance" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+TODO
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="opa.treatment_function_code">
+    <strong>treatment_function_code</strong>
+    <a class="headerlink" href="#opa.treatment_function_code" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+TODO
 
   </dd>
 </div>

--- a/ehrql/backends/tpp.py
+++ b/ehrql/backends/tpp.py
@@ -453,6 +453,18 @@ class TPPBackend(BaseBackend):
     """
     )
 
+    opa = MappedTable(
+        source="OPA",
+        columns={
+            "opa_ident": "OPA_Ident",
+            "appointment_date": "Appointment_Date",
+            "attendance_status": "Attendance_Status",
+            "consultation_medium_used": "Consultation_Medium_Used",
+            "first_attendance": "First_Attendance",
+            "treatment_function_code": "Treatment_Function_Code",
+        },
+    )
+
     opa_cost = QueryTable(
         """
         SELECT

--- a/ehrql/tables/beta/tpp.py
+++ b/ehrql/tables/beta/tpp.py
@@ -676,6 +676,35 @@ class ec_cost(EventFrame):
 
 
 @table
+class opa(EventFrame):
+    opa_ident = Series(
+        int,
+        constraints=[Constraint.NotNull()],
+        description="TODO",
+    )
+    appointment_date = Series(
+        datetime.date,
+        description="TODO",
+    )
+    attendance_status = Series(
+        str,
+        description="TODO",
+    )
+    consultation_medium_used = Series(
+        str,
+        description="TODO",
+    )
+    first_attendance = Series(
+        str,
+        description="TODO",
+    )
+    treatment_function_code = Series(
+        str,
+        description="TODO",
+    )
+
+
+@table
 class opa_cost(EventFrame):
     opa_ident = Series(
         int,

--- a/tests/integration/backends/test_tpp.py
+++ b/tests/integration/backends/test_tpp.py
@@ -1095,6 +1095,32 @@ def test_ec_cost(select_all):
     ]
 
 
+@register_test_for(tpp.opa)
+def test_opa(select_all):
+    results = select_all(
+        OPA(
+            Patient_ID=1,
+            OPA_Ident=1,
+            Appointment_Date=date(2023, 2, 1),
+            Attendance_Status="1",
+            Consultation_Medium_Used="2",
+            First_Attendance="3",
+            Treatment_Function_Code="999",
+        ),
+    )
+    assert results == [
+        {
+            "patient_id": 1,
+            "opa_ident": 1,
+            "appointment_date": date(2023, 2, 1),
+            "attendance_status": "1",
+            "consultation_medium_used": "2",
+            "first_attendance": "3",
+            "treatment_function_code": "999",
+        },
+    ]
+
+
 @register_test_for(tpp.opa_cost)
 def test_opa_cost(select_all):
     results = select_all(


### PR DESCRIPTION
Only columns that are queryable in cohort-extractor have been exposed.

Fixes #1460.