### PR TITLE
Update documentation for death in primary care vs ONS

### DIFF
--- a/docs/how-to/examples.md
+++ b/docs/how-to/examples.md
@@ -134,7 +134,7 @@ dataset.date_of_death = patients.date_of_death
 dataset.define_population(patients.exists_for_patient())
 ```
 
-:notepad_spiral: This value comes from the patient's EHR record. You can find more information about the accuracy of this value in the [reference schema](https://docs.opensafely.org/ehrql/reference/schemas/beta.core/#recording-of-death-in-primary-care).
+:notepad_spiral: This value comes from the patient's EHR record. You can find more information about the accuracy of this value in the [reference schema](../reference/schemas/beta.core.md#recording-of-death-in-primary-care).
 
 
 ### Finding each patient's date, place, and cause of death from ONS records

--- a/docs/how-to/examples.md
+++ b/docs/how-to/examples.md
@@ -134,12 +134,8 @@ dataset.date_of_death = patients.date_of_death
 dataset.define_population(patients.exists_for_patient())
 ```
 
-:notepad_spiral: This value comes from the patient's EHR record.
+:notepad_spiral: This value comes from the patient's EHR record. You can find more information about the accuracy of this value in the [reference schema](https://docs.opensafely.org/ehrql/reference/schemas/beta.core/#recording-of-death-in-primary-care).
 
-There is generally a lag between the death being recorded in ONS data and appearing in the primary care record,
-but the date itself is usually reliable when it appears. There may be multiple records of death for each patient
-within this table, so you may wish to take the earliest or latest record available for each patient.
-By contrast, cause of death is often not accurate in the primary care record so we don't make it available to query here.
 
 ### Finding each patient's date, place, and cause of death from ONS records
 

--- a/docs/includes/generated_docs/schemas/beta.core.md
+++ b/docs/includes/generated_docs/schemas/beta.core.md
@@ -125,6 +125,10 @@ In the associated database table [ONS_Deaths](https://reports.opensafely.org/rep
 a small number of patients have multiple registered deaths.
 This table contains the earliest registered death.
 The `ehrql.tables.beta.raw.ons_deaths` table contains all registered deaths.
+
+!!! warning
+    There is also a in ONS death recording caused amongst other things by things like autopsies and inquests delaying
+    reporting on cause of death. This is evident in the [OpenSAFELY historical database coverage report](https://reports.opensafely.org/reports/opensafely-tpp-database-history/#ons_deaths)
 <div markdown="block" class="definition-list-wrapper">
   <div class="title">Columns</div>
   <dl markdown="block">
@@ -373,6 +377,28 @@ If the patient doesn't register with a new practice within a given amount of tim
 (normally from four to eight weeks),
 then the patient's records are permanently deducted and are _orphan records_.
 There are roughly 1.6 million orphan records.
+
+### Recording of death in primary care
+
+In England, it is the statutory duty of the doctor who had attended in the last
+illness to complete a medical certificate of cause of death (MCCD). ONS death data
+are considered the gold standard for identifying patient deaths because they are
+based on these MCCDs.
+
+There is generally a lag between the death being recorded in ONS data and it
+appearing in the primary care record, but the coverage or recorded death is almost
+complete and the date of death date is usually reliable when it appears. There is
+also a lag in ONS death recording (see [below](https://docs.opensafely.org/ehrql/reference/schemas/beta.core/#ons_deaths)
+for more detail). You can find out more about the accuracy of date of death
+recording in primary care in:
+
+> Gallagher, A. M., Dedman, D., Padmanabhan, S., Leufkens, H. G. M. & de Vries, F 2019. The accuracy of date of death recording in the Clinical
+> Practice Research Datalink GOLD database in England compared with the Office for National Statistics death registrations.
+> Pharmacoepidemiol. Drug Saf. 28, 563–569.
+> <https://doi.org/10.1002/pds.4747>
+
+By contrast, cause of death is often not accurate in the primary care record so we
+don't make it available to query here.
 <div markdown="block" class="definition-list-wrapper">
   <div class="title">Columns</div>
   <dl markdown="block">

--- a/docs/includes/generated_docs/schemas/beta.core.md
+++ b/docs/includes/generated_docs/schemas/beta.core.md
@@ -127,7 +127,7 @@ This table contains the earliest registered death.
 The `ehrql.tables.beta.raw.ons_deaths` table contains all registered deaths.
 
 !!! warning
-    There is also a in ONS death recording caused amongst other things by things like autopsies and inquests delaying
+    There is also a lag in ONS death recording caused amongst other things by things like autopsies and inquests delaying
     reporting on cause of death. This is evident in the [OpenSAFELY historical database coverage report](https://reports.opensafely.org/reports/opensafely-tpp-database-history/#ons_deaths)
 <div markdown="block" class="definition-list-wrapper">
   <div class="title">Columns</div>

--- a/docs/includes/generated_docs/schemas/beta.core.md
+++ b/docs/includes/generated_docs/schemas/beta.core.md
@@ -387,8 +387,8 @@ based on these MCCDs.
 
 There is generally a lag between the death being recorded in ONS data and it
 appearing in the primary care record, but the coverage or recorded death is almost
-complete and the date of death date is usually reliable when it appears. There is
-also a lag in ONS death recording (see [below](https://docs.opensafely.org/ehrql/reference/schemas/beta.core/#ons_deaths)
+complete and the date of death is usually reliable when it appears. There is
+also a lag in ONS death recording (see [`ons_deaths`](/reference/schemas/beta.core/#ons_deaths) below
 for more detail). You can find out more about the accuracy of date of death
 recording in primary care in:
 

--- a/docs/includes/generated_docs/schemas/beta.tpp.md
+++ b/docs/includes/generated_docs/schemas/beta.tpp.md
@@ -2056,8 +2056,8 @@ based on these MCCDs.
 
 There is generally a lag between the death being recorded in ONS data and it
 appearing in the primary care record, but the coverage or recorded death is almost
-complete and the date of death date is usually reliable when it appears. There is
-also a lag in ONS death recording (see [below](https://docs.opensafely.org/ehrql/reference/schemas/beta.core/#ons_deaths)
+complete and the date of death is usually reliable when it appears. There is
+also a lag in ONS death recording (see [`ons_deaths`](/reference/schemas/beta.core/#ons_deaths) below
 for more detail). You can find out more about the accuracy of date of death
 recording in primary care in:
 

--- a/docs/includes/generated_docs/schemas/beta.tpp.md
+++ b/docs/includes/generated_docs/schemas/beta.tpp.md
@@ -1301,6 +1301,10 @@ In the associated database table [ONS_Deaths](https://reports.opensafely.org/rep
 a small number of patients have multiple registered deaths.
 This table contains the earliest registered death.
 The `ehrql.tables.beta.raw.ons_deaths` table contains all registered deaths.
+
+!!! warning
+    There is also a in ONS death recording caused amongst other things by things like autopsies and inquests delaying
+    reporting on cause of death. This is evident in the [OpenSAFELY historical database coverage report](https://reports.opensafely.org/reports/opensafely-tpp-database-history/#ons_deaths)
 <div markdown="block" class="definition-list-wrapper">
   <div class="title">Columns</div>
   <dl markdown="block">
@@ -2042,6 +2046,28 @@ If the patient doesn't register with a new practice within a given amount of tim
 (normally from four to eight weeks),
 then the patient's records are permanently deducted and are _orphan records_.
 There are roughly 1.6 million orphan records.
+
+### Recording of death in primary care
+
+In England, it is the statutory duty of the doctor who had attended in the last
+illness to complete a medical certificate of cause of death (MCCD). ONS death data
+are considered the gold standard for identifying patient deaths because they are
+based on these MCCDs.
+
+There is generally a lag between the death being recorded in ONS data and it
+appearing in the primary care record, but the coverage or recorded death is almost
+complete and the date of death date is usually reliable when it appears. There is
+also a lag in ONS death recording (see [below](https://docs.opensafely.org/ehrql/reference/schemas/beta.core/#ons_deaths)
+for more detail). You can find out more about the accuracy of date of death
+recording in primary care in:
+
+> Gallagher, A. M., Dedman, D., Padmanabhan, S., Leufkens, H. G. M. & de Vries, F 2019. The accuracy of date of death recording in the Clinical
+> Practice Research Datalink GOLD database in England compared with the Office for National Statistics death registrations.
+> Pharmacoepidemiol. Drug Saf. 28, 563–569.
+> <https://doi.org/10.1002/pds.4747>
+
+By contrast, cause of death is often not accurate in the primary care record so we
+don't make it available to query here.
 <div markdown="block" class="definition-list-wrapper">
   <div class="title">Columns</div>
   <dl markdown="block">

--- a/docs/includes/generated_docs/schemas/beta.tpp.md
+++ b/docs/includes/generated_docs/schemas/beta.tpp.md
@@ -1303,7 +1303,7 @@ This table contains the earliest registered death.
 The `ehrql.tables.beta.raw.ons_deaths` table contains all registered deaths.
 
 !!! warning
-    There is also a in ONS death recording caused amongst other things by things like autopsies and inquests delaying
+    There is also a lag in ONS death recording caused amongst other things by things like autopsies and inquests delaying
     reporting on cause of death. This is evident in the [OpenSAFELY historical database coverage report](https://reports.opensafely.org/reports/opensafely-tpp-database-history/#ons_deaths)
 <div markdown="block" class="definition-list-wrapper">
   <div class="title">Columns</div>

--- a/ehrql/tables/beta/core.py
+++ b/ehrql/tables/beta/core.py
@@ -57,7 +57,7 @@ class patients(PatientFrame):
     There is generally a lag between the death being recorded in ONS data and it
     appearing in the primary care record, but the coverage or recorded death is almost
     complete and the date of death date is usually reliable when it appears. There is
-    also a lag in ONS death recording (see [below](https://docs.opensafely.org/ehrql/reference/schemas/beta.core/#ons_deaths)
+    also a lag in ONS death recording (see [`ons_deaths`](/reference/schemas/beta.core/#ons_deaths) below
     for more detail). You can find out more about the accuracy of date of death
     recording in primary care in:
 

--- a/ehrql/tables/beta/core.py
+++ b/ehrql/tables/beta/core.py
@@ -56,7 +56,7 @@ class patients(PatientFrame):
 
     There is generally a lag between the death being recorded in ONS data and it
     appearing in the primary care record, but the coverage or recorded death is almost
-    complete and the date of death date is usually reliable when it appears. There is
+    complete and the date of death is usually reliable when it appears. There is
     also a lag in ONS death recording (see [`ons_deaths`](/reference/schemas/beta.core/#ons_deaths) below
     for more detail). You can find out more about the accuracy of date of death
     recording in primary care in:

--- a/ehrql/tables/beta/core.py
+++ b/ehrql/tables/beta/core.py
@@ -51,9 +51,7 @@ class patients(PatientFrame):
 
     There is generally a lag between the death being recorded in ONS data and appearing
     in the primary care record, but the date itself is usually reliable when it appears. 
-    There may be multiple records of death for each patient within this table, so you
-    may wish to take the earliest or latest record available for each patient. By
-    contrast, cause of death is often not accurate in the primary care record so we
+    By contrast, cause of death is often not accurate in the primary care record so we
     don't make it available to query here.
 
     """

--- a/ehrql/tables/beta/core.py
+++ b/ehrql/tables/beta/core.py
@@ -128,7 +128,7 @@ class ons_deaths(PatientFrame):
     The `ehrql.tables.beta.raw.ons_deaths` table contains all registered deaths.
 
     !!! warning
-        There is also a in ONS death recording caused amongst other things by things like autopsies and inquests delaying
+        There is also a lag in ONS death recording caused amongst other things by things like autopsies and inquests delaying
         reporting on cause of death. This is evident in the [OpenSAFELY historical database coverage report](https://reports.opensafely.org/reports/opensafely-tpp-database-history/#ons_deaths)
     """
 

--- a/ehrql/tables/beta/core.py
+++ b/ehrql/tables/beta/core.py
@@ -56,8 +56,10 @@ class patients(PatientFrame):
 
     There is generally a lag between the death being recorded in ONS data and it
     appearing in the primary care record, but the coverage or recorded death is almost
-    complete and the date of death date is usually reliable when it appears. You can
-    find out more about the accuracy of date of death recording in primary care in:
+    complete and the date of death date is usually reliable when it appears. There is
+    also a lag in ONS death recording (see [below](https://docs.opensafely.org/ehrql/reference/schemas/beta.core/#ons_deaths)
+    for more detail). You can find out more about the accuracy of date of death
+    recording in primary care in:
 
     > Gallagher, A. M., Dedman, D., Padmanabhan, S., Leufkens, H. G. M. & de Vries, F 2019. The accuracy of date of death recording in the Clinical
     > Practice Research Datalink GOLD database in England compared with the Office for National Statistics death registrations.
@@ -124,6 +126,10 @@ class ons_deaths(PatientFrame):
     a small number of patients have multiple registered deaths.
     This table contains the earliest registered death.
     The `ehrql.tables.beta.raw.ons_deaths` table contains all registered deaths.
+
+    !!! warning
+        There is also a in ONS death recording caused amongst other things by things like autopsies and inquests delaying
+        reporting on cause of death. This is evident in the [OpenSAFELY historical database coverage report](https://reports.opensafely.org/reports/opensafely-tpp-database-history/#ons_deaths)
     """
 
     date = Series(

--- a/ehrql/tables/beta/core.py
+++ b/ehrql/tables/beta/core.py
@@ -46,6 +46,16 @@ class patients(PatientFrame):
     (normally from four to eight weeks),
     then the patient's records are permanently deducted and are _orphan records_.
     There are roughly 1.6 million orphan records.
+
+    ### Recording of death in primary care
+
+    There is generally a lag between the death being recorded in ONS data and appearing
+    in the primary care record, but the date itself is usually reliable when it appears. 
+    There may be multiple records of death for each patient within this table, so you
+    may wish to take the earliest or latest record available for each patient. By
+    contrast, cause of death is often not accurate in the primary care record so we
+    don't make it available to query here.
+
     """
 
     date_of_birth = Series(

--- a/ehrql/tables/beta/core.py
+++ b/ehrql/tables/beta/core.py
@@ -49,11 +49,23 @@ class patients(PatientFrame):
 
     ### Recording of death in primary care
 
-    There is generally a lag between the death being recorded in ONS data and appearing
-    in the primary care record, but the date itself is usually reliable when it appears. 
+    In England, it is the statutory duty of the doctor who had attended in the last
+    illness to complete a medical certificate of cause of death (MCCD). ONS death data
+    are considered the gold standard for identifying patient deaths because they are
+    based on these MCCDs.
+
+    There is generally a lag between the death being recorded in ONS data and it
+    appearing in the primary care record, but the coverage or recorded death is almost
+    complete and the date of death date is usually reliable when it appears. You can
+    find out more about the accuracy of date of death recording in primary care in:
+
+    > Gallagher, A. M., Dedman, D., Padmanabhan, S., Leufkens, H. G. M. & de Vries, F 2019. The accuracy of date of death recording in the Clinical
+    > Practice Research Datalink GOLD database in England compared with the Office for National Statistics death registrations.
+    > Pharmacoepidemiol. Drug Saf. 28, 563–569.
+    > <https://doi.org/10.1002/pds.4747>
+
     By contrast, cause of death is often not accurate in the primary care record so we
     don't make it available to query here.
-
     """
 
     date_of_birth = Series(


### PR DESCRIPTION
This updates the documentation for both death recorded in primary care and deaths from ONS. This is motivated by wanting to know what differences are expected between these two sources.  There is currently the following caveat in the examples section of the docs, but it's not clear where this recommendation comes from.

> There is generally a lag between the death being recorded in ONS data and appearing in the primary care record, but the date itself is usually reliable when it appears. There may be multiple records of death for each patient within this table, so you may wish to take the earliest or latest record available for each patient. By contrast, cause of death is often not accurate in the primary care record so we don't make it available to query here.

To support this, i've provided a reference for the accuracy of PC deaths, taken from [this Slack thread](https://bennettoxford.slack.com/archives/C010SJ89SA3/p1596112932336000?thread_ts=1596016599.257400&cid=C010SJ89SA3). I've also moved this info from the examples section into the schema - I think this is where it should live. I've linked to this section in the original example.

Whilst doing this, i've also highlighted that there is a lag in ONS deaths too and linked to the database report where this is apparent, as suggested by @alexwalkerepi [here](https://bennettoxford.slack.com/archives/C02HJTL065A/p1699363287737269?thread_ts=1699361319.827269&cid=C02HJTL065A)