### PR TITLE
Document beta.core.clinical_events table

### DIFF
--- a/docs/includes/generated_docs/schemas/beta.core.md
+++ b/docs/includes/generated_docs/schemas/beta.core.md
@@ -23,7 +23,11 @@ from ehrql.tables.beta.core import (
 <p class="dimension-indicator"><code>many rows per patient</code></p>
 ## clinical_events
 
+Each record corresponds to a single clinical or consultation event for a patient.
 
+Note that event codes do not change in this table. If an event code in the coding
+system becomes inactive, the event will still be coded to the inactive code.
+As such, codelists should include all relevant inactive codes.
 <div markdown="block" class="definition-list-wrapper">
   <div class="title">Columns</div>
   <dl markdown="block">

--- a/ehrql/tables/beta/core.py
+++ b/ehrql/tables/beta/core.py
@@ -195,6 +195,15 @@ class ons_deaths(PatientFrame):
 
 @table
 class clinical_events(EventFrame):
+    """
+    Each record corresponds to a single clinical or consultation event for a patient.
+
+    Note that event codes do not change in this table. If an event code in the coding
+    system becomes inactive, the event will still be coded to the inactive code.
+    As such, codelists should include all relevant inactive codes.
+
+    """
+
     date = Series(datetime.date)
     snomedct_code = Series(SNOMEDCTCode)
     numeric_value = Series(float)


### PR DESCRIPTION
#1522 documented the clinical events table, but I failed to notice that we have a clinical events table in both `tables.beta.tpp` and `tables.beta.core`.  This adds the documentation for the core table too.