### PR TITLE
Fix dummy data generation for inline tables

### DIFF
--- a/ehrql/assurance.py
+++ b/ehrql/assurance.py
@@ -1,7 +1,7 @@
 from ehrql.query_engines.in_memory import InMemoryQueryEngine
 from ehrql.query_engines.in_memory_database import InMemoryDatabase
 from ehrql.query_language import compile
-from ehrql.query_model.nodes import get_table_nodes
+from ehrql.query_model.introspection import get_table_nodes
 from ehrql.utils.orm_utils import orm_classes_from_tables
 
 

--- a/ehrql/dummy_data/generator.py
+++ b/ehrql/dummy_data/generator.py
@@ -79,6 +79,11 @@ class DummyDataGenerator:
             results = engine.get_results(population_query)
             # Accumulate all data from matching patients, returning once we have enough
             for row in results:
+                # Because of the existence of InlinePatientTables it's possible to get
+                # patients out of a population which we didn't put in. We want to ignore
+                # these.
+                if row.patient_id not in patient_batch:
+                    continue
                 data.extend(patient_batch[row.patient_id])
                 # Include additional data needed for the dataset but not required just
                 # to determine population membership

--- a/ehrql/query_engines/csv.py
+++ b/ehrql/query_engines/csv.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 from ehrql.query_engines.in_memory import InMemoryQueryEngine
 from ehrql.query_engines.in_memory_database import InMemoryDatabase
-from ehrql.query_model.nodes import get_table_nodes
+from ehrql.query_model.introspection import get_table_nodes
 from ehrql.utils.orm_utils import (
     orm_classes_from_tables,
     read_orm_models_from_csv_directory,

--- a/ehrql/query_engines/in_memory.py
+++ b/ehrql/query_engines/in_memory.py
@@ -11,6 +11,7 @@ from ehrql.query_engines.in_memory_database import (
     handle_null,
 )
 from ehrql.query_model import nodes as qm
+from ehrql.query_model.introspection import all_inline_patient_ids
 from ehrql.query_model.transforms import apply_transforms
 from ehrql.utils import date_utils, math_utils
 
@@ -38,9 +39,15 @@ class InMemoryQueryEngine(BaseQueryEngine):
 
         variable_definitions = apply_transforms(variable_definitions)
 
+        # If the query contains any InlinePatientTables then we need to include all the
+        # patient IDs contained in those in our big list of all the patients
+        all_patients = self.all_patients.union(
+            all_inline_patient_ids(*variable_definitions.values())
+        )
+
         name_to_col = {
             "patient_id": PatientColumn(
-                {patient: patient for patient in self.all_patients},
+                {patient: patient for patient in all_patients},
                 default=None,
             )
         }

--- a/ehrql/query_engines/in_memory.py
+++ b/ehrql/query_engines/in_memory.py
@@ -97,7 +97,7 @@ class InMemoryQueryEngine(BaseQueryEngine):
             value = self.convert_value(node.value)
         return PatientColumn(
             {patient: value for patient in self.all_patients},
-            default=None,
+            default=value,
         )
 
     def convert_value(self, value):

--- a/ehrql/query_engines/in_memory_database.py
+++ b/ehrql/query_engines/in_memory_database.py
@@ -3,9 +3,10 @@ the in-memory engine.
 
 See tests in test_database.py for comprehensive examples of how this all works.
 """
-
 from collections import UserDict, defaultdict
 from dataclasses import dataclass
+
+import sqlalchemy
 
 from ehrql.utils.itertools_utils import iter_flatten
 from ehrql.utils.orm_utils import table_has_one_row_per_patient
@@ -22,7 +23,8 @@ class InMemoryDatabase:
         elif input_data:
             metadata = input_data[0].metadata
         else:
-            assert False, "No source of metadata"
+            metadata = sqlalchemy.MetaData()
+
         assert all(item.metadata is metadata for item in input_data)
 
         sqla_table_to_items = {table: [] for table in metadata.sorted_tables}

--- a/ehrql/query_engines/sandbox.py
+++ b/ehrql/query_engines/sandbox.py
@@ -2,7 +2,8 @@ from functools import reduce
 
 from ehrql.query_engines.csv import CSVQueryEngine
 from ehrql.query_language import compile
-from ehrql.query_model.nodes import AggregateByPatient, Function, get_table_nodes
+from ehrql.query_model.introspection import get_table_nodes
+from ehrql.query_model.nodes import AggregateByPatient, Function
 
 
 class SandboxQueryEngine(CSVQueryEngine):

--- a/ehrql/query_model/introspection.py
+++ b/ehrql/query_model/introspection.py
@@ -1,4 +1,9 @@
-from ehrql.query_model.nodes import SelectPatientTable, SelectTable, get_input_nodes
+from ehrql.query_model.nodes import (
+    InlinePatientTable,
+    SelectPatientTable,
+    SelectTable,
+    get_input_nodes,
+)
 
 
 def all_nodes(tree):  # pragma: no cover
@@ -38,3 +43,15 @@ def get_table_nodes(*nodes):
         for subnode in all_unique_nodes(*nodes)
         if isinstance(subnode, SelectTable | SelectPatientTable)
     }
+
+
+def all_inline_patient_ids(*nodes):
+    """
+    Given some nodes, return a set of all the patient IDs contained in any inline tables
+    referenced by those nodes
+    """
+    patient_ids = set()
+    for node in all_unique_nodes(*nodes):
+        if isinstance(node, InlinePatientTable):
+            patient_ids.update(row[0] for row in node.rows)
+    return patient_ids

--- a/ehrql/query_model/introspection.py
+++ b/ehrql/query_model/introspection.py
@@ -1,7 +1,7 @@
 from ehrql.query_model.nodes import SelectPatientTable, SelectTable, get_input_nodes
 
 
-def all_nodes(tree):
+def all_nodes(tree):  # pragma: no cover
     nodes = []
 
     for subnode in get_input_nodes(tree):

--- a/ehrql/query_model/introspection.py
+++ b/ehrql/query_model/introspection.py
@@ -18,10 +18,23 @@ def node_types(tree):  # pragma: no cover
     return [type(node) for node in all_nodes(tree)]
 
 
-def get_table_nodes(*nodes):
-    table_nodes = set()
+def all_unique_nodes(*nodes):
+    found = set()
     for node in nodes:
-        for subnode in all_nodes(node):
-            if isinstance(subnode, SelectTable | SelectPatientTable):
-                table_nodes.add(subnode)
-    return table_nodes
+        gather_unique_nodes(node, found)
+    return found
+
+
+def gather_unique_nodes(node, found):
+    found.add(node)
+    for subnode in get_input_nodes(node):
+        if subnode not in found:
+            gather_unique_nodes(subnode, found)
+
+
+def get_table_nodes(*nodes):
+    return {
+        subnode
+        for subnode in all_unique_nodes(*nodes)
+        if isinstance(subnode, SelectTable | SelectPatientTable)
+    }

--- a/ehrql/query_model/introspection.py
+++ b/ehrql/query_model/introspection.py
@@ -1,0 +1,27 @@
+from ehrql.query_model.nodes import SelectPatientTable, SelectTable, get_input_nodes
+
+
+def all_nodes(tree):
+    nodes = []
+
+    for subnode in get_input_nodes(tree):
+        for node in all_nodes(subnode):
+            nodes.append(node)
+    return [tree] + nodes
+
+
+def count_nodes(tree):  # pragma: no cover
+    return len(all_nodes(tree))
+
+
+def node_types(tree):  # pragma: no cover
+    return [type(node) for node in all_nodes(tree)]
+
+
+def get_table_nodes(*nodes):
+    table_nodes = set()
+    for node in nodes:
+        for subnode in all_nodes(node):
+            if isinstance(subnode, SelectTable | SelectPatientTable):
+                table_nodes.add(subnode)
+    return table_nodes

--- a/ehrql/query_model/nodes.py
+++ b/ehrql/query_model/nodes.py
@@ -38,11 +38,7 @@ __all__ = [
     "has_one_row_per_patient",
     "has_many_rows_per_patient",
     "get_series_type",
-    "all_nodes",
-    "get_table_nodes",
     "get_domain",
-    "count_nodes",
-    "node_types",
     "get_input_nodes",
     "get_root_frame",
 ]
@@ -683,32 +679,6 @@ def is_sorted_sort(frame):
 @is_sorted.register(Filter)
 def is_sorted_filter(frame):
     return is_sorted(frame.source)
-
-
-def all_nodes(tree):
-    nodes = []
-
-    for subnode in get_input_nodes(tree):
-        for node in all_nodes(subnode):
-            nodes.append(node)
-    return [tree] + nodes
-
-
-def count_nodes(tree):  # pragma: no cover
-    return len(all_nodes(tree))
-
-
-def node_types(tree):  # pragma: no cover
-    return [type(node) for node in all_nodes(tree)]
-
-
-def get_table_nodes(*nodes):
-    table_nodes = set()
-    for node in nodes:
-        for subnode in all_nodes(node):
-            if isinstance(subnode, SelectTable | SelectPatientTable):
-                table_nodes.add(subnode)
-    return table_nodes
 
 
 # TYPE VALIDATION

--- a/ehrql/query_model/transforms.py
+++ b/ehrql/query_model/transforms.py
@@ -16,6 +16,7 @@ want to keep them separate from the core query model classes.
 from collections import defaultdict
 from typing import Any
 
+from ehrql.query_model.introspection import all_nodes
 from ehrql.query_model.nodes import (
     Case,
     Function,
@@ -24,7 +25,6 @@ from ehrql.query_model.nodes import (
     SelectColumn,
     Sort,
     Value,
-    all_nodes,
     get_input_nodes,
     get_series_type,
     get_sorts,

--- a/ehrql/query_model/transforms.py
+++ b/ehrql/query_model/transforms.py
@@ -16,7 +16,7 @@ want to keep them separate from the core query model classes.
 from collections import defaultdict
 from typing import Any
 
-from ehrql.query_model.introspection import all_nodes
+from ehrql.query_model.introspection import all_unique_nodes
 from ehrql.query_model.nodes import (
     Case,
     Function,
@@ -45,7 +45,7 @@ def apply_transforms(variables):
     # transforms. While we only have one this is obviously fine! It _might_ be OK as we
     # add more depending on whether they're commutative but we should be careful here
     # and might decide we want to restructure things to keep the transforms independent.
-    nodes = all_nodes_from_variables(variables)
+    nodes = all_unique_nodes(*variables.values())
     reverse_index = build_reverse_index(nodes)
 
     transforms = [
@@ -173,15 +173,6 @@ def make_sortable(col):
             cases={col: Value(2), Function.Not(col): Value(1)}, default=Value(0)
         )
     return col
-
-
-def all_nodes_from_variables(variables):
-    nodes = set()
-    for query in variables.values():
-        query_nodes = all_nodes(query)
-        for query_node in query_nodes:
-            nodes.add(query_node)
-    return nodes
 
 
 def build_reverse_index(nodes):

--- a/tests/generative/recording.py
+++ b/tests/generative/recording.py
@@ -4,7 +4,7 @@ from collections import defaultdict
 
 import pytest
 
-from ehrql.query_model.nodes import count_nodes, node_types
+from ehrql.query_model.introspection import count_nodes, node_types
 
 
 class Recorder:

--- a/tests/generative/test_query_model.py
+++ b/tests/generative/test_query_model.py
@@ -9,7 +9,7 @@ import pytest
 import sqlalchemy.exc
 
 from ehrql.dummy_data import DummyDataGenerator
-from ehrql.query_model.introspection import node_types
+from ehrql.query_model.introspection import all_unique_nodes
 from ehrql.query_model.nodes import (
     AggregateByPatient,
     Column,
@@ -106,7 +106,7 @@ def test_variable_strategy_is_comprehensive():
     @hyp.seed(123456)
     @hyp.given(variable=variable_strategy)
     def record_operations_seen(variable):
-        operations_seen.update(node_types(variable))
+        operations_seen.update(type(node) for node in all_unique_nodes(variable))
 
     record_operations_seen()
 

--- a/tests/generative/test_query_model.py
+++ b/tests/generative/test_query_model.py
@@ -9,6 +9,7 @@ import pytest
 import sqlalchemy.exc
 
 from ehrql.dummy_data import DummyDataGenerator
+from ehrql.query_model.introspection import node_types
 from ehrql.query_model.nodes import (
     AggregateByPatient,
     Column,
@@ -18,7 +19,6 @@ from ehrql.query_model.nodes import (
     SelectPatientTable,
     TableSchema,
     Value,
-    node_types,
 )
 from tests.lib.query_model_utils import get_all_operations
 

--- a/tests/integration/test_query_engines.py
+++ b/tests/integration/test_query_engines.py
@@ -95,13 +95,13 @@ def test_handles_inline_patient_table_with_different_patients(engine):
 
     dataset = Dataset()
     dataset.define_population(test_table.exists_for_patient())
-    dataset.i = test_table.i
+    dataset.n = test_table.i + 100
     dataset.sex = patients.sex
 
     results = engine.extract(dataset)
 
     assert results == [
-        {"patient_id": 1, "i": 10, "sex": "female"},
-        {"patient_id": 2, "i": 20, "sex": None},
-        {"patient_id": 3, "i": 30, "sex": None},
+        {"patient_id": 1, "n": 110, "sex": "female"},
+        {"patient_id": 2, "n": 120, "sex": None},
+        {"patient_id": 3, "n": 130, "sex": None},
     ]


### PR DESCRIPTION
This contains fixes for a variety of different issues with both the in-memory query engine and the dummy data generator when it comes to working with `InlinePatientTable` (i.e. the thing produced by `table_from_file` or `table_from_rows`).

All of these are now covered by tests but they weren't caught by either our standard tests _or_ the generative tests because neither adequately cover "non-standard" population definitions.

We've discussed elsewhere how we might extend the generative tests to do better here. I'll create a separate ticket to track that work.