### PR TITLE
Describe the contents of the `appointments` short data report

### DIFF
--- a/docs/includes/generated_docs/schemas/beta.tpp.md
+++ b/docs/includes/generated_docs/schemas/beta.tpp.md
@@ -370,7 +370,14 @@ TODO
 
 Appointments in primary care.
 
-You can find out more about this table in the [short data report][appointments_1].
+You can find out more about [the associated database table][appointments_5] in the [short data report][appointments_1].
+It shows:
+
+* Date ranges for `booked_date`, `start_date`, and `seen_date`
+* Row counts by month for `booked_date` and `start_date`
+* The distribution of lead times (`start_date - booked_date`)
+* Row counts for each value of `status`
+
 To view it, you will need a login for OpenSAFELY Jobs and the Project Collaborator
 or Project Developer role for the [project][appointments_4]. The
 [workspace][appointments_2] shows when the code that comprises the report was run;
@@ -399,6 +406,7 @@ repository on GitHub.
 [appointments_2]: https://jobs.opensafely.org/curation-of-gp-appointments-data-short-data-report/appointments-short-data-report/
 [appointments_3]: https://github.com/opensafely/appointments-short-data-report
 [appointments_4]: https://jobs.opensafely.org/curation-of-gp-appointments-data-short-data-report/
+[appointments_5]: https://reports.opensafely.org/reports/opensafely-tpp-database-schema/#Appointment
 <div markdown="block" class="definition-list-wrapper">
   <div class="title">Columns</div>
   <dl markdown="block">

--- a/ehrql/tables/beta/tpp.py
+++ b/ehrql/tables/beta/tpp.py
@@ -139,7 +139,14 @@ class appointments(EventFrame):
     """
     Appointments in primary care.
 
-    You can find out more about this table in the [short data report][appointments_1].
+    You can find out more about [the associated database table][appointments_5] in the [short data report][appointments_1].
+    It shows:
+
+    * Date ranges for `booked_date`, `start_date`, and `seen_date`
+    * Row counts by month for `booked_date` and `start_date`
+    * The distribution of lead times (`start_date - booked_date`)
+    * Row counts for each value of `status`
+
     To view it, you will need a login for OpenSAFELY Jobs and the Project Collaborator
     or Project Developer role for the [project][appointments_4]. The
     [workspace][appointments_2] shows when the code that comprises the report was run;
@@ -168,6 +175,7 @@ class appointments(EventFrame):
     [appointments_2]: https://jobs.opensafely.org/curation-of-gp-appointments-data-short-data-report/appointments-short-data-report/
     [appointments_3]: https://github.com/opensafely/appointments-short-data-report
     [appointments_4]: https://jobs.opensafely.org/curation-of-gp-appointments-data-short-data-report/
+    [appointments_5]: https://reports.opensafely.org/reports/opensafely-tpp-database-schema/#Appointment
     """
 
     booked_date = Series(


### PR DESCRIPTION
Doing so should give the reader enough information to decide whether to click the link, login to OpenSAFELY Jobs, and (possibly) request a suitable role for the project (although see #1688).

Preview: <https://f176a7ac.databuilder.pages.dev/reference/schemas/beta.tpp/#appointments>

Closes #1638

---

There's an aspect of this PR that is important, but out of scope: the short data report will tell you that the maximum value of `Appointment.SeenDate` is 9999-12-31. However, because of

https://github.com/opensafely-core/ehrql/blob/8138a516057db480e39241d63be337e1a206fdbd/ehrql/backends/tpp.py#L150

the maximum value of `appointments.seen_date` isn't. The short data report is SQL Runner-based data development. Ideally, we'd replace it with ehrQL-based data curation. However, doing so it out of scope.