### PR TITLE
Replace ceiling dates in PatientAddress with NULL

### DIFF
--- a/ehrql/backends/tpp.py
+++ b/ehrql/backends/tpp.py
@@ -79,8 +79,8 @@ class TPPBackend(SQLBackend):
             SELECT
                 addr.Patient_ID AS patient_id,
                 addr.PatientAddress_ID AS address_id,
-                CAST(addr.StartDate AS date) AS start_date,
-                CAST(addr.EndDate AS date) AS end_date,
+                CAST(NULLIF(addr.StartDate, '9999-12-31T00:00:00') AS date) AS start_date,
+                CAST(NULLIF(addr.EndDate, '9999-12-31T00:00:00') AS date) AS end_date,
                 addr.AddressType AS address_type,
                 addr.RuralUrbanClassificationCode AS rural_urban_classification,
                 NULLIF(addr.ImdRankRounded, -1) AS imd_rounded,

--- a/tests/integration/backends/test_tpp.py
+++ b/tests/integration/backends/test_tpp.py
@@ -131,6 +131,16 @@ def test_addresses(select_all):
             LocationRequiresNursing="Y",
             LocationDoesNotRequireNursing="N",
         ),
+        PatientAddress(
+            Patient_ID=1,
+            PatientAddress_ID=5,
+            StartDate="9999-12-31T00:00:00",
+            EndDate="9999-12-31T00:00:00",
+            AddressType=3,
+            RuralUrbanClassificationCode=4,
+            ImdRankRounded=1000,
+            MSOACode="NPC",
+        ),
     )
     assert results == [
         {
@@ -174,6 +184,20 @@ def test_addresses(select_all):
             "care_home_is_potential_match": True,
             "care_home_requires_nursing": True,
             "care_home_does_not_require_nursing": False,
+        },
+        {
+            "patient_id": 1,
+            "address_id": 5,
+            "start_date": None,
+            "end_date": None,
+            "address_type": 3,
+            "rural_urban_classification": 4,
+            "imd_rounded": 1000,
+            "msoa_code": None,
+            "has_postcode": False,
+            "care_home_is_potential_match": False,
+            "care_home_requires_nursing": None,
+            "care_home_does_not_require_nursing": None,
         },
     ]
 


### PR DESCRIPTION
Replace ceiling `start_date` and `end_date` in PatientAddress table with `NULL`.

As described in [this](https://github.com/opensafely-core/ehrql/issues/1668#issuecomment-1795200793) comment, this change should not impact the results of existing studies

Closes #1668 