### PR TITLE
fix: Silence unnecessary dummy data logging

### DIFF
--- a/ehrql/dummy_data/generator.py
+++ b/ehrql/dummy_data/generator.py
@@ -79,13 +79,13 @@ class DummyDataGenerator:
                 if found >= self.population_size:
                     break
 
+            if found >= self.population_size:
+                return data
+
             log.info(
                 f"Generated {batch_start + self.batch_size - 1} patients, "
                 f"found {found} matching"
             )
-
-            if found >= self.population_size:
-                return data
 
             if time.time() - start > self.timeout:
                 log.warn(


### PR DESCRIPTION
It's only interesting to know how many we generated and matched if we didn't manage to match enough patients.