### PR TITLE
fix: Always validate categorical data in user-provided arrow dummy dataset

### DIFF
--- a/ehrql/file_formats/arrow.py
+++ b/ehrql/file_formats/arrow.py
@@ -204,8 +204,13 @@ class ArrowDatasetReader(BaseDatasetReader):
                 f"Type mismatch in column '{name}': "
                 f"expected {spec.type}, got {column.type}"
             )
-        if pyarrow.types.is_dictionary(column.type) and spec.categories is not None:
-            column_categories = column.dictionary.to_pylist()
+        if spec.categories is not None:
+            if pyarrow.types.is_dictionary(column.type):
+                column_categories = column.dictionary.to_pylist()
+            else:
+                column_categories = sorted(
+                    {v for v in column.to_pylist() if v is not None}
+                )
             unexpected_categories = set(column_categories) - set(spec.categories)
             if unexpected_categories:
                 return (

--- a/tests/integration/test_file_formats.py
+++ b/tests/integration/test_file_formats.py
@@ -142,6 +142,28 @@ def test_read_dataset_validates_categories(test_file):
         read_dataset(test_file, column_specs)
 
 
+def test_read_dataset_validates_categories_on_non_categorical_column(test_file):
+    # This tests that categories are validated even if an arrow column is not
+    # categorical. This is relevant if a user provides their own dummy dataset without
+    # making the columns categorical.
+
+    if test_file.suffix != ".arrow":
+        pytest.skip("only relevant for arrow files")
+
+    # Create a copy of the column specs with modified column categories
+    column_specs = TEST_FILE_SPECS.copy()
+    column_specs["s"] = ColumnSpec(str, categories=("X", "Y"))
+
+    error = (
+        "Unexpected categories in column 's'\n"
+        "  Categories: a, b\n"
+        "  Expected: X, Y"
+    )
+
+    with pytest.raises(ValidationError, match=error):
+        read_dataset(test_file, column_specs)
+
+
 def test_read_dataset_accepts_subset_of_expected_categories(test_file):
     # Create a copy of the column specs with an extra category on the categorical column
     # and the categories in a different order


### PR DESCRIPTION
When a user provides their own dummy dataset, we read it in and then write it out again.  If a dataset variable is categorical, and if the dataset is written out to an arrow file, an error will be thrown by pyarrow if the corresponding column contains unexpected values.

As such, when we read in a user's dummy dataset from an arrow file, we need to validate that the values in a categorical column are in the set of expected values, even if pyarrow does not think that the column is categorical.