### PR TITLE
Change `configure_dummy_datastet` to `configure_dummy_data`

### DIFF
--- a/docs/includes/generated_docs/language__general.md
+++ b/docs/includes/generated_docs/language__general.md
@@ -28,15 +28,15 @@ dataset.define_population(patients.date_of_birth < "1990-01-01")
 ```
 </div>
 
-<div class="attr-heading" id="Dataset.configure_dummy_dataset">
-  <tt><strong>configure_dummy_dataset</strong>(<em>population_size</em>)</tt>
-  <a class="headerlink" href="#Dataset.configure_dummy_dataset" title="Permanent link">🔗</a>
+<div class="attr-heading" id="Dataset.configure_dummy_data">
+  <tt><strong>configure_dummy_data</strong>(<em>population_size</em>)</tt>
+  <a class="headerlink" href="#Dataset.configure_dummy_data" title="Permanent link">🔗</a>
 </div>
 <div markdown="block" class="indent">
-Configure the dummy dataset.
+Configure the dummy data to be generated.
 
 ```py
-dataset.configure_dummy_dataset(population_size=10000)
+dataset.configure_dummy_data(population_size=10000)
 ```
 </div>
 

--- a/ehrql/docs/language.py
+++ b/ehrql/docs/language.py
@@ -164,6 +164,8 @@ def build_class_details(name, cls):
 def is_included_attr(name, attr):
     if name.startswith("_") and name not in OPERATORS:
         return False
+    if getattr(attr, "exclude_from_docs", None):
+        return False
     return inspect.isfunction(attr) or inspect.isdatadescriptor(attr)
 
 

--- a/ehrql/dummy_data/generator.py
+++ b/ehrql/dummy_data/generator.py
@@ -57,7 +57,7 @@ class DummyDataGenerator:
             f"(random seed: {self.random_seed}, timeout: {self.timeout}s)"
         )
         log.info(
-            "Use `dataset.configure_dummy_dataset(population_size=N)` "
+            "Use `dataset.configure_dummy_data(population_size=N)` "
             "to change number of patients generated"
         )
         start = time.time()

--- a/ehrql/query_language.py
+++ b/ehrql/query_language.py
@@ -12,6 +12,7 @@ from ehrql.query_model.column_specs import get_column_specs_from_schema
 from ehrql.query_model.nodes import get_series_type, has_one_row_per_patient
 from ehrql.query_model.population_validation import validate_population_definition
 from ehrql.utils import date_utils
+from ehrql.utils.docs_utils import exclude_from_docs
 from ehrql.utils.string_utils import strip_indent
 
 
@@ -74,15 +75,22 @@ class Dataset:
         validate_population_definition(population_condition._qm_node)
         self.variables["population"] = population_condition
 
-    def configure_dummy_dataset(self, *, population_size):
+    def configure_dummy_data(self, *, population_size):
         """
-        Configure the dummy dataset.
+        Configure the dummy data to be generated.
 
         ```py
-        dataset.configure_dummy_dataset(population_size=10000)
+        dataset.configure_dummy_data(population_size=10000)
         ```
         """
         self.dummy_dataset_config.population_size = population_size
+
+    @exclude_from_docs
+    def configure_dummy_dataset(self, **kwargs):  # pragma: no cover
+        """
+        Deprecated alias from `configure_dummy_data`
+        """
+        return self.configure_dummy_data(**kwargs)
 
     def __setattr__(self, name, value):
         if name == "population":

--- a/ehrql/utils/docs_utils.py
+++ b/ehrql/utils/docs_utils.py
@@ -1,0 +1,3 @@
+def exclude_from_docs(fn):
+    fn.exclude_from_docs = True
+    return fn

--- a/tests/lib/fixtures.py
+++ b/tests/lib/fixtures.py
@@ -7,7 +7,7 @@ year = patients.date_of_birth.year
 dataset.define_population(year >= 1940)
 dataset.year = year
 
-dataset.configure_dummy_dataset(population_size=10)
+dataset.configure_dummy_data(population_size=10)
 """
 
 no_dataset_attribute_dataset_definition = """

--- a/tests/unit/docs/test_language.py
+++ b/tests/unit/docs/test_language.py
@@ -1,0 +1,37 @@
+import pytest
+
+from ehrql.docs.language import is_included_attr
+from ehrql.utils.docs_utils import exclude_from_docs
+
+
+class Example:
+    some_attr = "some_value"
+
+    def some_method(self):
+        raise NotImplementedError()
+
+    @property
+    def some_property(self):
+        raise NotImplementedError()
+
+    def _some_internal_method(self):
+        raise NotImplementedError()
+
+    @exclude_from_docs
+    def some_excluded_method(self):
+        raise NotImplementedError()
+
+
+@pytest.mark.parametrize(
+    "name,expected",
+    [
+        ("some_attr", False),
+        ("some_method", True),
+        ("some_property", True),
+        ("_some_internal_method", False),
+        ("some_excluded_method", False),
+    ],
+)
+def test_is_included_attr(name, expected):
+    value = getattr(Example, name)
+    assert is_included_attr(name, value) == expected


### PR DESCRIPTION
We leave the old method name in place as an undocumented alias for now. Once we're sure no one is using it we can remove this.

We're trying to be consistent with our terminology here so:
 * "dummy data" for the general approach of making up some fake data to test with;
 * "dummy dataset" for _output_ files containing dummy data;
 * "dummy tables" for _input_ files containing dummy data.

The method in question configures settings which affect both dummy datasets and dummy tables so "dummy data" is the more appropriate term to use.

It also means that we can use the same method name with measures, which is a consistency benefit.