### PR TITLE
Add ethnictity_from_sus table

### DIFF
--- a/docs/includes/generated_docs/schemas/beta.tpp.md
+++ b/docs/includes/generated_docs/schemas/beta.tpp.md
@@ -16,6 +16,7 @@ from ehrql.tables.beta.tpp import (
     ec,
     ec_cost,
     emergency_care_attendances,
+    ethnicity_from_sus,
     hospital_admissions,
     household_memberships_2020,
     medications,
@@ -995,6 +996,46 @@ TODO
   <dd markdown="block">
 
 
+  </dd>
+</div>
+
+  </dl>
+</div>
+
+
+<p class="dimension-indicator"><code>one row per patient</code></p>
+## ethnicity_from_sus
+
+This finds the most frequently used national ethnicity code for each patient from
+the various SUS (Secondary Uses Service) tables.
+
+Specifically it uses ethnicity codes from the following tables:
+
+    APCS (In-patient hospital admissions)
+    EC (A&E attendances)
+    OPA (Out-patient hospital appointments)
+
+Codes are as defined by "Ethnic Category Code 2001" — the 16+1 ethnic data
+categories used in the 2001 census:
+https://www.datadictionary.nhs.uk/data_elements/ethnic_category.html
+
+Codes beginning Z ("Not stated") and 99 ("Not known") are excluded.
+
+Where there is a tie for the most common code the lexically greatest code is used.
+<div markdown="block" class="definition-list-wrapper">
+  <div class="title">Columns</div>
+  <dl markdown="block">
+<div markdown="block">
+  <dt id="ethnicity_from_sus.code">
+    <strong>code</strong>
+    <a class="headerlink" href="#ethnicity_from_sus.code" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+First character of recorded ethncity code (national code):
+https://www.datadictionary.nhs.uk/data_elements/ethnic_category.html
+
+ * Possible values: `A`, `B`, `C`, `D`, `E`, `F`, `G`, `H`, `J`, `K`, `L`, `M`, `N`, `P`, `R`, `S`
   </dd>
 </div>
 

--- a/ehrql/tables/beta/tpp.py
+++ b/ehrql/tables/beta/tpp.py
@@ -20,6 +20,7 @@ __all__ = [
     "ec",
     "ec_cost",
     "emergency_care_attendances",
+    "ethnicity_from_sus",
     "hospital_admissions",
     "household_memberships_2020",
     "medications",
@@ -780,4 +781,37 @@ class wl_openpathways(EventFrame):
     week_ending_date = Series(
         datetime.date,
         description="The Sunday of the week that the pathway relates to",
+    )
+
+
+@table
+class ethnicity_from_sus(PatientFrame):
+    """
+    This finds the most frequently used national ethnicity code for each patient from
+    the various SUS (Secondary Uses Service) tables.
+
+    Specifically it uses ethnicity codes from the following tables:
+
+        APCS (In-patient hospital admissions)
+        EC (A&E attendances)
+        OPA (Out-patient hospital appointments)
+
+    Codes are as defined by "Ethnic Category Code 2001" — the 16+1 ethnic data
+    categories used in the 2001 census:
+    https://www.datadictionary.nhs.uk/data_elements/ethnic_category.html
+
+    Codes beginning Z ("Not stated") and 99 ("Not known") are excluded.
+
+    Where there is a tie for the most common code the lexically greatest code is used.
+    """
+
+    code = Series(
+        str,
+        constraints=[
+            Constraint.Categorical(list("ABCDEFGHJKLMNPRS")),
+        ],
+        description=(
+            "First character of recorded ethncity code (national code):\n"
+            "https://www.datadictionary.nhs.uk/data_elements/ethnic_category.html"
+        ),
     )

--- a/tests/integration/backends/test_tpp.py
+++ b/tests/integration/backends/test_tpp.py
@@ -469,6 +469,52 @@ def test_emergency_care_attendances(select_all):
     ]
 
 
+@register_test_for(tpp.ethnicity_from_sus)
+def test_ethnicity_from_sus(select_all):
+    results = select_all(
+        # patient 1; Z is ignored; A and B (ignoring the second (optional local code)
+        # characterare equally common; B is selected as it is lexically > A
+        # The EC table's Ethnic Category is national group only (1 character)
+        EC(Patient_ID=1, Ethnic_Category="A"),
+        EC(Patient_ID=1, Ethnic_Category="Z"),
+        EC(Patient_ID=1, Ethnic_Category="P"),
+        APCS(Patient_ID=1, Ethnic_Group="AA"),
+        APCS(Patient_ID=1, Ethnic_Group="BA"),
+        APCS(Patient_ID=1, Ethnic_Group="A1"),
+        OPA(Patient_ID=1, Ethnic_Category="B1"),
+        OPA(Patient_ID=1, Ethnic_Category="B"),
+        # patient 2; Z and 9 codes the most frequent, but are excluded
+        EC(
+            Patient_ID=2,
+            Ethnic_Category="Z",
+        ),
+        EC(
+            Patient_ID=2,
+            Ethnic_Category="9",
+        ),
+        APCS(Patient_ID=2, Ethnic_Group="99"),
+        APCS(Patient_ID=2, Ethnic_Group="ZA"),
+        OPA(Patient_ID=2, Ethnic_Category="G5"),
+        # patient 3; only first (national code) character counts; although D1 is the most frequent
+        # full code, E is the most frequent first character
+        EC(Patient_ID=3, Ethnic_Category="E"),
+        APCS(Patient_ID=3, Ethnic_Group="D1"),
+        APCS(Patient_ID=3, Ethnic_Group="D1"),
+        APCS(Patient_ID=3, Ethnic_Group="E1"),
+        APCS(Patient_ID=3, Ethnic_Group="E2"),
+        # patient 4; no valid codes
+        EC(Patient_ID=4, Ethnic_Category="Z"),
+        APCS(Patient_ID=4, Ethnic_Group="99"),
+        OPA(Patient_ID=4, Ethnic_Category=""),
+        OPA(Patient_ID=4, Ethnic_Category=None),
+    )
+    assert results == [
+        {"patient_id": 1, "code": "B"},
+        {"patient_id": 2, "code": "G"},
+        {"patient_id": 3, "code": "E"},
+    ]
+
+
 @register_test_for(tpp.hospital_admissions)
 def test_hospital_admissions(select_all):
     results = select_all(


### PR DESCRIPTION
Fixes #937 

ethnicity_from_sus involves collecting all [ethnicity codes](https://www.datadictionary.nhs.uk/data_elements/ethnic_category.html) from the EC, APCS and OPA tables and finding the most frequent one.  APCS and OPA can have a 2 character code, both the national and optional local codes. EC can only take a single character, the national code. Only the national code is relevant for the frequency counts, so we extract it from the APCS and OPA tables before counting/sorting.

see also [slack discussion](https://bennettoxford.slack.com/archives/C03FB777L1M/p1699982433341039)