### PR TITLE
Document `vaccinations` table

### DIFF
--- a/docs/includes/generated_docs/schemas/beta.tpp.md
+++ b/docs/includes/generated_docs/schemas/beta.tpp.md
@@ -2172,7 +2172,16 @@ return ordered_regs.last_for_patient()
 <p class="dimension-indicator"><code>many rows per patient</code></p>
 ## vaccinations
 
+This table contains information on administered vaccinations,
+identified using either the target disease (e.g., Influenza),
+or the vaccine product name (e.g., Optaflu).
+For more information about this table see the
+"[Vaccinaton names in the OpenSAFELY-TPP database][vaccinations_1]" report.
 
+Vaccinations that were administered at work or in a pharmacy might not be
+included in this table.
+
+[vaccinations_1]: https://reports.opensafely.org/reports/opensafely-tpp-vaccination-names/
 <div markdown="block" class="definition-list-wrapper">
   <div class="title">Columns</div>
   <dl markdown="block">
@@ -2183,7 +2192,7 @@ return ordered_regs.last_for_patient()
     <code>integer</code>
   </dt>
   <dd markdown="block">
-
+Vaccination identifier.
 
   </dd>
 </div>
@@ -2195,7 +2204,7 @@ return ordered_regs.last_for_patient()
     <code>date</code>
   </dt>
   <dd markdown="block">
-
+The date the vaccination was administered.
 
   </dd>
 </div>
@@ -2207,7 +2216,7 @@ return ordered_regs.last_for_patient()
     <code>string</code>
   </dt>
   <dd markdown="block">
-
+Vaccine's target disease.
 
   </dd>
 </div>
@@ -2219,7 +2228,7 @@ return ordered_regs.last_for_patient()
     <code>string</code>
   </dt>
   <dd markdown="block">
-
+Vaccine's product name.
 
   </dd>
 </div>

--- a/ehrql/tables/beta/tpp.py
+++ b/ehrql/tables/beta/tpp.py
@@ -628,10 +628,35 @@ class sgss_covid_all_tests(EventFrame):
 
 @table
 class vaccinations(EventFrame):
-    vaccination_id = Series(int)
-    date = Series(datetime.date)
-    target_disease = Series(str)
-    product_name = Series(str)
+    """
+    This table contains information on administered vaccinations,
+    identified using either the target disease (e.g., Influenza),
+    or the vaccine product name (e.g., Optaflu).
+    For more information about this table see the
+    "[Vaccinaton names in the OpenSAFELY-TPP database][vaccinations_1]" report.
+
+    Vaccinations that were administered at work or in a pharmacy might not be
+    included in this table.
+
+    [vaccinations_1]: https://reports.opensafely.org/reports/opensafely-tpp-vaccination-names/
+    """
+
+    vaccination_id = Series(
+        int,
+        description="Vaccination identifier.",
+    )
+    date = Series(
+        datetime.date,
+        description="The date the vaccination was administered.",
+    )
+    target_disease = Series(
+        str,
+        description="Vaccine's target disease.",
+    )
+    product_name = Series(
+        str,
+        description="Vaccine's product name.",
+    )
 
 
 @table


### PR DESCRIPTION
Improve documentation of the `vaccinations` table. In our current documentation we only refer to this table in the [OpenSAFELY-TPP database](https://docs.opensafely.org/data-sources/systmone/#the-opensafely-tpp-database) section.

This adds a description for all columns and adds some context about vaccinations that might be missing from this table. I also included a link to a released output of all vaccination names, @iaindillingham suggested publishing this output on https://reports.opensafely.org/. A draft report already exists for this output but it is not yet available publicly and was last updated on 13 Dec 2022.

I'm waiting for more feedback from researchers before converting from draft to ready for review.


Closes #1340 