### PR TITLE
Add `WL_Clockstops` and `WL_OpenPathways`

### DIFF
--- a/docs/includes/generated_docs/schemas/beta.tpp.md
+++ b/docs/includes/generated_docs/schemas/beta.tpp.md
@@ -31,6 +31,10 @@ from ehrql.tables.beta.tpp import (
     practice_registrations,
     sgss_covid_all_tests,
     vaccinations,
+    wl_clockstops,
+    wl_clockstops_raw,
+    wl_openpathways,
+    wl_openpathways_raw,
 )
 ```
 
@@ -2812,6 +2816,667 @@ return ordered_regs.last_for_patient()
   <dt id="vaccinations.product_name">
     <strong>product_name</strong>
     <a class="headerlink" href="#vaccinations.product_name" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+  </dl>
+</div>
+
+
+<p class="dimension-indicator"><code>many rows per patient</code></p>
+## wl_clockstops
+
+National Waiting List Clock Stops
+
+This dataset contains all completed referral-to-treatment (RTT) pathways with a "clock stop" date between May 2021 and May 2022.
+Patients referred for non-emergency consultant-led treatment are on RTT pathways.
+The "clock start" date is the date of the first referral that starts the pathway.
+The "clock stop" date is when the patient either: receives treatment;
+declines treatment;
+enters a period of active monitoring;
+no longer requires treatment;
+or dies.
+The time spent waiting is the difference in these two dates.
+
+A patient may have multiple rows if they have multiple completed RTT pathways;
+however, there is only one row per unique pathway.
+Because referral identifiers aren't necessarily unique between hospitals,
+unique RTT pathways can be identified using a combination of:
+
+* `pseudo_organisation_code_patient_pathway_identifier_issuer`
+* `pseudo_patient_pathway_identifier`
+* `pseudo_referral_identifier`
+* `referral_to_treatment_period_start_date`
+
+For more information, see
+"[Consultant-led Referral to Treatment Waiting Times Rules and Guidance][wl_clockstops_1]".
+
+[wl_clockstops_1]: https://www.england.nhs.uk/statistics/statistical-work-areas/rtt-waiting-times/rtt-guidance/
+<div markdown="block" class="definition-list-wrapper">
+  <div class="title">Columns</div>
+  <dl markdown="block">
+<div markdown="block">
+  <dt id="wl_clockstops.activity_treatment_function_code">
+    <strong>activity_treatment_function_code</strong>
+    <a class="headerlink" href="#wl_clockstops.activity_treatment_function_code" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+The treatment function
+
+ * Matches regular expression: `[a-zA-Z0-9]{3}`
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="wl_clockstops.priority_type_code">
+    <strong>priority_type_code</strong>
+    <a class="headerlink" href="#wl_clockstops.priority_type_code" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+The priority type
+
+ * Possible values: `routine`, `urgent`, `two week wait`
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="wl_clockstops.pseudo_organisation_code_patient_pathway_identifier_issuer">
+    <strong>pseudo_organisation_code_patient_pathway_identifier_issuer</strong>
+    <a class="headerlink" href="#wl_clockstops.pseudo_organisation_code_patient_pathway_identifier_issuer" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="wl_clockstops.pseudo_patient_pathway_identifier">
+    <strong>pseudo_patient_pathway_identifier</strong>
+    <a class="headerlink" href="#wl_clockstops.pseudo_patient_pathway_identifier" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="wl_clockstops.pseudo_referral_identifier">
+    <strong>pseudo_referral_identifier</strong>
+    <a class="headerlink" href="#wl_clockstops.pseudo_referral_identifier" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="wl_clockstops.referral_request_received_date">
+    <strong>referral_request_received_date</strong>
+    <a class="headerlink" href="#wl_clockstops.referral_request_received_date" title="Permanent link">🔗</a>
+    <code>date</code>
+  </dt>
+  <dd markdown="block">
+The date the referral was received, for the referral that started the original pathway
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="wl_clockstops.referral_to_treatment_period_end_date">
+    <strong>referral_to_treatment_period_end_date</strong>
+    <a class="headerlink" href="#wl_clockstops.referral_to_treatment_period_end_date" title="Permanent link">🔗</a>
+    <code>date</code>
+  </dt>
+  <dd markdown="block">
+Clock stop for the completed pathway
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="wl_clockstops.referral_to_treatment_period_start_date">
+    <strong>referral_to_treatment_period_start_date</strong>
+    <a class="headerlink" href="#wl_clockstops.referral_to_treatment_period_start_date" title="Permanent link">🔗</a>
+    <code>date</code>
+  </dt>
+  <dd markdown="block">
+Clock start for the completed pathway
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="wl_clockstops.source_of_referral_for_outpatients">
+    <strong>source_of_referral_for_outpatients</strong>
+    <a class="headerlink" href="#wl_clockstops.source_of_referral_for_outpatients" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="wl_clockstops.waiting_list_type">
+    <strong>waiting_list_type</strong>
+    <a class="headerlink" href="#wl_clockstops.waiting_list_type" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+The waiting list type on completion of the pathway
+
+ * Possible values: `ORTT`, `IRTT`
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="wl_clockstops.week_ending_date">
+    <strong>week_ending_date</strong>
+    <a class="headerlink" href="#wl_clockstops.week_ending_date" title="Permanent link">🔗</a>
+    <code>date</code>
+  </dt>
+  <dd markdown="block">
+The Sunday of the week that the pathway relates to
+
+  </dd>
+</div>
+
+  </dl>
+</div>
+
+
+<p class="dimension-indicator"><code>many rows per patient</code></p>
+## wl_clockstops_raw
+
+National Waiting List Clock Stops
+
+Unlike [`wl_clockstops`](#wl_clockstops),
+the columns in this table have the same data types as the columns in [the associated
+database table][wl_clockstops_raw_1]. The three "pseudo" columns are small
+exceptions, as they are converted from binary columns to string columns.
+
+[wl_clockstops_raw_1]: https://reports.opensafely.org/reports/opensafely-tpp-database-schema/#WL_ClockStops
+<div markdown="block" class="definition-list-wrapper">
+  <div class="title">Columns</div>
+  <dl markdown="block">
+<div markdown="block">
+  <dt id="wl_clockstops_raw.activity_treatment_function_code">
+    <strong>activity_treatment_function_code</strong>
+    <a class="headerlink" href="#wl_clockstops_raw.activity_treatment_function_code" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="wl_clockstops_raw.priority_type_code">
+    <strong>priority_type_code</strong>
+    <a class="headerlink" href="#wl_clockstops_raw.priority_type_code" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="wl_clockstops_raw.pseudo_organisation_code_patient_pathway_identifier_issuer">
+    <strong>pseudo_organisation_code_patient_pathway_identifier_issuer</strong>
+    <a class="headerlink" href="#wl_clockstops_raw.pseudo_organisation_code_patient_pathway_identifier_issuer" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="wl_clockstops_raw.pseudo_patient_pathway_identifier">
+    <strong>pseudo_patient_pathway_identifier</strong>
+    <a class="headerlink" href="#wl_clockstops_raw.pseudo_patient_pathway_identifier" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="wl_clockstops_raw.pseudo_referral_identifier">
+    <strong>pseudo_referral_identifier</strong>
+    <a class="headerlink" href="#wl_clockstops_raw.pseudo_referral_identifier" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="wl_clockstops_raw.referral_request_received_date">
+    <strong>referral_request_received_date</strong>
+    <a class="headerlink" href="#wl_clockstops_raw.referral_request_received_date" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="wl_clockstops_raw.referral_to_treatment_period_end_date">
+    <strong>referral_to_treatment_period_end_date</strong>
+    <a class="headerlink" href="#wl_clockstops_raw.referral_to_treatment_period_end_date" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="wl_clockstops_raw.referral_to_treatment_period_start_date">
+    <strong>referral_to_treatment_period_start_date</strong>
+    <a class="headerlink" href="#wl_clockstops_raw.referral_to_treatment_period_start_date" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="wl_clockstops_raw.source_of_referral_for_outpatients">
+    <strong>source_of_referral_for_outpatients</strong>
+    <a class="headerlink" href="#wl_clockstops_raw.source_of_referral_for_outpatients" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="wl_clockstops_raw.waiting_list_type">
+    <strong>waiting_list_type</strong>
+    <a class="headerlink" href="#wl_clockstops_raw.waiting_list_type" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="wl_clockstops_raw.week_ending_date">
+    <strong>week_ending_date</strong>
+    <a class="headerlink" href="#wl_clockstops_raw.week_ending_date" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+  </dl>
+</div>
+
+
+<p class="dimension-indicator"><code>many rows per patient</code></p>
+## wl_openpathways
+
+National Waiting List Open Pathways
+
+This dataset contains all people on open (incomplete) RTT or not current RTT (non-RTT) pathways as of May 2022.
+It is a snapshot of everyone still awaiting treatment as of May 2022 (i.e., the clock hasn't stopped).
+Patients referred for non-emergency consultant-led treatment are on RTT pathways,
+while patients referred for non-consultant-led treatment are on non-RTT pathways.
+For each pathway, there is one row for every week that the patient is still waiting.
+Because referral identifiers aren't necessarily unique between hospitals,
+unique RTT pathways can be identified using a combination of:
+
+* `pseudo_organisation_code_patient_pathway_identifier_issuer`
+* `pseudo_patient_pathway_identifier`
+* `pseudo_referral_identifier`
+* `referral_to_treatment_period_start_date`
+
+
+For more information, see
+"[Consultant-led Referral to Treatment Waiting Times Rules and Guidance][wl_openpathways_1]".
+
+[wl_openpathways_1]: https://www.england.nhs.uk/statistics/statistical-work-areas/rtt-waiting-times/rtt-guidance/
+<div markdown="block" class="definition-list-wrapper">
+  <div class="title">Columns</div>
+  <dl markdown="block">
+<div markdown="block">
+  <dt id="wl_openpathways.activity_treatment_function_code">
+    <strong>activity_treatment_function_code</strong>
+    <a class="headerlink" href="#wl_openpathways.activity_treatment_function_code" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+The treatment function
+
+ * Matches regular expression: `[a-zA-Z0-9]{3}`
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="wl_openpathways.current_pathway_period_start_date">
+    <strong>current_pathway_period_start_date</strong>
+    <a class="headerlink" href="#wl_openpathways.current_pathway_period_start_date" title="Permanent link">🔗</a>
+    <code>date</code>
+  </dt>
+  <dd markdown="block">
+Latest clock start for this pathway period
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="wl_openpathways.priority_type_code">
+    <strong>priority_type_code</strong>
+    <a class="headerlink" href="#wl_openpathways.priority_type_code" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+The priority type
+
+ * Possible values: `routine`, `urgent`, `two week wait`
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="wl_openpathways.pseudo_organisation_code_patient_pathway_identifier_issuer">
+    <strong>pseudo_organisation_code_patient_pathway_identifier_issuer</strong>
+    <a class="headerlink" href="#wl_openpathways.pseudo_organisation_code_patient_pathway_identifier_issuer" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="wl_openpathways.pseudo_patient_pathway_identifier">
+    <strong>pseudo_patient_pathway_identifier</strong>
+    <a class="headerlink" href="#wl_openpathways.pseudo_patient_pathway_identifier" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="wl_openpathways.pseudo_referral_identifier">
+    <strong>pseudo_referral_identifier</strong>
+    <a class="headerlink" href="#wl_openpathways.pseudo_referral_identifier" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="wl_openpathways.referral_request_received_date">
+    <strong>referral_request_received_date</strong>
+    <a class="headerlink" href="#wl_openpathways.referral_request_received_date" title="Permanent link">🔗</a>
+    <code>date</code>
+  </dt>
+  <dd markdown="block">
+The date the referral was received, for the referral that started the original pathway
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="wl_openpathways.referral_to_treatment_period_end_date">
+    <strong>referral_to_treatment_period_end_date</strong>
+    <a class="headerlink" href="#wl_openpathways.referral_to_treatment_period_end_date" title="Permanent link">🔗</a>
+    <code>date</code>
+  </dt>
+  <dd markdown="block">
+If the pathway is open, then `NULL`
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="wl_openpathways.referral_to_treatment_period_start_date">
+    <strong>referral_to_treatment_period_start_date</strong>
+    <a class="headerlink" href="#wl_openpathways.referral_to_treatment_period_start_date" title="Permanent link">🔗</a>
+    <code>date</code>
+  </dt>
+  <dd markdown="block">
+Latest clock start for this pathway. If the pathway is not a current pathway, then `NULL`.
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="wl_openpathways.source_of_referral">
+    <strong>source_of_referral</strong>
+    <a class="headerlink" href="#wl_openpathways.source_of_referral" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+National referral source code for the referral that created the original pathway
+
+ * Matches regular expression: `[a-zA-Z0-9]{2}`
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="wl_openpathways.waiting_list_type">
+    <strong>waiting_list_type</strong>
+    <a class="headerlink" href="#wl_openpathways.waiting_list_type" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+
+
+ * Possible values: `ORTT`, `IRTT`, `ONON`, `INON`
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="wl_openpathways.week_ending_date">
+    <strong>week_ending_date</strong>
+    <a class="headerlink" href="#wl_openpathways.week_ending_date" title="Permanent link">🔗</a>
+    <code>date</code>
+  </dt>
+  <dd markdown="block">
+The Sunday of the week that the pathway relates to
+
+  </dd>
+</div>
+
+  </dl>
+</div>
+
+
+<p class="dimension-indicator"><code>many rows per patient</code></p>
+## wl_openpathways_raw
+
+National Waiting List Open Pathways
+
+Unlike [`wl_openpathways`](#wl_openpathways),
+the columns in this table have the same data types as the columns in [the associated
+database table][wl_openpathways_raw_1]. The three "pseudo" columns are small
+exceptions, as they are converted from binary columns to string columns.
+
+[wl_openpathways_raw_1]: https://reports.opensafely.org/reports/opensafely-tpp-database-schema/#WL_OpenPathways
+<div markdown="block" class="definition-list-wrapper">
+  <div class="title">Columns</div>
+  <dl markdown="block">
+<div markdown="block">
+  <dt id="wl_openpathways_raw.activity_treatment_function_code">
+    <strong>activity_treatment_function_code</strong>
+    <a class="headerlink" href="#wl_openpathways_raw.activity_treatment_function_code" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="wl_openpathways_raw.current_pathway_period_start_date">
+    <strong>current_pathway_period_start_date</strong>
+    <a class="headerlink" href="#wl_openpathways_raw.current_pathway_period_start_date" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="wl_openpathways_raw.priority_type_code">
+    <strong>priority_type_code</strong>
+    <a class="headerlink" href="#wl_openpathways_raw.priority_type_code" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="wl_openpathways_raw.pseudo_organisation_code_patient_pathway_identifier_issuer">
+    <strong>pseudo_organisation_code_patient_pathway_identifier_issuer</strong>
+    <a class="headerlink" href="#wl_openpathways_raw.pseudo_organisation_code_patient_pathway_identifier_issuer" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="wl_openpathways_raw.pseudo_patient_pathway_identifier">
+    <strong>pseudo_patient_pathway_identifier</strong>
+    <a class="headerlink" href="#wl_openpathways_raw.pseudo_patient_pathway_identifier" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="wl_openpathways_raw.pseudo_referral_identifier">
+    <strong>pseudo_referral_identifier</strong>
+    <a class="headerlink" href="#wl_openpathways_raw.pseudo_referral_identifier" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="wl_openpathways_raw.referral_request_received_date">
+    <strong>referral_request_received_date</strong>
+    <a class="headerlink" href="#wl_openpathways_raw.referral_request_received_date" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="wl_openpathways_raw.referral_to_treatment_period_end_date">
+    <strong>referral_to_treatment_period_end_date</strong>
+    <a class="headerlink" href="#wl_openpathways_raw.referral_to_treatment_period_end_date" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="wl_openpathways_raw.referral_to_treatment_period_start_date">
+    <strong>referral_to_treatment_period_start_date</strong>
+    <a class="headerlink" href="#wl_openpathways_raw.referral_to_treatment_period_start_date" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="wl_openpathways_raw.source_of_referral">
+    <strong>source_of_referral</strong>
+    <a class="headerlink" href="#wl_openpathways_raw.source_of_referral" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="wl_openpathways_raw.waiting_list_type">
+    <strong>waiting_list_type</strong>
+    <a class="headerlink" href="#wl_openpathways_raw.waiting_list_type" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="wl_openpathways_raw.week_ending_date">
+    <strong>week_ending_date</strong>
+    <a class="headerlink" href="#wl_openpathways_raw.week_ending_date" title="Permanent link">🔗</a>
     <code>string</code>
   </dt>
   <dd markdown="block">

--- a/ehrql/backends/tpp.py
+++ b/ehrql/backends/tpp.py
@@ -535,3 +535,35 @@ class TPPBackend(SQLBackend):
             ON vax.VaccinationName_ID = ref.VaccinationName_ID
         """
     )
+
+    wl_clockstops_raw = QueryTable(
+        # columns passed to CONVERT are likely to contain sha256 hashes
+        """
+            SELECT
+                Patient_ID AS patient_id,
+                ACTIVITY_TREATMENT_FUNCTION_CODE AS activity_treatment_function_code,
+                PRIORITY_TYPE_CODE AS priority_type_code,
+                CONVERT(
+                    varchar(max),
+                    PSEUDO_ORGANISATION_CODE_PATIENT_PATHWAY_IDENTIFIER_ISSUER,
+                    2
+                ) AS pseudo_organisation_code_patient_pathway_identifier_issuer,
+                CONVERT(
+                    varchar(max),
+                    PSEUDO_PATIENT_PATHWAY_IDENTIFIER,
+                    2
+                ) AS pseudo_patient_pathway_identifier,
+                CONVERT(
+                    varchar(max),
+                    Pseudo_Referral_Identifier,
+                    2
+                ) AS pseudo_referral_identifier,
+                Referral_Request_Received_Date AS referral_request_received_date,
+                REFERRAL_TO_TREATMENT_PERIOD_END_DATE AS referral_to_treatment_period_end_date,
+                REFERRAL_TO_TREATMENT_PERIOD_START_DATE AS referral_to_treatment_period_start_date,
+                SOURCE_OF_REFERRAL_FOR_OUTPATIENTS AS source_of_referral_for_outpatients,
+                Waiting_List_Type AS waiting_list_type,
+                Week_Ending_Date AS week_ending_date
+            FROM WL_ClockStops
+        """
+    )

--- a/ehrql/backends/tpp.py
+++ b/ehrql/backends/tpp.py
@@ -635,3 +635,43 @@ class TPPBackend(SQLBackend):
             FROM WL_OpenPathways
         """
     )
+
+    wl_openpathways = QueryTable(
+        """
+            SELECT
+                Patient_ID AS patient_id,
+                ACTIVITY_TREATMENT_FUNCTION_CODE AS activity_treatment_function_code,
+                CONVERT(DATE, Current_Pathway_Period_Start_Date, 23) AS current_pathway_period_start_date,
+                CASE PRIORITY_TYPE_CODE
+                    WHEN '1' THEN 'routine'
+                    WHEN '2' THEN 'urgent'
+                    WHEN '3' THEN 'two week wait'
+                END AS priority_type_code,
+                CONVERT(
+                    varchar(max),
+                    PSEUDO_ORGANISATION_CODE_PATIENT_PATHWAY_IDENTIFIER_ISSUER,
+                    2
+                ) AS pseudo_organisation_code_patient_pathway_identifier_issuer,
+                CONVERT(
+                    varchar(max),
+                    PSEUDO_PATIENT_PATHWAY_IDENTIFIER,
+                    2
+                ) AS pseudo_patient_pathway_identifier,
+                CONVERT(
+                    varchar(max),
+                    Pseudo_Referral_Identifier,
+                    2
+                ) AS pseudo_referral_identifier,
+                CONVERT(DATE, REFERRAL_REQUEST_RECEIVED_DATE, 23) AS referral_request_received_date,
+                CONVERT(
+                    DATE,
+                    NULLIF(REFERRAL_TO_TREATMENT_PERIOD_END_DATE, '9999-12-31'),
+                    23
+                ) AS referral_to_treatment_period_end_date,
+                CONVERT(DATE, REFERRAL_TO_TREATMENT_PERIOD_START_DATE, 23) AS referral_to_treatment_period_start_date,
+                SOURCE_OF_REFERRAL AS source_of_referral,
+                NULLIF(Waiting_List_Type, 'NULL') AS waiting_list_type,
+                CONVERT(DATE, Week_Ending_Date, 23) AS week_ending_date
+            FROM WL_OpenPathways
+        """
+    )

--- a/ehrql/backends/tpp.py
+++ b/ehrql/backends/tpp.py
@@ -567,3 +567,38 @@ class TPPBackend(SQLBackend):
             FROM WL_ClockStops
         """
     )
+
+    wl_clockstops = QueryTable(
+        """
+            SELECT
+                Patient_ID AS patient_id,
+                ACTIVITY_TREATMENT_FUNCTION_CODE AS activity_treatment_function_code,
+                CASE PRIORITY_TYPE_CODE
+                    WHEN '1' THEN 'routine'
+                    WHEN '2' THEN 'urgent'
+                    WHEN '3' THEN 'two week wait'
+                END AS priority_type_code,
+                CONVERT(
+                    varchar(max),
+                    PSEUDO_ORGANISATION_CODE_PATIENT_PATHWAY_IDENTIFIER_ISSUER,
+                    2
+                ) AS pseudo_organisation_code_patient_pathway_identifier_issuer,
+                CONVERT(
+                    varchar(max),
+                    PSEUDO_PATIENT_PATHWAY_IDENTIFIER,
+                    2
+                ) AS pseudo_patient_pathway_identifier,
+                CONVERT(
+                    varchar(max),
+                    Pseudo_Referral_Identifier,
+                    2
+                ) AS pseudo_referral_identifier,
+                CONVERT(DATE, Referral_Request_Received_Date, 23) AS referral_request_received_date,
+                CONVERT(DATE, REFERRAL_TO_TREATMENT_PERIOD_END_DATE, 23) AS referral_to_treatment_period_end_date,
+                CONVERT(DATE, REFERRAL_TO_TREATMENT_PERIOD_START_DATE, 23) AS referral_to_treatment_period_start_date,
+                SOURCE_OF_REFERRAL_FOR_OUTPATIENTS AS source_of_referral_for_outpatients,
+                NULLIF(Waiting_List_Type, 'NULL') AS waiting_list_type,
+                CONVERT(DATE, Week_Ending_Date, 23) AS week_ending_date
+            FROM WL_ClockStops
+        """
+    )

--- a/ehrql/backends/tpp.py
+++ b/ehrql/backends/tpp.py
@@ -602,3 +602,36 @@ class TPPBackend(SQLBackend):
             FROM WL_ClockStops
         """
     )
+
+    wl_openpathways_raw = QueryTable(
+        # columns passed to CONVERT are likely to contain sha256 hashes
+        """
+            SELECT
+                Patient_ID AS patient_id,
+                ACTIVITY_TREATMENT_FUNCTION_CODE AS activity_treatment_function_code,
+                Current_Pathway_Period_Start_Date AS current_pathway_period_start_date,
+                PRIORITY_TYPE_CODE AS priority_type_code,
+                CONVERT(
+                    varchar(max),
+                    PSEUDO_ORGANISATION_CODE_PATIENT_PATHWAY_IDENTIFIER_ISSUER,
+                    2
+                ) AS pseudo_organisation_code_patient_pathway_identifier_issuer,
+                CONVERT(
+                    varchar(max),
+                    PSEUDO_PATIENT_PATHWAY_IDENTIFIER,
+                    2
+                ) AS pseudo_patient_pathway_identifier,
+                CONVERT(
+                    varchar(max),
+                    Pseudo_Referral_Identifier,
+                    2
+                ) AS pseudo_referral_identifier,
+                REFERRAL_REQUEST_RECEIVED_DATE AS referral_request_received_date,
+                REFERRAL_TO_TREATMENT_PERIOD_END_DATE AS referral_to_treatment_period_end_date,
+                REFERRAL_TO_TREATMENT_PERIOD_START_DATE AS referral_to_treatment_period_start_date,
+                SOURCE_OF_REFERRAL AS source_of_referral,
+                Waiting_List_Type AS waiting_list_type,
+                Week_Ending_Date AS week_ending_date
+            FROM WL_OpenPathways
+        """
+    )

--- a/ehrql/tables/beta/tpp.py
+++ b/ehrql/tables/beta/tpp.py
@@ -37,6 +37,7 @@ __all__ = [
     "vaccinations",
     "wl_clockstops",
     "wl_clockstops_raw",
+    "wl_openpathways",
     "wl_openpathways_raw",
 ]
 
@@ -990,3 +991,81 @@ class wl_openpathways_raw(EventFrame):
     source_of_referral = Series(str)
     waiting_list_type = Series(str)
     week_ending_date = Series(str)
+
+
+@table
+class wl_openpathways(EventFrame):
+    """
+    National Waiting List Open Pathways
+
+    This dataset contains all people on open (incomplete) RTT or not current RTT (non-RTT) pathways as of May 2022.
+    It is a snapshot of everyone still awaiting treatment as of May 2022 (i.e., the clock hasn't stopped).
+    Patients referred for non-emergency consultant-led treatment are on RTT pathways,
+    while patients referred for non-consultant-led treatment are on non-RTT pathways.
+    For each pathway, there is one row for every week that the patient is still waiting.
+    Because referral identifiers aren't necessarily unique between hospitals,
+    unique RTT pathways can be identified using a combination of:
+
+    * `pseudo_organisation_code_patient_pathway_identifier_issuer`
+    * `pseudo_patient_pathway_identifier`
+    * `pseudo_referral_identifier`
+    * `referral_to_treatment_period_start_date`
+
+
+    For more information, see
+    "[Consultant-led Referral to Treatment Waiting Times Rules and Guidance][wl_openpathways_1]".
+
+    [wl_openpathways_1]: https://www.england.nhs.uk/statistics/statistical-work-areas/rtt-waiting-times/rtt-guidance/
+    """
+
+    activity_treatment_function_code = Series(
+        str,
+        description="The treatment function",
+        constraints=[Constraint.Regex(r"[a-zA-Z0-9]{3}")],
+    )
+    current_pathway_period_start_date = Series(
+        datetime.date,
+        description="Latest clock start for this pathway period",
+    )
+    priority_type_code = Series(
+        str,
+        description="The priority type",
+        constraints=[Constraint.Categorical(["routine", "urgent", "two week wait"])],
+    )
+    pseudo_organisation_code_patient_pathway_identifier_issuer = Series(str)
+    pseudo_patient_pathway_identifier = Series(str)
+    pseudo_referral_identifier = Series(str)
+    referral_request_received_date = Series(
+        datetime.date,
+        description=(
+            "The date the referral was received, "
+            "for the referral that started the original pathway"
+        ),
+    )
+    referral_to_treatment_period_end_date = Series(
+        datetime.date,
+        description="If the pathway is open, then `NULL`",
+    )
+    referral_to_treatment_period_start_date = Series(
+        datetime.date,
+        description=(
+            "Latest clock start for this pathway. "
+            "If the pathway is not a current pathway, then `NULL`."
+        ),
+    )
+    source_of_referral = Series(
+        str,
+        description=(
+            "National referral source code "
+            "for the referral that created the original pathway"
+        ),
+        constraints=[Constraint.Regex(r"[a-zA-Z0-9]{2}")],
+    )
+    waiting_list_type = Series(
+        str,
+        constraints=[Constraint.Categorical(["ORTT", "IRTT", "ONON", "INON"])],
+    )
+    week_ending_date = Series(
+        datetime.date,
+        description="The Sunday of the week that the pathway relates to",
+    )

--- a/ehrql/tables/beta/tpp.py
+++ b/ehrql/tables/beta/tpp.py
@@ -37,6 +37,7 @@ __all__ = [
     "vaccinations",
     "wl_clockstops",
     "wl_clockstops_raw",
+    "wl_openpathways_raw",
 ]
 
 
@@ -872,7 +873,8 @@ class wl_clockstops_raw(EventFrame):
     """
     National Waiting List Clock Stops
 
-    The columns in this table have the same data types as the columns in [the associated
+    Unlike [`wl_clockstops`](#wl_clockstops),
+    the columns in this table have the same data types as the columns in [the associated
     database table][wl_clockstops_raw_1]. The three "pseudo" columns are small
     exceptions, as they are converted from binary columns to string columns.
 
@@ -961,3 +963,30 @@ class wl_clockstops(EventFrame):
         datetime.date,
         description="The Sunday of the week that the pathway relates to",
     )
+
+
+@table
+class wl_openpathways_raw(EventFrame):
+    """
+    National Waiting List Open Pathways
+
+    Unlike [`wl_openpathways`](#wl_openpathways),
+    the columns in this table have the same data types as the columns in [the associated
+    database table][wl_openpathways_raw_1]. The three "pseudo" columns are small
+    exceptions, as they are converted from binary columns to string columns.
+
+    [wl_openpathways_raw_1]: https://reports.opensafely.org/reports/opensafely-tpp-database-schema/#WL_OpenPathways
+    """
+
+    activity_treatment_function_code = Series(str)
+    current_pathway_period_start_date = Series(str)
+    priority_type_code = Series(str)
+    pseudo_organisation_code_patient_pathway_identifier_issuer = Series(str)
+    pseudo_patient_pathway_identifier = Series(str)
+    pseudo_referral_identifier = Series(str)
+    referral_request_received_date = Series(str)
+    referral_to_treatment_period_end_date = Series(str)
+    referral_to_treatment_period_start_date = Series(str)
+    source_of_referral = Series(str)
+    waiting_list_type = Series(str)
+    week_ending_date = Series(str)

--- a/ehrql/tables/beta/tpp.py
+++ b/ehrql/tables/beta/tpp.py
@@ -35,6 +35,7 @@ __all__ = [
     "practice_registrations",
     "sgss_covid_all_tests",
     "vaccinations",
+    "wl_clockstops",
     "wl_clockstops_raw",
 ]
 
@@ -889,3 +890,74 @@ class wl_clockstops_raw(EventFrame):
     source_of_referral_for_outpatients = Series(str)
     waiting_list_type = Series(str)
     week_ending_date = Series(str)
+
+
+@table
+class wl_clockstops(EventFrame):
+    """
+    National Waiting List Clock Stops
+
+    This dataset contains all completed referral-to-treatment (RTT) pathways with a "clock stop" date between May 2021 and May 2022.
+    Patients referred for non-emergency consultant-led treatment are on RTT pathways.
+    The "clock start" date is the date of the first referral that starts the pathway.
+    The "clock stop" date is when the patient either: receives treatment;
+    declines treatment;
+    enters a period of active monitoring;
+    no longer requires treatment;
+    or dies.
+    The time spent waiting is the difference in these two dates.
+
+    A patient may have multiple rows if they have multiple completed RTT pathways;
+    however, there is only one row per unique pathway.
+    Because referral identifiers aren't necessarily unique between hospitals,
+    unique RTT pathways can be identified using a combination of:
+
+    * `pseudo_organisation_code_patient_pathway_identifier_issuer`
+    * `pseudo_patient_pathway_identifier`
+    * `pseudo_referral_identifier`
+    * `referral_to_treatment_period_start_date`
+
+    For more information, see
+    "[Consultant-led Referral to Treatment Waiting Times Rules and Guidance][wl_clockstops_1]".
+
+    [wl_clockstops_1]: https://www.england.nhs.uk/statistics/statistical-work-areas/rtt-waiting-times/rtt-guidance/
+    """
+
+    activity_treatment_function_code = Series(
+        str,
+        description="The treatment function",
+        constraints=[Constraint.Regex(r"[a-zA-Z0-9]{3}")],
+    )
+    priority_type_code = Series(
+        str,
+        description="The priority type",
+        constraints=[Constraint.Categorical(["routine", "urgent", "two week wait"])],
+    )
+    pseudo_organisation_code_patient_pathway_identifier_issuer = Series(str)
+    pseudo_patient_pathway_identifier = Series(str)
+    pseudo_referral_identifier = Series(str)
+    referral_request_received_date = Series(
+        datetime.date,
+        description=(
+            "The date the referral was received, "
+            "for the referral that started the original pathway"
+        ),
+    )
+    referral_to_treatment_period_end_date = Series(
+        datetime.date,
+        description="Clock stop for the completed pathway",
+    )
+    referral_to_treatment_period_start_date = Series(
+        datetime.date,
+        description="Clock start for the completed pathway",
+    )
+    source_of_referral_for_outpatients = Series(str)
+    waiting_list_type = Series(
+        str,
+        description="The waiting list type on completion of the pathway",
+        constraints=[Constraint.Categorical(["ORTT", "IRTT"])],
+    )
+    week_ending_date = Series(
+        datetime.date,
+        description="The Sunday of the week that the pathway relates to",
+    )

--- a/ehrql/tables/beta/tpp.py
+++ b/ehrql/tables/beta/tpp.py
@@ -35,6 +35,7 @@ __all__ = [
     "practice_registrations",
     "sgss_covid_all_tests",
     "vaccinations",
+    "wl_clockstops_raw",
 ]
 
 
@@ -863,3 +864,28 @@ class vaccinations(EventFrame):
     date = Series(datetime.date)
     target_disease = Series(str)
     product_name = Series(str)
+
+
+@table
+class wl_clockstops_raw(EventFrame):
+    """
+    National Waiting List Clock Stops
+
+    The columns in this table have the same data types as the columns in [the associated
+    database table][wl_clockstops_raw_1]. The three "pseudo" columns are small
+    exceptions, as they are converted from binary columns to string columns.
+
+    [wl_clockstops_raw_1]: https://reports.opensafely.org/reports/opensafely-tpp-database-schema/#WL_ClockStops
+    """
+
+    activity_treatment_function_code = Series(str)
+    priority_type_code = Series(str)
+    pseudo_organisation_code_patient_pathway_identifier_issuer = Series(str)
+    pseudo_patient_pathway_identifier = Series(str)
+    pseudo_referral_identifier = Series(str)
+    referral_request_received_date = Series(str)
+    referral_to_treatment_period_end_date = Series(str)
+    referral_to_treatment_period_start_date = Series(str)
+    source_of_referral_for_outpatients = Series(str)
+    waiting_list_type = Series(str)
+    week_ending_date = Series(str)

--- a/tests/integration/backends/test_tpp.py
+++ b/tests/integration/backends/test_tpp.py
@@ -1392,6 +1392,47 @@ def test_wl_openpathways_raw(select_all):
     ]
 
 
+@register_test_for(tpp.wl_openpathways)
+def test_wl_openpathways(select_all):
+    results = select_all(
+        Patient(Patient_ID=1),
+        WL_OpenPathways(
+            Patient_ID=1,
+            ACTIVITY_TREATMENT_FUNCTION_CODE="110",
+            Current_Pathway_Period_Start_Date="2024-03-02",
+            PRIORITY_TYPE_CODE="2",
+            PSEUDO_ORGANISATION_CODE_PATIENT_PATHWAY_IDENTIFIER_ISSUER=sha256_digest(1),
+            PSEUDO_PATIENT_PATHWAY_IDENTIFIER=sha256_digest(1),
+            Pseudo_Referral_Identifier=sha256_digest(1),
+            REFERRAL_REQUEST_RECEIVED_DATE="2023-02-01",
+            REFERRAL_TO_TREATMENT_PERIOD_END_DATE="9999-12-31",
+            REFERRAL_TO_TREATMENT_PERIOD_START_DATE="2024-03-02",
+            SOURCE_OF_REFERRAL="",
+            Waiting_List_Type="IRTT",
+            Week_Ending_Date="2024-03-03",
+        ),
+    )
+    assert results == [
+        {
+            "patient_id": 1,
+            "activity_treatment_function_code": "110",
+            "current_pathway_period_start_date": date(2024, 3, 2),
+            "priority_type_code": "urgent",
+            "pseudo_organisation_code_patient_pathway_identifier_issuer": to_hex(
+                sha256_digest(1)
+            ),
+            "pseudo_patient_pathway_identifier": to_hex(sha256_digest(1)),
+            "pseudo_referral_identifier": to_hex(sha256_digest(1)),
+            "referral_request_received_date": date(2023, 2, 1),
+            "referral_to_treatment_period_end_date": None,
+            "referral_to_treatment_period_start_date": date(2024, 3, 2),
+            "source_of_referral": "",
+            "waiting_list_type": "IRTT",
+            "week_ending_date": date(2024, 3, 3),
+        }
+    ]
+
+
 def test_registered_tests_are_exhaustive():
     for name, table in vars(tpp).items():
         if not isinstance(table, BaseFrame):

--- a/tests/integration/backends/test_tpp.py
+++ b/tests/integration/backends/test_tpp.py
@@ -40,6 +40,7 @@ from tests.lib.tpp_schema import (
     Vaccination,
     VaccinationReference,
     WL_ClockStops,
+    WL_OpenPathways,
 )
 
 
@@ -1346,6 +1347,47 @@ def test_wl_clockstops(select_all):
             "source_of_referral_for_outpatients": "",
             "waiting_list_type": "ORTT",
             "week_ending_date": date(2024, 3, 3),
+        }
+    ]
+
+
+@register_test_for(tpp.wl_openpathways_raw)
+def test_wl_openpathways_raw(select_all):
+    results = select_all(
+        Patient(Patient_ID=1),
+        WL_OpenPathways(
+            Patient_ID=1,
+            ACTIVITY_TREATMENT_FUNCTION_CODE="110",
+            Current_Pathway_Period_Start_Date="2024-03-02",
+            PRIORITY_TYPE_CODE="2",
+            PSEUDO_ORGANISATION_CODE_PATIENT_PATHWAY_IDENTIFIER_ISSUER=sha256_digest(1),
+            PSEUDO_PATIENT_PATHWAY_IDENTIFIER=sha256_digest(1),
+            Pseudo_Referral_Identifier=sha256_digest(1),
+            REFERRAL_REQUEST_RECEIVED_DATE="2023-02-01",
+            REFERRAL_TO_TREATMENT_PERIOD_END_DATE="9999-12-31",
+            REFERRAL_TO_TREATMENT_PERIOD_START_DATE="2024-03-02",
+            SOURCE_OF_REFERRAL="",
+            Waiting_List_Type="IRTT",
+            Week_Ending_Date="2024-03-03",
+        ),
+    )
+    assert results == [
+        {
+            "patient_id": 1,
+            "activity_treatment_function_code": "110",
+            "current_pathway_period_start_date": "2024-03-02",
+            "priority_type_code": "2",
+            "pseudo_organisation_code_patient_pathway_identifier_issuer": to_hex(
+                sha256_digest(1)
+            ),
+            "pseudo_patient_pathway_identifier": to_hex(sha256_digest(1)),
+            "pseudo_referral_identifier": to_hex(sha256_digest(1)),
+            "referral_request_received_date": "2023-02-01",
+            "referral_to_treatment_period_end_date": "9999-12-31",
+            "referral_to_treatment_period_start_date": "2024-03-02",
+            "source_of_referral": "",
+            "waiting_list_type": "IRTT",
+            "week_ending_date": "2024-03-03",
         }
     ]
 

--- a/tests/integration/backends/test_tpp.py
+++ b/tests/integration/backends/test_tpp.py
@@ -1,3 +1,4 @@
+import hashlib
 from datetime import date
 
 import pytest
@@ -38,6 +39,7 @@ from tests.lib.tpp_schema import (
     SGSS_AllTests_Positive,
     Vaccination,
     VaccinationReference,
+    WL_ClockStops,
 )
 
 
@@ -1259,6 +1261,53 @@ def test_vaccinations(select_all):
             "target_disease": "bar",
             "product_name": "baz",
         },
+    ]
+
+
+def sha256_digest(int_):
+    return hashlib.sha256(int_.to_bytes()).digest()
+
+
+def to_hex(bytes_):
+    return bytes_.hex().upper()
+
+
+@register_test_for(tpp.wl_clockstops_raw)
+def test_wl_clockstops_raw(select_all):
+    results = select_all(
+        Patient(Patient_ID=1),
+        WL_ClockStops(
+            Patient_ID=1,
+            ACTIVITY_TREATMENT_FUNCTION_CODE="110",
+            PRIORITY_TYPE_CODE="1",
+            PSEUDO_ORGANISATION_CODE_PATIENT_PATHWAY_IDENTIFIER_ISSUER=sha256_digest(1),
+            PSEUDO_PATIENT_PATHWAY_IDENTIFIER=sha256_digest(1),
+            Pseudo_Referral_Identifier=sha256_digest(1),
+            Referral_Request_Received_Date="2023-02-01",
+            REFERRAL_TO_TREATMENT_PERIOD_END_DATE="2025-04-03",
+            REFERRAL_TO_TREATMENT_PERIOD_START_DATE="2024-03-02",
+            SOURCE_OF_REFERRAL_FOR_OUTPATIENTS="",
+            Waiting_List_Type="ORTT",
+            Week_Ending_Date="2024-03-03",
+        ),
+    )
+    assert results == [
+        {
+            "patient_id": 1,
+            "activity_treatment_function_code": "110",
+            "priority_type_code": "1",
+            "pseudo_organisation_code_patient_pathway_identifier_issuer": to_hex(
+                sha256_digest(1)
+            ),
+            "pseudo_patient_pathway_identifier": to_hex(sha256_digest(1)),
+            "pseudo_referral_identifier": to_hex(sha256_digest(1)),
+            "referral_request_received_date": "2023-02-01",
+            "referral_to_treatment_period_end_date": "2025-04-03",
+            "referral_to_treatment_period_start_date": "2024-03-02",
+            "source_of_referral_for_outpatients": "",
+            "waiting_list_type": "ORTT",
+            "week_ending_date": "2024-03-03",
+        }
     ]
 
 

--- a/tests/integration/backends/test_tpp.py
+++ b/tests/integration/backends/test_tpp.py
@@ -1311,6 +1311,45 @@ def test_wl_clockstops_raw(select_all):
     ]
 
 
+@register_test_for(tpp.wl_clockstops)
+def test_wl_clockstops(select_all):
+    results = select_all(
+        Patient(Patient_ID=1),
+        WL_ClockStops(
+            Patient_ID=1,
+            ACTIVITY_TREATMENT_FUNCTION_CODE="110",
+            PRIORITY_TYPE_CODE="1",
+            PSEUDO_ORGANISATION_CODE_PATIENT_PATHWAY_IDENTIFIER_ISSUER=sha256_digest(1),
+            PSEUDO_PATIENT_PATHWAY_IDENTIFIER=sha256_digest(1),
+            Pseudo_Referral_Identifier=sha256_digest(1),
+            Referral_Request_Received_Date="2023-02-01",
+            REFERRAL_TO_TREATMENT_PERIOD_END_DATE="2025-04-03",
+            REFERRAL_TO_TREATMENT_PERIOD_START_DATE="2024-03-02",
+            SOURCE_OF_REFERRAL_FOR_OUTPATIENTS="",
+            Waiting_List_Type="ORTT",
+            Week_Ending_Date="2024-03-03",
+        ),
+    )
+    assert results == [
+        {
+            "patient_id": 1,
+            "activity_treatment_function_code": "110",
+            "priority_type_code": "routine",
+            "pseudo_organisation_code_patient_pathway_identifier_issuer": to_hex(
+                sha256_digest(1)
+            ),
+            "pseudo_patient_pathway_identifier": to_hex(sha256_digest(1)),
+            "pseudo_referral_identifier": to_hex(sha256_digest(1)),
+            "referral_request_received_date": date(2023, 2, 1),
+            "referral_to_treatment_period_end_date": date(2025, 4, 3),
+            "referral_to_treatment_period_start_date": date(2024, 3, 2),
+            "source_of_referral_for_outpatients": "",
+            "waiting_list_type": "ORTT",
+            "week_ending_date": date(2024, 3, 3),
+        }
+    ]
+
+
 def test_registered_tests_are_exhaustive():
     for name, table in vars(tpp).items():
         if not isinstance(table, BaseFrame):


### PR DESCRIPTION
This adds the database table `WL_Clockstops` as the ehrQL tables `wl_clockstops_raw` and `wl_clockstops`, and the database table `WL_OpenPathways` as the ehrQL tables `wl_openpathways_raw` and `wl_openpathways`.

The raw ehrQL tables should help researchers understand the structure and semantics of the database tables (i.e. undertake _data development_). I've added their corresponding backend tables as instances of `QueryTable` rather than `MappedTable`, because the database tables contain binary columns that must be converted to string columns using custom SQL.

If we treat `wl_clockstops` as a view, then filtering each of the date columns in turn for rows that fall within a range takes from roughly 40ms to roughly 500ms. Adding another filter, such as also filtering by `priority_type_code`, takes from roughly 100ms to 1500ms. If we treat `wl_openpathways` as a view, then similar queries take about 500ms longer, possibly because many values of `wl_openpathways.current_pathway_period_start_date` are `NULL`.

I've added the constraints using the information in National Waiting List Dataset Submission v12.[^1] The categorical constraints on `priority_type_code` and `waiting_list_type` are especially useful, as they ensure that the dummy data are more realistic. As @alschaffer notes, however, in the real tables around 10% of values in each of these columns do not match the categorical constraints. Consequently, these values will be missing (`NULL`) in a real dataset.

You can find the rendered documentation at <https://iaindillingham-add-nhse-wl.databuilder.pages.dev/reference/schemas/beta.tpp/#wl_clockstops>. Thanks for your help documenting the ehrQL tables, @alschaffer.

---

~I used the National Waiting List Dataset Submission v12[^1] to help document the columns. However, I'm still unclear what Clock Stops and Open Pathways are. Could you help me describe the ehrQL tables, @alschaffer? Are there URLs to these datasets that I could add to the documentation?~

~I haven't been able to test the performance characteristics of the cooked ehrQL tables, because I cannot connect to the VPN.[^2] However, when I can, I will. Similarly, I haven't been able to check that the constraints reflect the data, rather than the documentation.~

[^1]: https://bennettoxford.slack.com/archives/C02HJTL065A/p1697015782102079?thread_ts=1694531849.195469&cid=C02HJTL065A
[^2]: https://bennettoxford.slack.com/archives/C010SJ89SA3/p1696602442369059