### PR TITLE
fix: Accept subset of categories when reading Arrow files

### DIFF
--- a/ehrql/file_formats/arrow.py
+++ b/ehrql/file_formats/arrow.py
@@ -206,7 +206,8 @@ class ArrowDatasetReader(BaseDatasetReader):
             )
         if pyarrow.types.is_dictionary(column.type) and spec.categories is not None:
             column_categories = column.dictionary.to_pylist()
-            if column_categories != list(spec.categories):
+            unexpected_categories = set(column_categories) - set(spec.categories)
+            if unexpected_categories:
                 return (
                     f"Unexpected categories in column '{name}'\n"
                     f"  Categories: {', '.join(column_categories)}\n"

--- a/tests/integration/test_file_formats.py
+++ b/tests/integration/test_file_formats.py
@@ -142,6 +142,17 @@ def test_read_dataset_validates_categories(test_file):
         read_dataset(test_file, column_specs)
 
 
+def test_read_dataset_accepts_subset_of_expected_categories(test_file):
+    # Create a copy of the column specs with an extra category on the categorical column
+    # and the categories in a different order
+    column_specs = TEST_FILE_SPECS.copy()
+    column_specs["c"] = ColumnSpec(str, categories=("C", "B", "A"))
+
+    # Check we can still read it correctly
+    reader = read_dataset(test_file, column_specs)
+    assert list(reader) == TEST_FILE_DATA
+
+
 def test_dataset_readers_identity(test_file):
     reader_1 = read_dataset(test_file, TEST_FILE_SPECS)
     reader_2 = read_dataset(test_file, TEST_FILE_SPECS)


### PR DESCRIPTION
If we have a column in a file where the available categories are A, B and C it's perfectly valid for the file to contain only A and B. Therefore we shouldn't enforce that the categorical dictionary contains C as well.

There's a wider question around how we help users make sure their code can cope with all the values the real data might throw at it when those values aren't represented in the dummy data. But enforcing an exact match for Arrow categoricals isn't the way to achieve this.