### PR TITLE
fix: Replace negative IMD values with NULLs

### DIFF
--- a/ehrql/backends/tpp.py
+++ b/ehrql/backends/tpp.py
@@ -31,7 +31,7 @@ class TPPBackend(BaseBackend):
                 CAST(addr.EndDate AS date) AS end_date,
                 addr.AddressType AS address_type,
                 addr.RuralUrbanClassificationCode AS rural_urban_classification,
-                addr.ImdRankRounded AS imd_rounded,
+                NULLIF(addr.ImdRankRounded, -1) AS imd_rounded,
                 CASE
                     WHEN addr.MSOACode NOT IN ('NPC', '') THEN addr.MSOACode
                 END AS msoa_code,

--- a/tests/integration/backends/test_tpp.py
+++ b/tests/integration/backends/test_tpp.py
@@ -108,7 +108,7 @@ def test_addresses(select_all):
             EndDate="2020-01-01T10:10:00",
             AddressType=3,
             RuralUrbanClassificationCode=4,
-            ImdRankRounded=2000,
+            ImdRankRounded=-1,
             MSOACode="",
         ),
         PatientAddress(
@@ -149,7 +149,7 @@ def test_addresses(select_all):
             "end_date": date(2020, 1, 1),
             "address_type": 3,
             "rural_urban_classification": 4,
-            "imd_rounded": 2000,
+            "imd_rounded": None,
             "msoa_code": None,
             "has_postcode": False,
             "care_home_is_potential_match": False,


### PR DESCRIPTION
Although the issue mentions negative IMD values, the only negative IMD values are -1s. So, we can use NULLIF to replace -1s with NULLs.

I've checked the performance impact of this change by comparing the execution time of the new query (NULLIF) to the old query.

The first template query counted the number of rows where imd_rounded was GTE zero. In this case, there was an 88ms difference in elapsed time between new and old, favouring old.

The second template query counted the number of rows where imd_rounded was NULL (new query) or was -1 (old query). In this case, there was a 33ms difference in elapsed time between new and old, favouring new.

Fixes #1548