### PR TITLE
Don't recompile requirements when installing

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -60,7 +60,7 @@ requirements-dev *args: requirements-prod
 
 
 # ensure prod requirements installed and up to date
-prodenv: requirements-prod
+prodenv: _virtualenv
     #!/usr/bin/env bash
     set -euo pipefail
 
@@ -75,7 +75,7 @@ prodenv: requirements-prod
 # a killer feature over Makefiles.
 #
 # ensure dev requirements installed and up to date
-devenv: prodenv requirements-dev && _install-precommit
+devenv: prodenv _virtualenv && _install-precommit
     #!/usr/bin/env bash
     set -euo pipefail
 


### PR DESCRIPTION
Because we use timestamps to test for modifications this ends up getting run all the time when rebasing or hopping between branches. Installing requirements only involves local operations and is generally very fast (especially when it's a no-op) but _compiling_ requirements requires talking to PyPI and can be intolerably slow.

And I think in any case this is the wrong behaviour: re-compiling requirements should be an explicit operation.

Further discussion here:
https://bennettoxford.slack.com/archives/C63UXGB8E/p1693556976925389