### PR TITLE
Support large codelists

### DIFF
--- a/ehrql/query_engines/base_sql.py
+++ b/ehrql/query_engines/base_sql.py
@@ -621,9 +621,9 @@ class BaseSQLQueryEngine(BaseQueryEngine):
             sqlalchemy.Column(name, type_from_python_type(col_type))
             for name, col_type in column_types
         ]
-        return self.create_inline_patient_table(columns, node.rows)
+        return self.create_inline_table(columns, node.rows)
 
-    def create_inline_patient_table(self, columns, rows):
+    def create_inline_table(self, columns, rows):
         table_name = f"inline_data_{self.get_next_id()}"
         table = GeneratedTable(
             table_name,

--- a/ehrql/query_engines/mssql.py
+++ b/ehrql/query_engines/mssql.py
@@ -132,7 +132,7 @@ class MSSQLQueryEngine(BaseSQLQueryEngine):
             index_col="patient_id",
         )
 
-    def create_inline_patient_table(self, columns, rows):
+    def create_inline_table(self, columns, rows):
         table_name = f"#inline_data_{self.get_next_id()}"
         table = GeneratedTable(
             table_name,

--- a/ehrql/query_engines/trino.py
+++ b/ehrql/query_engines/trino.py
@@ -116,7 +116,7 @@ class TrinoQueryEngine(BaseSQLQueryEngine):
         columns = get_cyclic_coalescence(columns)
         return aggregate_function(*columns)
 
-    def create_inline_patient_table(self, columns, rows):
+    def create_inline_table(self, columns, rows):
         # Trino doesn't support temporary tables, so we create
         # a new persistent table and drop it in the cleanup
         # queries

--- a/ehrql/sqlalchemy_types.py
+++ b/ehrql/sqlalchemy_types.py
@@ -8,7 +8,7 @@ TYPE_MAP = {
     datetime.date: sqlalchemy.Date,
     float: sqlalchemy.Float,
     int: sqlalchemy.Integer,
-    str: sqlalchemy.Text,
+    str: sqlalchemy.String,
 }
 
 

--- a/tests/generative/test_query_model.py
+++ b/tests/generative/test_query_model.py
@@ -183,7 +183,12 @@ def run_with(engine, instances, variables):
         engine.setup(instances, metadata=sqla_metadata)
         return engine.extract_qm(
             variables,
-            config=ENGINE_CONFIG.get(engine.name, {}),
+            config={
+                # In order to exercise the temporary table code path we set the limit
+                # here very low
+                "EHRQL_MAX_MULTIVALUE_PARAM_LENGTH": 3,
+                **ENGINE_CONFIG.get(engine.name, {}),
+            },
         )
     except Exception as e:
         if error_type := get_ignored_error_type(e):

--- a/tests/generative/variable_strategies.py
+++ b/tests/generative/variable_strategies.py
@@ -255,7 +255,7 @@ def population_and_variable(patient_tables, event_tables, schema, value_strategi
     def in_(draw, _type, frame):
         type_ = draw(any_type())
         values = Value(
-            frozenset(draw(st.sets(value_strategies[type_], min_size=1, max_size=3)))
+            frozenset(draw(st.sets(value_strategies[type_], min_size=1, max_size=5)))
         )
         return Function.In(draw(series(type_, frame)), values)
 

--- a/tests/integration/backends/test_tpp.py
+++ b/tests/integration/backends/test_tpp.py
@@ -17,6 +17,7 @@ from tests.lib.tpp_schema import (
     APCS_Cost,
     APCS_Der,
     Appointment,
+    Base,
     CodedEvent,
     CodedEvent_SNOMED,
     CustomMedicationDictionary,
@@ -1482,6 +1483,135 @@ def test_registered_tests_are_exhaustive():
         if not isinstance(table, BaseFrame):
             continue
         assert table in REGISTERED_TABLES, f"No test for {tpp.__name__}.{name}"
+
+
+# Where queries involve joins with temporary tables on string columns we need to ensure
+# the collations of the columns are consistent or MSSQL will error. Special care must be
+# taken with columns which don't have the default collation so we test each of those
+# individually below.
+@pytest.mark.parametrize(
+    "table,column,values,factory",
+    [
+        (
+            tpp.clinical_events,
+            tpp.clinical_events.ctv3_code,
+            ["abc00", "abc01", "abc02", "abc03"],
+            lambda patient_id, value: [
+                CodedEvent(Patient_ID=patient_id, CTV3Code=value)
+            ],
+        ),
+        (
+            tpp.clinical_events,
+            tpp.clinical_events.snomedct_code,
+            ["123000", "123001", "123002", "123003"],
+            lambda patient_id, value: [
+                CodedEvent_SNOMED(Patient_ID=patient_id, ConceptId=value)
+            ],
+        ),
+        (
+            tpp.medications,
+            tpp.medications.dmd_code,
+            ["123000", "123001", "123002", "123003"],
+            lambda patient_id, value: [
+                MedicationDictionary(MultilexDrug_ID=f";{value};", DMD_ID=value),
+                MedicationIssue(Patient_ID=patient_id, MultilexDrug_ID=f";{value};"),
+            ],
+        ),
+        (
+            tpp.open_prompt,
+            tpp.open_prompt.ctv3_code,
+            ["abc00", "abc01", "abc02", "abc03"],
+            lambda patient_id, value: [
+                OpenPROMPT(Patient_ID=patient_id, CTV3Code=value)
+            ],
+        ),
+        (
+            tpp.open_prompt,
+            tpp.open_prompt.snomedct_code,
+            ["123000", "123001", "123002", "123003"],
+            lambda patient_id, value: [
+                OpenPROMPT(Patient_ID=patient_id, ConceptId=value, CodeSystemId=0)
+            ],
+        ),
+    ],
+)
+def test_is_in_queries_on_columns_with_nonstandard_collation(
+    mssql_engine, table, column, values, factory
+):
+    # Assign a patient ID to each value
+    patient_values = list(enumerate(values, start=1))
+    # Create patient data for each of the values
+    mssql_engine.setup(
+        [factory(patient_id, value) for patient_id, value in patient_values]
+    )
+    # Choose every other value to match against (so we have a mixture of matching and
+    # non-matching patients)
+    matching_values = values[::2]
+
+    dataset = create_dataset()
+    dataset.define_population(table.exists_for_patient())
+    dataset.matches = table.where(column.is_in(matching_values)).exists_for_patient()
+    results = mssql_engine.extract(
+        dataset,
+        # Configure query engine to always break out lists into temporary tables so we
+        # exercise that code path
+        config={"EHRQL_MAX_MULTIVALUE_PARAM_LENGTH": 1},
+        backend=TPPBackend(
+            config={"TEMP_DATABASE_NAME": "temp_tables"},
+        ),
+    )
+
+    # Check that the expected patients match
+    assert results == [
+        {"patient_id": patient_id, "matches": value in matching_values}
+        for patient_id, value in patient_values
+    ]
+
+
+def test_nonstandard_collation_test_is_exhaustive():
+    nonstandard_columns = set(_get_columns_with_nonstandard_collation())
+    referenced_columns = set(_get_columns_referenced_in_collation_test())
+    missing = nonstandard_columns - referenced_columns
+    assert (
+        not missing
+    ), f"Untested columns with non-default collations: {', '.join(missing)}"
+
+
+def _get_columns_with_nonstandard_collation():
+    # We want to find every column on every table *that we actually use* which has a
+    # nonstandard collation. How do we determine which tables we use? Well our
+    # `test_registered_tests_are_exhaustive` check ensures that we have a test for every
+    # frame in the TPP schema. And in order to construct a test for a frame we have to
+    # insert rows into whatever database tables underly it. And that means we need to
+    # import the corresponding ORM classes. So we can use the set of ORM classes
+    # imported into this module as a proxy for the set of classes we actually use.
+    #
+    # This is not *wonderful*, but it works for now.
+    for obj in globals().values():
+        if not isinstance(obj, type) or not issubclass(obj, Base) or obj is Base:
+            continue
+        table = obj.__table__
+        for column in table.columns.values():
+            if isinstance(column.type, sqlalchemy.String):
+                if column.type.collation != TPPBackend.DEFAULT_COLLATION:
+                    yield f"{table.name}.{column.key}"
+
+
+def _get_columns_referenced_in_collation_test():
+    # Iterate over the test parameters and collect every column referenced
+    pytestmark = test_is_in_queries_on_columns_with_nonstandard_collation.pytestmark
+    params = pytestmark[0].args[1]
+    for _, _, values, factory in params:
+        # Construct some models using an arbitrary patient ID and an arbitrarily chosen
+        # value
+        models = factory(patient_id=1, value=values[0])
+        # Walk over the models and collect any explicitly set fields
+        for model in models:
+            yield from (
+                f"{model.__table__.name}.{key}"
+                for key in model.__dict__.keys()
+                if not key.startswith("_")
+            )
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/backends/test_base.py
+++ b/tests/unit/backends/test_base.py
@@ -104,7 +104,8 @@ def test_query_table_from_function_sql():
 
 
 def test_default_backend_sql():
-    table = DefaultSQLBackend().get_table_expression(
+    backend = DefaultSQLBackend(query_engine_class=BaseSQLQueryEngine)
+    table = backend.get_table_expression(
         "some_table", TableSchema(i=Column(int), b=Column(bool))
     )
     sql = str(sqlalchemy.select(table.c.patient_id, table.c.i, table.c.b))

--- a/tests/unit/test_sqlalchemy_types.py
+++ b/tests/unit/test_sqlalchemy_types.py
@@ -14,8 +14,8 @@ from ehrql.sqlalchemy_types import type_from_python_type
         (datetime.date, types.Date),
         (float, types.Float),
         (int, types.Integer),
-        (str, types.Text),
-        (CTV3Code, types.Text),
+        (str, types.String),
+        (CTV3Code, types.String),
     ],
 )
 def test_type_from_python_type(type_, expected):


### PR DESCRIPTION
This addresses the easier half of #512 which involves restructuring large `x IN(a, b, c, ...)` queries to use a temporary table containing the parameters. (The more difficult half is rewriting large `.to_category()` queries to use a JOIN rather than a CASE expression.)

The core of the implementation is relatively simple; most of the complexity is in handling column collations for MSSQL.