### PR TITLE
docs: Document `ons_deaths` tables

### DIFF
--- a/docs/includes/generated_docs/schemas/beta.core.md
+++ b/docs/includes/generated_docs/schemas/beta.core.md
@@ -108,7 +108,18 @@ from ehrql.tables.beta.core import (
 Registered deaths
 
 Date and cause of death based on information recorded when deaths are
-certified and registered in England and Wales.
+certified and registered in England and Wales from February 2019 onwards.
+The data provider is the Office for National Statistics (ONS).
+This table is updated approximately weekly in OpenSAFELY.
+
+This table includes the underlying cause of death and up to 15 medical conditions mentioned on the death certificate.
+These codes (`cause_of_death_01` to `cause_of_death_15`) are not ordered meaningfully.
+
+More information about this table can be found in following documents provided by the ONS:
+
+- [Information collected at death registration](https://www.ons.gov.uk/peoplepopulationandcommunity/birthsdeathsandmarriages/deaths/methodologies/userguidetomortalitystatisticsjuly2017#information-collected-at-death-registration)
+- [User guide to mortality statistics](https://www.ons.gov.uk/peoplepopulationandcommunity/birthsdeathsandmarriages/deaths/methodologies/userguidetomortalitystatisticsjuly2017)
+- [How death registrations are recorded and stored by ONS](https://www.ons.gov.uk/aboutus/transparencyandgovernance/freedomofinformationfoi/howdeathregistrationsarerecordedandstoredbyons)
 
 In the associated database table [ONS_Deaths](https://reports.opensafely.org/reports/opensafely-tpp-database-schema/#ONS_Deaths),
 a small number of patients have multiple registered deaths.
@@ -124,7 +135,7 @@ The `ehrql.tables.beta.raw.ons_deaths` table contains all registered deaths.
     <code>date</code>
   </dt>
   <dd markdown="block">
-Patient's date of death. Only deaths registered from February 2019 are recorded.
+Patient's date of death.
 
   </dd>
 </div>
@@ -136,7 +147,7 @@ Patient's date of death. Only deaths registered from February 2019 are recorded.
     <code>string</code>
   </dt>
   <dd markdown="block">
-
+Patient's date of death.
 
  * Possible values: `Care Home`, `Elsewhere`, `Home`, `Hospice`, `Hospital`, `Other communal establishment`
   </dd>
@@ -149,7 +160,7 @@ Patient's date of death. Only deaths registered from February 2019 are recorded.
     <code>ICD-10 code</code>
   </dt>
   <dd markdown="block">
-
+Patient's underlying cause of death of death.
 
   </dd>
 </div>
@@ -161,7 +172,7 @@ Patient's date of death. Only deaths registered from February 2019 are recorded.
     <code>ICD-10 code</code>
   </dt>
   <dd markdown="block">
-
+Medical condition mentioned on the death certificate.
 
   </dd>
 </div>
@@ -173,7 +184,7 @@ Patient's date of death. Only deaths registered from February 2019 are recorded.
     <code>ICD-10 code</code>
   </dt>
   <dd markdown="block">
-
+Medical condition mentioned on the death certificate.
 
   </dd>
 </div>
@@ -185,7 +196,7 @@ Patient's date of death. Only deaths registered from February 2019 are recorded.
     <code>ICD-10 code</code>
   </dt>
   <dd markdown="block">
-
+Medical condition mentioned on the death certificate.
 
   </dd>
 </div>
@@ -197,7 +208,7 @@ Patient's date of death. Only deaths registered from February 2019 are recorded.
     <code>ICD-10 code</code>
   </dt>
   <dd markdown="block">
-
+Medical condition mentioned on the death certificate.
 
   </dd>
 </div>
@@ -209,7 +220,7 @@ Patient's date of death. Only deaths registered from February 2019 are recorded.
     <code>ICD-10 code</code>
   </dt>
   <dd markdown="block">
-
+Medical condition mentioned on the death certificate.
 
   </dd>
 </div>
@@ -221,7 +232,7 @@ Patient's date of death. Only deaths registered from February 2019 are recorded.
     <code>ICD-10 code</code>
   </dt>
   <dd markdown="block">
-
+Medical condition mentioned on the death certificate.
 
   </dd>
 </div>
@@ -233,7 +244,7 @@ Patient's date of death. Only deaths registered from February 2019 are recorded.
     <code>ICD-10 code</code>
   </dt>
   <dd markdown="block">
-
+Medical condition mentioned on the death certificate.
 
   </dd>
 </div>
@@ -245,7 +256,7 @@ Patient's date of death. Only deaths registered from February 2019 are recorded.
     <code>ICD-10 code</code>
   </dt>
   <dd markdown="block">
-
+Medical condition mentioned on the death certificate.
 
   </dd>
 </div>
@@ -257,7 +268,7 @@ Patient's date of death. Only deaths registered from February 2019 are recorded.
     <code>ICD-10 code</code>
   </dt>
   <dd markdown="block">
-
+Medical condition mentioned on the death certificate.
 
   </dd>
 </div>
@@ -269,7 +280,7 @@ Patient's date of death. Only deaths registered from February 2019 are recorded.
     <code>ICD-10 code</code>
   </dt>
   <dd markdown="block">
-
+Medical condition mentioned on the death certificate.
 
   </dd>
 </div>
@@ -281,7 +292,7 @@ Patient's date of death. Only deaths registered from February 2019 are recorded.
     <code>ICD-10 code</code>
   </dt>
   <dd markdown="block">
-
+Medical condition mentioned on the death certificate.
 
   </dd>
 </div>
@@ -293,7 +304,7 @@ Patient's date of death. Only deaths registered from February 2019 are recorded.
     <code>ICD-10 code</code>
   </dt>
   <dd markdown="block">
-
+Medical condition mentioned on the death certificate.
 
   </dd>
 </div>
@@ -305,7 +316,7 @@ Patient's date of death. Only deaths registered from February 2019 are recorded.
     <code>ICD-10 code</code>
   </dt>
   <dd markdown="block">
-
+Medical condition mentioned on the death certificate.
 
   </dd>
 </div>
@@ -317,7 +328,7 @@ Patient's date of death. Only deaths registered from February 2019 are recorded.
     <code>ICD-10 code</code>
   </dt>
   <dd markdown="block">
-
+Medical condition mentioned on the death certificate.
 
   </dd>
 </div>
@@ -329,7 +340,7 @@ Patient's date of death. Only deaths registered from February 2019 are recorded.
     <code>ICD-10 code</code>
   </dt>
   <dd markdown="block">
-
+Medical condition mentioned on the death certificate.
 
   </dd>
 </div>

--- a/docs/includes/generated_docs/schemas/beta.raw.core.md
+++ b/docs/includes/generated_docs/schemas/beta.raw.core.md
@@ -27,7 +27,18 @@ from ehrql.tables.beta.raw.core import (
 Registered deaths
 
 Date and cause of death based on information recorded when deaths are
-certified and registered in England and Wales.
+certified and registered in England and Wales from February 2019 onwards.
+The data provider is the Office for National Statistics (ONS).
+This table is updated approximately weekly in OpenSAFELY.
+
+This table includes the underlying cause of death and up to 15 medical conditions mentioned on the death certificate.
+These codes (`cause_of_death_01` to `cause_of_death_15`) are not ordered meaningfully.
+
+More information about this table can be found in following documents provided by the ONS:
+
+- [Information collected at death registration](https://www.ons.gov.uk/peoplepopulationandcommunity/birthsdeathsandmarriages/deaths/methodologies/userguidetomortalitystatisticsjuly2017#information-collected-at-death-registration)
+- [User guide to mortality statistics](https://www.ons.gov.uk/peoplepopulationandcommunity/birthsdeathsandmarriages/deaths/methodologies/userguidetomortalitystatisticsjuly2017)
+- [How death registrations are recorded and stored by ONS](https://www.ons.gov.uk/aboutus/transparencyandgovernance/freedomofinformationfoi/howdeathregistrationsarerecordedandstoredbyons)
 
 In the associated database table [ONS_Deaths](https://reports.opensafely.org/reports/opensafely-tpp-database-schema/#ONS_Deaths),
 a small number of patients have multiple registered deaths.
@@ -51,7 +62,7 @@ The `ehrql.tables.beta.ons_deaths` table contains the earliest registered death.
     <code>date</code>
   </dt>
   <dd markdown="block">
-Patient's date of death. Only deaths registered from February 2019 are recorded.
+Patient's date of death.
 
   </dd>
 </div>
@@ -88,7 +99,7 @@ Patient's date of death. Only deaths registered from February 2019 are recorded.
     <code>ICD-10 code</code>
   </dt>
   <dd markdown="block">
-
+Medical condition mentioned on the death certificate.
 
   </dd>
 </div>
@@ -100,7 +111,7 @@ Patient's date of death. Only deaths registered from February 2019 are recorded.
     <code>ICD-10 code</code>
   </dt>
   <dd markdown="block">
-
+Medical condition mentioned on the death certificate.
 
   </dd>
 </div>
@@ -112,7 +123,7 @@ Patient's date of death. Only deaths registered from February 2019 are recorded.
     <code>ICD-10 code</code>
   </dt>
   <dd markdown="block">
-
+Medical condition mentioned on the death certificate.
 
   </dd>
 </div>
@@ -124,7 +135,7 @@ Patient's date of death. Only deaths registered from February 2019 are recorded.
     <code>ICD-10 code</code>
   </dt>
   <dd markdown="block">
-
+Medical condition mentioned on the death certificate.
 
   </dd>
 </div>
@@ -136,7 +147,7 @@ Patient's date of death. Only deaths registered from February 2019 are recorded.
     <code>ICD-10 code</code>
   </dt>
   <dd markdown="block">
-
+Medical condition mentioned on the death certificate.
 
   </dd>
 </div>
@@ -148,7 +159,7 @@ Patient's date of death. Only deaths registered from February 2019 are recorded.
     <code>ICD-10 code</code>
   </dt>
   <dd markdown="block">
-
+Medical condition mentioned on the death certificate.
 
   </dd>
 </div>
@@ -160,7 +171,7 @@ Patient's date of death. Only deaths registered from February 2019 are recorded.
     <code>ICD-10 code</code>
   </dt>
   <dd markdown="block">
-
+Medical condition mentioned on the death certificate.
 
   </dd>
 </div>
@@ -172,7 +183,7 @@ Patient's date of death. Only deaths registered from February 2019 are recorded.
     <code>ICD-10 code</code>
   </dt>
   <dd markdown="block">
-
+Medical condition mentioned on the death certificate.
 
   </dd>
 </div>
@@ -184,7 +195,7 @@ Patient's date of death. Only deaths registered from February 2019 are recorded.
     <code>ICD-10 code</code>
   </dt>
   <dd markdown="block">
-
+Medical condition mentioned on the death certificate.
 
   </dd>
 </div>
@@ -196,7 +207,7 @@ Patient's date of death. Only deaths registered from February 2019 are recorded.
     <code>ICD-10 code</code>
   </dt>
   <dd markdown="block">
-
+Medical condition mentioned on the death certificate.
 
   </dd>
 </div>
@@ -208,7 +219,7 @@ Patient's date of death. Only deaths registered from February 2019 are recorded.
     <code>ICD-10 code</code>
   </dt>
   <dd markdown="block">
-
+Medical condition mentioned on the death certificate.
 
   </dd>
 </div>
@@ -220,7 +231,7 @@ Patient's date of death. Only deaths registered from February 2019 are recorded.
     <code>ICD-10 code</code>
   </dt>
   <dd markdown="block">
-
+Medical condition mentioned on the death certificate.
 
   </dd>
 </div>
@@ -232,7 +243,7 @@ Patient's date of death. Only deaths registered from February 2019 are recorded.
     <code>ICD-10 code</code>
   </dt>
   <dd markdown="block">
-
+Medical condition mentioned on the death certificate.
 
   </dd>
 </div>
@@ -244,7 +255,7 @@ Patient's date of death. Only deaths registered from February 2019 are recorded.
     <code>ICD-10 code</code>
   </dt>
   <dd markdown="block">
-
+Medical condition mentioned on the death certificate.
 
   </dd>
 </div>
@@ -256,7 +267,7 @@ Patient's date of death. Only deaths registered from February 2019 are recorded.
     <code>ICD-10 code</code>
   </dt>
   <dd markdown="block">
-
+Medical condition mentioned on the death certificate.
 
   </dd>
 </div>

--- a/docs/includes/generated_docs/schemas/beta.raw.tpp.md
+++ b/docs/includes/generated_docs/schemas/beta.raw.tpp.md
@@ -800,7 +800,18 @@ Outcome date.
 Registered deaths
 
 Date and cause of death based on information recorded when deaths are
-certified and registered in England and Wales.
+certified and registered in England and Wales from February 2019 onwards.
+The data provider is the Office for National Statistics (ONS).
+This table is updated approximately weekly in OpenSAFELY.
+
+This table includes the underlying cause of death and up to 15 medical conditions mentioned on the death certificate.
+These codes (`cause_of_death_01` to `cause_of_death_15`) are not ordered meaningfully.
+
+More information about this table can be found in following documents provided by the ONS:
+
+- [Information collected at death registration](https://www.ons.gov.uk/peoplepopulationandcommunity/birthsdeathsandmarriages/deaths/methodologies/userguidetomortalitystatisticsjuly2017#information-collected-at-death-registration)
+- [User guide to mortality statistics](https://www.ons.gov.uk/peoplepopulationandcommunity/birthsdeathsandmarriages/deaths/methodologies/userguidetomortalitystatisticsjuly2017)
+- [How death registrations are recorded and stored by ONS](https://www.ons.gov.uk/aboutus/transparencyandgovernance/freedomofinformationfoi/howdeathregistrationsarerecordedandstoredbyons)
 
 In the associated database table [ONS_Deaths](https://reports.opensafely.org/reports/opensafely-tpp-database-schema/#ONS_Deaths),
 a small number of patients have multiple registered deaths.
@@ -824,7 +835,7 @@ The `ehrql.tables.beta.ons_deaths` table contains the earliest registered death.
     <code>date</code>
   </dt>
   <dd markdown="block">
-Patient's date of death. Only deaths registered from February 2019 are recorded.
+Patient's date of death.
 
   </dd>
 </div>
@@ -861,7 +872,7 @@ Patient's date of death. Only deaths registered from February 2019 are recorded.
     <code>ICD-10 code</code>
   </dt>
   <dd markdown="block">
-
+Medical condition mentioned on the death certificate.
 
   </dd>
 </div>
@@ -873,7 +884,7 @@ Patient's date of death. Only deaths registered from February 2019 are recorded.
     <code>ICD-10 code</code>
   </dt>
   <dd markdown="block">
-
+Medical condition mentioned on the death certificate.
 
   </dd>
 </div>
@@ -885,7 +896,7 @@ Patient's date of death. Only deaths registered from February 2019 are recorded.
     <code>ICD-10 code</code>
   </dt>
   <dd markdown="block">
-
+Medical condition mentioned on the death certificate.
 
   </dd>
 </div>
@@ -897,7 +908,7 @@ Patient's date of death. Only deaths registered from February 2019 are recorded.
     <code>ICD-10 code</code>
   </dt>
   <dd markdown="block">
-
+Medical condition mentioned on the death certificate.
 
   </dd>
 </div>
@@ -909,7 +920,7 @@ Patient's date of death. Only deaths registered from February 2019 are recorded.
     <code>ICD-10 code</code>
   </dt>
   <dd markdown="block">
-
+Medical condition mentioned on the death certificate.
 
   </dd>
 </div>
@@ -921,7 +932,7 @@ Patient's date of death. Only deaths registered from February 2019 are recorded.
     <code>ICD-10 code</code>
   </dt>
   <dd markdown="block">
-
+Medical condition mentioned on the death certificate.
 
   </dd>
 </div>
@@ -933,7 +944,7 @@ Patient's date of death. Only deaths registered from February 2019 are recorded.
     <code>ICD-10 code</code>
   </dt>
   <dd markdown="block">
-
+Medical condition mentioned on the death certificate.
 
   </dd>
 </div>
@@ -945,7 +956,7 @@ Patient's date of death. Only deaths registered from February 2019 are recorded.
     <code>ICD-10 code</code>
   </dt>
   <dd markdown="block">
-
+Medical condition mentioned on the death certificate.
 
   </dd>
 </div>
@@ -957,7 +968,7 @@ Patient's date of death. Only deaths registered from February 2019 are recorded.
     <code>ICD-10 code</code>
   </dt>
   <dd markdown="block">
-
+Medical condition mentioned on the death certificate.
 
   </dd>
 </div>
@@ -969,7 +980,7 @@ Patient's date of death. Only deaths registered from February 2019 are recorded.
     <code>ICD-10 code</code>
   </dt>
   <dd markdown="block">
-
+Medical condition mentioned on the death certificate.
 
   </dd>
 </div>
@@ -981,7 +992,7 @@ Patient's date of death. Only deaths registered from February 2019 are recorded.
     <code>ICD-10 code</code>
   </dt>
   <dd markdown="block">
-
+Medical condition mentioned on the death certificate.
 
   </dd>
 </div>
@@ -993,7 +1004,7 @@ Patient's date of death. Only deaths registered from February 2019 are recorded.
     <code>ICD-10 code</code>
   </dt>
   <dd markdown="block">
-
+Medical condition mentioned on the death certificate.
 
   </dd>
 </div>
@@ -1005,7 +1016,7 @@ Patient's date of death. Only deaths registered from February 2019 are recorded.
     <code>ICD-10 code</code>
   </dt>
   <dd markdown="block">
-
+Medical condition mentioned on the death certificate.
 
   </dd>
 </div>
@@ -1017,7 +1028,7 @@ Patient's date of death. Only deaths registered from February 2019 are recorded.
     <code>ICD-10 code</code>
   </dt>
   <dd markdown="block">
-
+Medical condition mentioned on the death certificate.
 
   </dd>
 </div>
@@ -1029,7 +1040,7 @@ Patient's date of death. Only deaths registered from February 2019 are recorded.
     <code>ICD-10 code</code>
   </dt>
   <dd markdown="block">
-
+Medical condition mentioned on the death certificate.
 
   </dd>
 </div>

--- a/docs/includes/generated_docs/schemas/beta.tpp.md
+++ b/docs/includes/generated_docs/schemas/beta.tpp.md
@@ -1209,7 +1209,18 @@ undocumented algorithm.
 Registered deaths
 
 Date and cause of death based on information recorded when deaths are
-certified and registered in England and Wales.
+certified and registered in England and Wales from February 2019 onwards.
+The data provider is the Office for National Statistics (ONS).
+This table is updated approximately weekly in OpenSAFELY.
+
+This table includes the underlying cause of death and up to 15 medical conditions mentioned on the death certificate.
+These codes (`cause_of_death_01` to `cause_of_death_15`) are not ordered meaningfully.
+
+More information about this table can be found in following documents provided by the ONS:
+
+- [Information collected at death registration](https://www.ons.gov.uk/peoplepopulationandcommunity/birthsdeathsandmarriages/deaths/methodologies/userguidetomortalitystatisticsjuly2017#information-collected-at-death-registration)
+- [User guide to mortality statistics](https://www.ons.gov.uk/peoplepopulationandcommunity/birthsdeathsandmarriages/deaths/methodologies/userguidetomortalitystatisticsjuly2017)
+- [How death registrations are recorded and stored by ONS](https://www.ons.gov.uk/aboutus/transparencyandgovernance/freedomofinformationfoi/howdeathregistrationsarerecordedandstoredbyons)
 
 In the associated database table [ONS_Deaths](https://reports.opensafely.org/reports/opensafely-tpp-database-schema/#ONS_Deaths),
 a small number of patients have multiple registered deaths.
@@ -1225,7 +1236,7 @@ The `ehrql.tables.beta.raw.ons_deaths` table contains all registered deaths.
     <code>date</code>
   </dt>
   <dd markdown="block">
-Patient's date of death. Only deaths registered from February 2019 are recorded.
+Patient's date of death.
 
   </dd>
 </div>
@@ -1237,7 +1248,7 @@ Patient's date of death. Only deaths registered from February 2019 are recorded.
     <code>string</code>
   </dt>
   <dd markdown="block">
-
+Patient's date of death.
 
  * Possible values: `Care Home`, `Elsewhere`, `Home`, `Hospice`, `Hospital`, `Other communal establishment`
   </dd>
@@ -1250,7 +1261,7 @@ Patient's date of death. Only deaths registered from February 2019 are recorded.
     <code>ICD-10 code</code>
   </dt>
   <dd markdown="block">
-
+Patient's underlying cause of death of death.
 
   </dd>
 </div>
@@ -1262,7 +1273,7 @@ Patient's date of death. Only deaths registered from February 2019 are recorded.
     <code>ICD-10 code</code>
   </dt>
   <dd markdown="block">
-
+Medical condition mentioned on the death certificate.
 
   </dd>
 </div>
@@ -1274,7 +1285,7 @@ Patient's date of death. Only deaths registered from February 2019 are recorded.
     <code>ICD-10 code</code>
   </dt>
   <dd markdown="block">
-
+Medical condition mentioned on the death certificate.
 
   </dd>
 </div>
@@ -1286,7 +1297,7 @@ Patient's date of death. Only deaths registered from February 2019 are recorded.
     <code>ICD-10 code</code>
   </dt>
   <dd markdown="block">
-
+Medical condition mentioned on the death certificate.
 
   </dd>
 </div>
@@ -1298,7 +1309,7 @@ Patient's date of death. Only deaths registered from February 2019 are recorded.
     <code>ICD-10 code</code>
   </dt>
   <dd markdown="block">
-
+Medical condition mentioned on the death certificate.
 
   </dd>
 </div>
@@ -1310,7 +1321,7 @@ Patient's date of death. Only deaths registered from February 2019 are recorded.
     <code>ICD-10 code</code>
   </dt>
   <dd markdown="block">
-
+Medical condition mentioned on the death certificate.
 
   </dd>
 </div>
@@ -1322,7 +1333,7 @@ Patient's date of death. Only deaths registered from February 2019 are recorded.
     <code>ICD-10 code</code>
   </dt>
   <dd markdown="block">
-
+Medical condition mentioned on the death certificate.
 
   </dd>
 </div>
@@ -1334,7 +1345,7 @@ Patient's date of death. Only deaths registered from February 2019 are recorded.
     <code>ICD-10 code</code>
   </dt>
   <dd markdown="block">
-
+Medical condition mentioned on the death certificate.
 
   </dd>
 </div>
@@ -1346,7 +1357,7 @@ Patient's date of death. Only deaths registered from February 2019 are recorded.
     <code>ICD-10 code</code>
   </dt>
   <dd markdown="block">
-
+Medical condition mentioned on the death certificate.
 
   </dd>
 </div>
@@ -1358,7 +1369,7 @@ Patient's date of death. Only deaths registered from February 2019 are recorded.
     <code>ICD-10 code</code>
   </dt>
   <dd markdown="block">
-
+Medical condition mentioned on the death certificate.
 
   </dd>
 </div>
@@ -1370,7 +1381,7 @@ Patient's date of death. Only deaths registered from February 2019 are recorded.
     <code>ICD-10 code</code>
   </dt>
   <dd markdown="block">
-
+Medical condition mentioned on the death certificate.
 
   </dd>
 </div>
@@ -1382,7 +1393,7 @@ Patient's date of death. Only deaths registered from February 2019 are recorded.
     <code>ICD-10 code</code>
   </dt>
   <dd markdown="block">
-
+Medical condition mentioned on the death certificate.
 
   </dd>
 </div>
@@ -1394,7 +1405,7 @@ Patient's date of death. Only deaths registered from February 2019 are recorded.
     <code>ICD-10 code</code>
   </dt>
   <dd markdown="block">
-
+Medical condition mentioned on the death certificate.
 
   </dd>
 </div>
@@ -1406,7 +1417,7 @@ Patient's date of death. Only deaths registered from February 2019 are recorded.
     <code>ICD-10 code</code>
   </dt>
   <dd markdown="block">
-
+Medical condition mentioned on the death certificate.
 
   </dd>
 </div>
@@ -1418,7 +1429,7 @@ Patient's date of death. Only deaths registered from February 2019 are recorded.
     <code>ICD-10 code</code>
   </dt>
   <dd markdown="block">
-
+Medical condition mentioned on the death certificate.
 
   </dd>
 </div>
@@ -1430,7 +1441,7 @@ Patient's date of death. Only deaths registered from February 2019 are recorded.
     <code>ICD-10 code</code>
   </dt>
   <dd markdown="block">
-
+Medical condition mentioned on the death certificate.
 
   </dd>
 </div>

--- a/ehrql/tables/beta/core.py
+++ b/ehrql/tables/beta/core.py
@@ -87,7 +87,18 @@ class ons_deaths(PatientFrame):
     Registered deaths
 
     Date and cause of death based on information recorded when deaths are
-    certified and registered in England and Wales.
+    certified and registered in England and Wales from February 2019 onwards.
+    The data provider is the Office for National Statistics (ONS).
+    This table is updated approximately weekly in OpenSAFELY.
+
+    This table includes the underlying cause of death and up to 15 medical conditions mentioned on the death certificate.
+    These codes (`cause_of_death_01` to `cause_of_death_15`) are not ordered meaningfully.
+
+    More information about this table can be found in following documents provided by the ONS:
+
+    - [Information collected at death registration](https://www.ons.gov.uk/peoplepopulationandcommunity/birthsdeathsandmarriages/deaths/methodologies/userguidetomortalitystatisticsjuly2017#information-collected-at-death-registration)
+    - [User guide to mortality statistics](https://www.ons.gov.uk/peoplepopulationandcommunity/birthsdeathsandmarriages/deaths/methodologies/userguidetomortalitystatisticsjuly2017)
+    - [How death registrations are recorded and stored by ONS](https://www.ons.gov.uk/aboutus/transparencyandgovernance/freedomofinformationfoi/howdeathregistrationsarerecordedandstoredbyons)
 
     In the associated database table [ONS_Deaths](https://reports.opensafely.org/reports/opensafely-tpp-database-schema/#ONS_Deaths),
     a small number of patients have multiple registered deaths.
@@ -97,13 +108,11 @@ class ons_deaths(PatientFrame):
 
     date = Series(
         datetime.date,
-        description=(
-            "Patient's date of death. "
-            "Only deaths registered from February 2019 are recorded."
-        ),
+        description=("Patient's date of death."),
     )
     place = Series(
         str,
+        description="Patient's date of death.",
         constraints=[
             Constraint.Categorical(
                 [
@@ -117,23 +126,71 @@ class ons_deaths(PatientFrame):
             ),
         ],
     )
-    underlying_cause_of_death = Series(ICD10Code)
+    underlying_cause_of_death = Series(
+        ICD10Code,
+        description="Patient's underlying cause of death of death.",
+    )
     # TODO: Revisit this when we have support for multi-valued fields
-    cause_of_death_01 = Series(ICD10Code)
-    cause_of_death_02 = Series(ICD10Code)
-    cause_of_death_03 = Series(ICD10Code)
-    cause_of_death_04 = Series(ICD10Code)
-    cause_of_death_05 = Series(ICD10Code)
-    cause_of_death_06 = Series(ICD10Code)
-    cause_of_death_07 = Series(ICD10Code)
-    cause_of_death_08 = Series(ICD10Code)
-    cause_of_death_09 = Series(ICD10Code)
-    cause_of_death_10 = Series(ICD10Code)
-    cause_of_death_11 = Series(ICD10Code)
-    cause_of_death_12 = Series(ICD10Code)
-    cause_of_death_13 = Series(ICD10Code)
-    cause_of_death_14 = Series(ICD10Code)
-    cause_of_death_15 = Series(ICD10Code)
+    cause_of_death_01 = Series(
+        ICD10Code,
+        description="Medical condition mentioned on the death certificate.",
+    )
+    cause_of_death_02 = Series(
+        ICD10Code,
+        description="Medical condition mentioned on the death certificate.",
+    )
+    cause_of_death_03 = Series(
+        ICD10Code,
+        description="Medical condition mentioned on the death certificate.",
+    )
+    cause_of_death_04 = Series(
+        ICD10Code,
+        description="Medical condition mentioned on the death certificate.",
+    )
+    cause_of_death_05 = Series(
+        ICD10Code,
+        description="Medical condition mentioned on the death certificate.",
+    )
+    cause_of_death_06 = Series(
+        ICD10Code,
+        description="Medical condition mentioned on the death certificate.",
+    )
+    cause_of_death_07 = Series(
+        ICD10Code,
+        description="Medical condition mentioned on the death certificate.",
+    )
+    cause_of_death_08 = Series(
+        ICD10Code,
+        description="Medical condition mentioned on the death certificate.",
+    )
+    cause_of_death_09 = Series(
+        ICD10Code,
+        description="Medical condition mentioned on the death certificate.",
+    )
+    cause_of_death_10 = Series(
+        ICD10Code,
+        description="Medical condition mentioned on the death certificate.",
+    )
+    cause_of_death_11 = Series(
+        ICD10Code,
+        description="Medical condition mentioned on the death certificate.",
+    )
+    cause_of_death_12 = Series(
+        ICD10Code,
+        description="Medical condition mentioned on the death certificate.",
+    )
+    cause_of_death_13 = Series(
+        ICD10Code,
+        description="Medical condition mentioned on the death certificate.",
+    )
+    cause_of_death_14 = Series(
+        ICD10Code,
+        description="Medical condition mentioned on the death certificate.",
+    )
+    cause_of_death_15 = Series(
+        ICD10Code,
+        description="Medical condition mentioned on the death certificate.",
+    )
 
 
 @table

--- a/ehrql/tables/beta/raw/core.py
+++ b/ehrql/tables/beta/raw/core.py
@@ -28,7 +28,18 @@ class ons_deaths_raw(EventFrame):
     Registered deaths
 
     Date and cause of death based on information recorded when deaths are
-    certified and registered in England and Wales.
+    certified and registered in England and Wales from February 2019 onwards.
+    The data provider is the Office for National Statistics (ONS).
+    This table is updated approximately weekly in OpenSAFELY.
+
+    This table includes the underlying cause of death and up to 15 medical conditions mentioned on the death certificate.
+    These codes (`cause_of_death_01` to `cause_of_death_15`) are not ordered meaningfully.
+
+    More information about this table can be found in following documents provided by the ONS:
+
+    - [Information collected at death registration](https://www.ons.gov.uk/peoplepopulationandcommunity/birthsdeathsandmarriages/deaths/methodologies/userguidetomortalitystatisticsjuly2017#information-collected-at-death-registration)
+    - [User guide to mortality statistics](https://www.ons.gov.uk/peoplepopulationandcommunity/birthsdeathsandmarriages/deaths/methodologies/userguidetomortalitystatisticsjuly2017)
+    - [How death registrations are recorded and stored by ONS](https://www.ons.gov.uk/aboutus/transparencyandgovernance/freedomofinformationfoi/howdeathregistrationsarerecordedandstoredbyons)
 
     In the associated database table [ONS_Deaths](https://reports.opensafely.org/reports/opensafely-tpp-database-schema/#ONS_Deaths),
     a small number of patients have multiple registered deaths.
@@ -46,10 +57,7 @@ class ons_deaths_raw(EventFrame):
 
     date = Series(
         datetime.date,
-        description=(
-            "Patient's date of death. "
-            "Only deaths registered from February 2019 are recorded."
-        ),
+        description=("Patient's date of death."),
     )
     place = Series(
         str,
@@ -68,21 +76,66 @@ class ons_deaths_raw(EventFrame):
     )
     underlying_cause_of_death = Series(ICD10Code)
     # TODO: Revisit this when we have support for multi-valued fields
-    cause_of_death_01 = Series(ICD10Code)
-    cause_of_death_02 = Series(ICD10Code)
-    cause_of_death_03 = Series(ICD10Code)
-    cause_of_death_04 = Series(ICD10Code)
-    cause_of_death_05 = Series(ICD10Code)
-    cause_of_death_06 = Series(ICD10Code)
-    cause_of_death_07 = Series(ICD10Code)
-    cause_of_death_08 = Series(ICD10Code)
-    cause_of_death_09 = Series(ICD10Code)
-    cause_of_death_10 = Series(ICD10Code)
-    cause_of_death_11 = Series(ICD10Code)
-    cause_of_death_12 = Series(ICD10Code)
-    cause_of_death_13 = Series(ICD10Code)
-    cause_of_death_14 = Series(ICD10Code)
-    cause_of_death_15 = Series(ICD10Code)
+    cause_of_death_01 = Series(
+        ICD10Code,
+        description="Medical condition mentioned on the death certificate.",
+    )
+    cause_of_death_02 = Series(
+        ICD10Code,
+        description="Medical condition mentioned on the death certificate.",
+    )
+    cause_of_death_03 = Series(
+        ICD10Code,
+        description="Medical condition mentioned on the death certificate.",
+    )
+    cause_of_death_04 = Series(
+        ICD10Code,
+        description="Medical condition mentioned on the death certificate.",
+    )
+    cause_of_death_05 = Series(
+        ICD10Code,
+        description="Medical condition mentioned on the death certificate.",
+    )
+    cause_of_death_06 = Series(
+        ICD10Code,
+        description="Medical condition mentioned on the death certificate.",
+    )
+    cause_of_death_07 = Series(
+        ICD10Code,
+        description="Medical condition mentioned on the death certificate.",
+    )
+    cause_of_death_08 = Series(
+        ICD10Code,
+        description="Medical condition mentioned on the death certificate.",
+    )
+    cause_of_death_09 = Series(
+        ICD10Code,
+        description="Medical condition mentioned on the death certificate.",
+    )
+    cause_of_death_10 = Series(
+        ICD10Code,
+        description="Medical condition mentioned on the death certificate.",
+    )
+    cause_of_death_11 = Series(
+        ICD10Code,
+        description="Medical condition mentioned on the death certificate.",
+    )
+    cause_of_death_12 = Series(
+        ICD10Code,
+        description="Medical condition mentioned on the death certificate.",
+    )
+    cause_of_death_13 = Series(
+        ICD10Code,
+        description="Medical condition mentioned on the death certificate.",
+    )
+    cause_of_death_14 = Series(
+        ICD10Code,
+        description="Medical condition mentioned on the death certificate.",
+    )
+    cause_of_death_15 = Series(
+        ICD10Code,
+        description="Medical condition mentioned on the death certificate.",
+    )
 
 
 ons_deaths = table(ons_deaths_raw)


### PR DESCRIPTION
This improves the documentation of the `ons_deaths` and `ons_deaths_raw` tables. The added information mainly comes our data sources documentation: https://docs.opensafely.org/data-sources/onsdeaths/.

Warnings about known issues and differences between the `ons_deaths` and `ons_deaths_raw` have already been added in https://github.com/opensafely-core/ehrql/pull/1691.
 
Closes #1379 
