### PR TITLE
Fiddle generative test settings

### DIFF
--- a/.github/workflows/generative-tests.yml
+++ b/.github/workflows/generative-tests.yml
@@ -26,9 +26,9 @@ jobs:
 
           just devenv
           export \
-            GENTEST_EXAMPLES=200 \
+            GENTEST_EXAMPLES=150 \
             GENTEST_RANDOMIZE=t \
-            GENTEST_MAX_DEPTH=30 \
+            GENTEST_MAX_DEPTH=25 \
             GENTEST_DEBUG=t \
             GENTEST_CHECK_IGNORED_ERRORS=t
 

--- a/.github/workflows/generative-tests.yml
+++ b/.github/workflows/generative-tests.yml
@@ -4,7 +4,7 @@ name: Long-running generative tests
 on:
   workflow_dispatch:
   schedule:
-    - cron:  "13 3 * * *"
+    - cron:  "26 0 * * *"
 
 jobs:
   gentests:

--- a/tests/generative/recording.py
+++ b/tests/generative/recording.py
@@ -69,7 +69,7 @@ def check_not_too_many_ignored_errors(recorder):
 
         # Allow more errors (proportionally) for smaller numbers of examples
         error_rate = recorder.num_ignored_errors / recorder.num_results
-        error_limit = 0.015
+        error_limit = 0.05
         assert error_rate <= error_limit, (
             f"{recorder.num_ignored_errors=}, "
             f"{recorder.num_results=}, "

--- a/tests/lib/databases.py
+++ b/tests/lib/databases.py
@@ -43,6 +43,7 @@ class DbDetails:
         db_name="",
         query=None,
         temp_db=None,
+        engine_kwargs=None,
     ):
         self.protocol = protocol
         self.driver = driver
@@ -55,6 +56,7 @@ class DbDetails:
         self.db_name = db_name
         self.query = query
         self.temp_db = temp_db
+        self.engine_kwargs = engine_kwargs or {}
         self.metadata = None
 
     def container_url(self):
@@ -68,7 +70,8 @@ class DbDetails:
             self.host_from_host, self.port_from_host, include_driver=bool(self.driver)
         )
         engine_url = sqlalchemy.engine.make_url(url)
-        engine = sqlalchemy.create_engine(engine_url, **kwargs)
+        engine_kwargs = self.engine_kwargs | kwargs
+        engine = sqlalchemy.create_engine(engine_url, **engine_kwargs)
         return engine
 
     def _url(self, host, port, include_driver=False):
@@ -240,6 +243,9 @@ def make_trino_database(containers):
         port_from_host=host_trino_port,
         username="trino",
         db_name="trino/default",
+        # Disable automatic retries for the test client: it's pointless and creates log
+        # noise
+        engine_kwargs={"connect_args": {"max_attempts": 1}},
     )
 
 


### PR DESCRIPTION
An effect of running multiple small batches is that we're more likely to randomly hit a batch which generates a larger than usual number of ignored errors. So we increase the threshold at which we complain about these.

We also reduce the batch size and maximum query depth to get batches to run in a more sensible time. (I've not seen any bugs exposed by very deeply nested queries that wouldn't also be exposed by just a few layers of nested operations.)