### PR TITLE
fix: Make min/max functions require at least two args

### DIFF
--- a/docs/includes/generated_docs/language__functions.md
+++ b/docs/includes/generated_docs/language__functions.md
@@ -44,7 +44,7 @@ category = when(size < 15).then("small").otherwise("large")
 
 
 <h4 class="attr-heading" id="maximum_of" data-toc-label="maximum_of" markdown>
-  <tt><strong>maximum_of</strong>(<em>*args</em>)</tt>
+  <tt><strong>maximum_of</strong>(<em>value</em>, <em>other_value</em>, <em>*other_values</em>)</tt>
 </h4>
 <div markdown="block" class="indent">
 Return the maximum value of a collection of Series or Values, disregarding NULLs
@@ -58,7 +58,7 @@ latest_event_date = maximum_of(event_series_1.date, event_series_2.date, "2001-0
 
 
 <h4 class="attr-heading" id="minimum_of" data-toc-label="minimum_of" markdown>
-  <tt><strong>minimum_of</strong>(<em>*args</em>)</tt>
+  <tt><strong>minimum_of</strong>(<em>value</em>, <em>other_value</em>, <em>*other_values</em>)</tt>
 </h4>
 <div markdown="block" class="indent">
 Return the minimum value of a collection of Series or Values, disregarding NULLs

--- a/docs/includes/generated_docs/specs.md
+++ b/docs/includes/generated_docs/specs.md
@@ -1752,52 +1752,6 @@ returns the following patient series:
 
 
 
-#### 6.5.20 Maximum of single value
-
-This example makes use of a patient-level table named `p` containing the following data:
-
-| patient|i1|i2|d1|d2|s1|s2|f1|f2 |
-| - | - | - | - | - | - | - | - | - |
-| 1|101|112|2001-01-01|2012-12-12|a|d|1.01|1.12 |
-| 2||211||2021-01-01||f||2.11 |
-| 3|||||||| |
-
-```python
-maximum_of(0)
-```
-returns the following patient series:
-
-| patient | value |
-| - | - |
-| 1|0 |
-| 2|0 |
-| 3|0 |
-
-
-
-#### 6.5.21 Minimum of single value
-
-This example makes use of a patient-level table named `p` containing the following data:
-
-| patient|i1|i2|d1|d2|s1|s2|f1|f2 |
-| - | - | - | - | - | - | - | - | - |
-| 1|101|112|2001-01-01|2012-12-12|a|d|1.01|1.12 |
-| 2||211||2021-01-01||f||2.11 |
-| 3|||||||| |
-
-```python
-minimum_of(0)
-```
-returns the following patient series:
-
-| patient | value |
-| - | - |
-| 1|0 |
-| 2|0 |
-| 3|0 |
-
-
-
 ### 6.6 Minimum and maximum aggregations across Event series
 
 

--- a/ehrql/query_language.py
+++ b/ehrql/query_language.py
@@ -1350,7 +1350,7 @@ def case(*when_thens, default=None):
 
 # HORIZONTAL AGGREGATION FUNCTIONS
 #
-def maximum_of(*args):
+def maximum_of(value, other_value, *other_values):
     """
     Return the maximum value of a collection of Series or Values, disregarding NULLs
 
@@ -1359,11 +1359,11 @@ def maximum_of(*args):
     latest_event_date = maximum_of(event_series_1.date, event_series_2.date, "2001-01-01")
     ```
     """
-    args = cast_all_arguments(args)
+    args = cast_all_arguments((value, other_value, *other_values))
     return _apply(qm.Function.MaximumOf, args)
 
 
-def minimum_of(*args):
+def minimum_of(value, other_value, *other_values):
     """
     Return the minimum value of a collection of Series or Values, disregarding NULLs
 
@@ -1372,5 +1372,5 @@ def minimum_of(*args):
     ealiest_event_date = minimum_of(event_series_1.date, event_series_2.date, "2001-01-01")
     ```
     """
-    args = cast_all_arguments(args)
+    args = cast_all_arguments((value, other_value, *other_values))
     return _apply(qm.Function.MinimumOf, args)

--- a/tests/spec/series_ops/test_maximum_of_and_minimum_of_patient_series.py
+++ b/tests/spec/series_ops/test_maximum_of_and_minimum_of_patient_series.py
@@ -244,27 +244,3 @@ def test_maximum_of_two_integers_all_a_values(spec_test):
             3: 3,
         },
     )
-
-
-def test_maximum_of_single_value(spec_test):
-    spec_test(
-        table_data,
-        maximum_of(0),
-        {
-            1: 0,
-            2: 0,
-            3: 0,
-        },
-    )
-
-
-def test_minimum_of_single_value(spec_test):
-    spec_test(
-        table_data,
-        minimum_of(0),
-        {
-            1: 0,
-            2: 0,
-            3: 0,
-        },
-    )


### PR DESCRIPTION
Previously the error message you got if you called them with no args was extremely cryptic. And calling them with a single arg is well-defined but pointless (it's a no-op) and so likely to be the result of confusion.

Closes #1508