### PR TITLE
fix: Restrict valid measure names

### DIFF
--- a/ehrql/measures/measures.py
+++ b/ehrql/measures/measures.py
@@ -154,6 +154,12 @@ class Measures:
                     f"No value supplied for '{key}' and no default defined"
                 )
 
+        # Ensure measure names are valid
+        if not VALID_VARIABLE_NAME_RE.match(name):
+            raise ValidationError(
+                f"Measure names must start with a letter and contain only"
+                f" alphanumeric characters and underscores, got: {name!r}"
+            )
         # Ensure measure names are unique
         if name in self._measures:
             raise ValidationError(f"Measure already defined with name: {name}")

--- a/tests/unit/measures/test_measures.py
+++ b/tests/unit/measures/test_measures.py
@@ -151,6 +151,32 @@ def test_names_must_be_unique():
         measures.define_measure(name="test", numerator=patients.is_interesting)
 
 
+@pytest.mark.parametrize(
+    "name",
+    [
+        "",
+        "12346No Spaces",
+        "No-Dashes",
+    ],
+)
+def test_names_must_be_valid(name):
+    measures = Measures()
+    with pytest.raises(
+        ValidationError,
+        match=(
+            "must start with a letter and contain only alphanumeric characters"
+            " and underscores"
+        ),
+    ):
+        measures.define_measure(
+            name=name,
+            numerator=patients.score,
+            denominator=patients.is_interesting,
+            intervals=[(date(2021, 1, 1), date(2021, 1, 31))],
+            group_by={"category": patients.category},
+        )
+
+
 def test_group_by_columns_must_be_consistent():
     measures = Measures()
 


### PR DESCRIPTION
We'll want to use these as filename components when we address #1395. I've confirmed with a Github search that all existing measures names are valid under the new criteria.