### PR TITLE
fix: Use temporary tables instead of CTEs for Trino

### DIFF
--- a/ehrql/query_engines/base_sql.py
+++ b/ehrql/query_engines/base_sql.py
@@ -147,7 +147,7 @@ class BaseSQLQueryEngine(BaseQueryEngine):
             # doesn't reference any tables at all. Our validation rules ensure that such
             # an expression will never evaluate True so the population will always be
             # empty. But we can at least return an empty result, rather than blowing up.
-            return sqlalchemy.select(sqlalchemy.literal(None).label("patient_id"))
+            return sqlalchemy.select(sqlalchemy.literal(0).label("patient_id"))
 
     # Some databases care about the distinction between "predicates" (expressions which
     # are guaranteed boolean-typed by virtue of their syntax) and other forms of

--- a/ehrql/query_engines/mssql.py
+++ b/ehrql/query_engines/mssql.py
@@ -261,10 +261,7 @@ class MSSQLQueryEngine(BaseSQLQueryEngine):
 
 def temporary_table_from_query(table_name, query, index_col=0, schema=None):
     # Define a table object with the same columns as the query
-    columns = [
-        sqlalchemy.Column(c.name, c.type, key=c.key) for c in query.selected_columns
-    ]
-    table = GeneratedTable(table_name, sqlalchemy.MetaData(), *columns, schema=schema)
+    table = GeneratedTable.from_query(table_name, query, schema=schema)
     table.setup_queries = [
         # Use the MSSQL `SELECT * INTO ...` construct to create and populate this
         # table

--- a/ehrql/utils/sqlalchemy_query_utils.py
+++ b/ehrql/utils/sqlalchemy_query_utils.py
@@ -56,6 +56,18 @@ class GeneratedTable(sqlalchemy.Table):
     setup_queries = ()
     cleanup_queries = ()
 
+    @classmethod
+    def from_query(cls, name, query, metadata=None, **kwargs):
+        """
+        Create a GeneratedTable whose column structure matches that of the supplied query
+        """
+        if metadata is None:
+            metadata = sqlalchemy.MetaData()
+        columns = [
+            sqlalchemy.Column(c.name, c.type, key=c.key) for c in query.selected_columns
+        ]
+        return cls(name, metadata, *columns, **kwargs)
+
 
 def get_setup_and_cleanup_queries(query):
     """

--- a/tests/unit/utils/test_sqlalchemy_query_utils.py
+++ b/tests/unit/utils/test_sqlalchemy_query_utils.py
@@ -192,6 +192,27 @@ def test_get_setup_and_cleanup_queries_with_insert_many():
     assert setup_cleanup == ([], [])
 
 
+def test_generated_table_from_query():
+    query = sqlalchemy.select(
+        sqlalchemy.literal(1).label("number"),
+        sqlalchemy.literal("a").label("string"),
+    )
+    table = GeneratedTable.from_query("some_table", query, schema="some_schema")
+    assert str(sqlalchemy.schema.CreateTable(table)).strip() == (
+        "CREATE TABLE some_schema.some_table (\n"
+        "\tnumber INTEGER, \n"
+        "\tstring VARCHAR\n"
+        ")"
+    )
+
+
+def test_generated_table_from_query_with_metadata():
+    metadata = sqlalchemy.MetaData()
+    query = sqlalchemy.select(sqlalchemy.literal(1).label("number"))
+    table = GeneratedTable.from_query("some_table", query, metadata=metadata)
+    assert table.metadata is metadata
+
+
 # The below tests exercise obscure corners of SQLAlchemy which used to have bugs that we
 # had to workaroud. These have been fixed in SQLAlchemy 2 but we retain the tests for
 # their warm fuzzy value.

--- a/tests/unit/utils/test_sqlalchemy_query_utils.py
+++ b/tests/unit/utils/test_sqlalchemy_query_utils.py
@@ -2,8 +2,10 @@ import pytest
 import sqlalchemy
 from sqlalchemy.dialects.sqlite.pysqlite import SQLiteDialect_pysqlite
 from sqlalchemy.engine.default import DefaultDialect
+from sqlalchemy.sql.visitors import iterate
 
 from ehrql.utils.sqlalchemy_query_utils import (
+    CreateTableAs,
     GeneratedTable,
     InsertMany,
     clause_as_str,
@@ -211,6 +213,36 @@ def test_generated_table_from_query_with_metadata():
     query = sqlalchemy.select(sqlalchemy.literal(1).label("number"))
     table = GeneratedTable.from_query("some_table", query, metadata=metadata)
     assert table.metadata is metadata
+
+
+def test_create_table_as():
+    query = sqlalchemy.select(
+        sqlalchemy.literal(1).label("number"),
+        sqlalchemy.literal("a").label("string"),
+    )
+    table = sqlalchemy.table("test")
+    create_table = CreateTableAs(table, query)
+
+    assert str(create_table) == (
+        "CREATE TABLE test AS SELECT :param_1 AS number, :param_2 AS string"
+    )
+
+
+def test_create_table_as_can_be_iterated():
+    # If we don't define the `get_children()` method on `CreateTableAs` we won't get an
+    # error when attempting to iterate the resulting element structure: it will just act
+    # as a leaf node. But as we rely heavily on query introspection we need to ensure we
+    # can iterate over query structures.
+    query = sqlalchemy.select(
+        sqlalchemy.literal(1).label("number"),
+        sqlalchemy.literal("a").label("string"),
+    )
+    table = sqlalchemy.table("test")
+    create_table = CreateTableAs(table, query)
+
+    # Check that the original elements show up when iterated
+    assert any([e is table for e in iterate(create_table)])
+    assert any([e is query for e in iterate(create_table)])
 
 
 # The below tests exercise obscure corners of SQLAlchemy which used to have bugs that we


### PR DESCRIPTION
These aren't actually temporary tables in the usual sense because Trino doesn't support those: they're standard, persisted tables which we delete after the query has completed. This does mean that we're not guaranteed to clean them in case of an error, but we use a naming scheme which includes the date as a prefix and so is amenable to having a scheduled cleanup job to clear old tables.

This is roughly what Cohort Extractor used to do when run in EMIS.

This change is needed because, after getting the serious generative tests running, we were hitting errors like:

    TrinoUserError(
        type=USER_ERROR,
        name=QUERY_HAS_TOO_MANY_STAGES,
        message=(
            "Number of stages in the query (178) exceeds the allowed "
            "maximum (150). If the query contains multiple aggregates "
            "with DISTINCT over different columns, please set the "
            "'mark_distinct_strategy' session property to 'none'. If the "
            "query contains WITH clauses that are referenced more than "
            "once, please create temporary table(s) for the queries in "
            "those clauses.",
        ),
        query_id=20230922_115126_08994_ksi7v,
    )