### PR TITLE
Run `update-external-studies` weekly rather than daily

### DIFF
--- a/.github/workflows/update-external-studies.yml
+++ b/.github/workflows/update-external-studies.yml
@@ -3,8 +3,9 @@ name: "Create PR to update `external_studies` test code"
 
 on:
   workflow_dispatch:
+  # Once a week on Sunday afternoon
   schedule:
-    - cron:  "43 2 * * *"
+    - cron:  "21 17 * * 0"
 
 jobs:
   create_external_studies_pr:


### PR DESCRIPTION
It's not critical that these be up-to-date, and we could do with less PR churn. If there are specific changes we'd like to pull in immediately we can use the manual workflow dispatch trigger:
https://github.com/opensafely-core/ehrql/actions/workflows/update-external-studies.yml