### PR TITLE
Set PRNG seed in `generate_patient_facts()`

### DIFF
--- a/ehrql/dummy_data/generator.py
+++ b/ehrql/dummy_data/generator.py
@@ -136,12 +136,9 @@ class DummyPatientGenerator:
         return self.get_patient_data(patient_id, self.query_info.other_table_names)
 
     def get_patient_data(self, patient_id, table_names):
-        # Seed the random generator using the patient_id so we always generate the same
-        # data for the same patient
-        self.rnd.seed(f"{self.random_seed}:{patient_id}")
         # Generate some basic demographic facts about the patient which subsequent table
         # generators can use to ensure a consistent patient history
-        self.generate_patient_facts()
+        self.generate_patient_facts(patient_id)
         for name in table_names:
             # Seed the random generator per-table, so that we get the same data no
             # matter what order the tables are generated in
@@ -159,7 +156,10 @@ class DummyPatientGenerator:
             orm_class = self.orm_classes[table_info.name]
             yield from (orm_class(**row) for row in rows)
 
-    def generate_patient_facts(self):
+    def generate_patient_facts(self, patient_id):
+        # Seed the random generator using the patient_id so we always generate the same
+        # data for the same patient
+        self.rnd.seed(f"{self.random_seed}:{patient_id}")
         # TODO: We could obviously generate more realistic age distributions than this
         date_of_birth = self.today - timedelta(days=self.rnd.randrange(0, 120 * 365))
         age_days = self.rnd.randrange(105 * 365)

--- a/tests/unit/dummy_data/test_generator.py
+++ b/tests/unit/dummy_data/test_generator.py
@@ -129,7 +129,7 @@ def test_get_random_value_on_first_of_month(dummy_patient_generator):
         type=datetime.date,
         constraints=(Constraint.FirstOfMonth(),),
     )
-    values = [dummy_patient_generator.get_random_value(column_info) for _ in range(100)]
+    values = [dummy_patient_generator.get_random_value(column_info) for _ in range(10)]
     assert len(set(values)) > 1, "dates are all identical"
     assert all(value.day == 1 for value in values)
 
@@ -166,8 +166,8 @@ def test_rows_for_patients_with_first_of_month_constraint(dummy_patient_generato
         },
     )
     rows = []
-    for _ in range(10):
-        dummy_patient_generator.generate_patient_facts()
+    for patient_id in range(10):
+        dummy_patient_generator.generate_patient_facts(patient_id)
         rows.extend(dummy_patient_generator.rows_for_patients(table_info))
     assert len(rows) == 10
     # Assert constraints are respected
@@ -192,5 +192,9 @@ def dummy_patient_generator():
     dataset.define_population(patients.exists_for_patient())
     variable_definitions = compile(dataset)
     generator = DummyPatientGenerator(variable_definitions, random_seed="abc")
-    generator.generate_patient_facts()
+    generator.generate_patient_facts(patient_id=1)
+    # Ensure that this patient has a long enough history that we get a sensible
+    # distribution of event dates (the fixed random seed above should ensure that the
+    # history length is always the same; this check is here as a failsafe)
+    assert (generator.events_end - generator.events_start).days > 365
     return generator


### PR DESCRIPTION
Because we weren't doing this previously, and because our tests were calling this method directly, the tests were actually non-deterministic even though it looked like they were using a fixed seed.

Mostly this didn't matter but occasionally we would generate a patient with an age of less than one month and then, when we tried to generate 100 dates for this patient rounded to the first of the month, they would all come out as the same date and it would look like we'd won the lottery (see #1584 and #961)

Closes #1584