### PR TITLE
Remove Trino from overnight generative tests

### DIFF
--- a/.github/workflows/generative-tests.yml
+++ b/.github/workflows/generative-tests.yml
@@ -17,7 +17,7 @@ jobs:
           install-just: true
           python-version: "3.11"
       - run: |
-          GENTEST_EXAMPLES=5000 \
+          GENTEST_EXAMPLES=10000 \
           GENTEST_RANDOMIZE=t \
           GENTEST_MAX_DEPTH=30 \
           GENTEST_DEBUG=t \

--- a/.github/workflows/generative-tests.yml
+++ b/.github/workflows/generative-tests.yml
@@ -22,6 +22,7 @@ jobs:
           GENTEST_MAX_DEPTH=30 \
           GENTEST_DEBUG=t \
           GENTEST_CHECK_IGNORED_ERRORS=t \
+          GENTEST_QUERY_ENGINES='in_memory sqlite mssql' \
           just test-generative
 
       - name: "Notify Slack on Failure"

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -101,6 +101,15 @@ want to crank the settings further e.g.
 GENTEST_EXAMPLES=10000 GENTEST_MAX_DEPTH=20 just test-generative
 ```
 
+You can control which query engines the tests exercise using the
+enviornment variable `GENTEST_QUERY_ENGINES`. For instance, if you have
+made a change to the basic SQL-building logic in BaseSQLQueryEngine and
+you want to rapidly test this with a large number of examples you could
+compare just the in-memory and SQLite engines using:
+```
+GENTEST_QUERY_ENGINES='in_memory sqlite' GENTEST_EXAMPLES=10000 just test-generative
+```
+
 In addition to whatever you do locally, a scheduled Github Actions
 workflow runs the generative test overnight with settings as high as we
 can get away with and alerts us in Slack if it finds a failure.

--- a/tests/generative/test_query_model.py
+++ b/tests/generative/test_query_model.py
@@ -84,6 +84,11 @@ ENGINE_CONFIG = {
 }
 
 
+SELECTED_QUERY_ENGINES = (
+    os.environ.get("GENTEST_QUERY_ENGINES", "").split() or QUERY_ENGINE_NAMES
+)
+
+
 @pytest.fixture(scope="session")
 def query_engines(request):
     # By contrast with the `engine` fixture which is parametrized over the types of
@@ -91,7 +96,7 @@ def query_engines(request):
     # the engines together at once
     return {
         name: engine_factory(request, name, with_session_scope=True)
-        for name in QUERY_ENGINE_NAMES
+        for name in SELECTED_QUERY_ENGINES
     }
 
 


### PR DESCRIPTION
This removes Trino from the query engines exercised by the overnight generative tests, though it will still be tested in CI and locally.

While #1567 is unresolved its presence renders our overnight tests useless as they fail with the same error every time.