### PR TITLE
fix: Set default T1OO config to false

### DIFF
--- a/ehrql/backends/tpp.py
+++ b/ehrql/backends/tpp.py
@@ -25,8 +25,7 @@ class TPPBackend(SQLBackend):
         ehrql.tables.beta.smoketest,
     ]
 
-    # TODO: Temporary default to support safe deployment
-    include_t1oo = True
+    include_t1oo = False
 
     def modify_dsn(self, dsn):
         """

--- a/tests/unit/backends/test_tpp.py
+++ b/tests/unit/backends/test_tpp.py
@@ -9,12 +9,12 @@ from ehrql.backends.tpp import TPPBackend
         (
             "mssql://user:pass@localhost:4321/db",
             "mssql://user:pass@localhost:4321/db",
-            True,
+            False,
         ),
         (
             "mssql://user:pass@localhost:4321/db?param1=one&param2&param1=three",
             "mssql://user:pass@localhost:4321/db?param1=one&param1=three&param2=",
-            True,
+            False,
         ),
         (
             "mssql://user:pass@localhost:4321/db?opensafely_include_t1oo&param2=two",


### PR DESCRIPTION
The previous default was a temporary measure to facilitate deployment.