### PR TITLE
Add disclosure control for measures

### DIFF
--- a/docs/includes/generated_docs/language__measures.md
+++ b/docs/includes/generated_docs/language__measures.md
@@ -82,6 +82,28 @@ measures.configure_dummy_data(population_size=10000)
 ```
 </div>
 
+<div class="attr-heading" id="Measures.configure_disclosure_control">
+  <tt><strong>configure_disclosure_control</strong>(<em>enabled=True</em>)</tt>
+  <a class="headerlink" href="#Measures.configure_disclosure_control" title="Permanent link">🔗</a>
+</div>
+<div markdown="block" class="indent">
+Configure disclosure control.
+
+By default, numerators and denominators are subject to disclosure control.
+First, values less than or equal to seven are replaced with zero (suppressed);
+then, values are rounded to the nearest five.
+
+To disable disclosure control:
+
+```py
+measures.configure_disclosure_control(enabled=False)
+```
+
+For more information about disclosure control in OpenSAFELY, please see the
+"[Updated disclosure control
+guidance](https://www.opensafely.org/updated-output-checking-processes/)" page.
+</div>
+
 </div>
 
 

--- a/ehrql/loaders.py
+++ b/ehrql/loaders.py
@@ -266,7 +266,11 @@ def load_measure_definitions_unsafe(definition_file, user_args):
         raise DefinitionError("'measures' must be an instance of ehrql.Measures")
     if len(measures) == 0:
         raise DefinitionError("No measures defined")
-    return list(measures), measures.dummy_data_config
+    return (
+        list(measures),
+        measures.dummy_data_config,
+        measures.disclosure_control_config,
+    )
 
 
 DEFINITION_LOADERS = {

--- a/ehrql/measures/__init__.py
+++ b/ehrql/measures/__init__.py
@@ -2,6 +2,7 @@ from ehrql.measures.calculate import (
     get_column_specs_for_measures,
     get_measure_results,
 )
+from ehrql.measures.disclosure_control import apply_sdc_to_measure_results
 from ehrql.measures.dummy_data import DummyMeasuresDataGenerator
 from ehrql.measures.measures import INTERVAL, Measures, create_measures
 
@@ -9,6 +10,7 @@ from ehrql.measures.measures import INTERVAL, Measures, create_measures
 __all__ = [
     "get_column_specs_for_measures",
     "get_measure_results",
+    "apply_sdc_to_measure_results",
     "DummyMeasuresDataGenerator",
     "INTERVAL",
     "Measures",

--- a/ehrql/measures/disclosure_control.py
+++ b/ehrql/measures/disclosure_control.py
@@ -1,0 +1,40 @@
+"""Statistical Disclosure Control (SDC)
+
+For more information, see:
+https://docs.opensafely.org/releasing-files/
+"""
+SUPPRESSION_THRESHOLD = 7
+ROUNDING_MULTIPLE = 5
+
+
+def apply_sdc(value):
+    assert value >= 0
+    assert isinstance(value, int)
+    value = 0 if value <= SUPPRESSION_THRESHOLD else value
+    value = int(ROUNDING_MULTIPLE * round(value / ROUNDING_MULTIPLE, ndigits=0))
+    return value
+
+
+def apply_sdc_to_measure_results(results):
+    for result in results:
+        (
+            measure_name,
+            interval_start,
+            interval_end,
+            _,
+            old_numerator,
+            old_denominator,
+            *group_names,
+        ) = result
+        numerator = apply_sdc(old_numerator)
+        denominator = apply_sdc(old_denominator)
+        ratio = numerator / denominator if denominator else None
+        yield (
+            measure_name,
+            interval_start,
+            interval_end,
+            ratio,
+            numerator,
+            denominator,
+            *group_names,
+        )

--- a/ehrql/measures/measures.py
+++ b/ehrql/measures/measures.py
@@ -62,6 +62,11 @@ class Measure:
     intervals: tuple[tuple[datetime.date, datetime.date]]
 
 
+@dataclasses.dataclass
+class DisclosureControlConfig:
+    enabled: bool = True
+
+
 # This provides an interface for construction a list of `Measure` instances (as above)
 # and consists almost entirely of validation logic
 class Measures:
@@ -84,6 +89,7 @@ class Measures:
         self._measures = {}
         self._defaults = {}
         self.dummy_data_config = DummyDataConfig(population_size=None)
+        self.disclosure_control_config = DisclosureControlConfig()
 
     def define_measure(
         self,
@@ -299,6 +305,26 @@ class Measures:
         ```
         """
         self.dummy_data_config.population_size = population_size
+
+    def configure_disclosure_control(self, *, enabled=True):
+        """
+        Configure disclosure control.
+
+        By default, numerators and denominators are subject to disclosure control.
+        First, values less than or equal to seven are replaced with zero (suppressed);
+        then, values are rounded to the nearest five.
+
+        To disable disclosure control:
+
+        ```py
+        measures.configure_disclosure_control(enabled=False)
+        ```
+
+        For more information about disclosure control in OpenSAFELY, please see the
+        "[Updated disclosure control
+        guidance](https://www.opensafely.org/updated-output-checking-processes/)" page.
+        """
+        self.disclosure_control_config.enabled = enabled
 
     def __iter__(self):
         return iter(self._measures.values())

--- a/ehrql/serializer.py
+++ b/ehrql/serializer.py
@@ -5,7 +5,7 @@ import pathlib
 
 from ehrql.codes import BaseCode
 from ehrql.file_formats.base import BaseDatasetReader
-from ehrql.measures.measures import Measure
+from ehrql.measures.measures import DisclosureControlConfig, Measure
 from ehrql.query_language import DummyDataConfig
 from ehrql.query_model.column_specs import ColumnSpec
 from ehrql.query_model.nodes import Node, Position, Value
@@ -36,6 +36,7 @@ TYPE_REGISTRY = {
         ColumnSpec,
         DummyDataConfig,
         Measure,
+        DisclosureControlConfig,
         *get_all_subclasses(Node),
         *get_all_subclasses(BaseCode),
         *get_all_subclasses(BaseConstraint),
@@ -156,6 +157,7 @@ class Marshaller:
     @marshal.register(ColumnSpec)
     @marshal.register(DummyDataConfig)
     @marshal.register(Measure)
+    @marshal.register(DisclosureControlConfig)
     def marshal_object(self, obj):
         return {
             type_name(obj): {
@@ -275,6 +277,7 @@ class Unmarshaller:
     @unmarshal_for.register(BaseDatasetReader)
     @unmarshal_for.register(DummyDataConfig)
     @unmarshal_for.register(Measure)
+    @unmarshal_for.register(DisclosureControlConfig)
     def unmarshal_for_object(self, type_, value):
         attrs = {key: self.unmarshal(v) for key, v in value.items()}
         return type_(**attrs)

--- a/tests/unit/measures/test_disclosure_control.py
+++ b/tests/unit/measures/test_disclosure_control.py
@@ -1,0 +1,14 @@
+import pytest
+
+from ehrql.measures.disclosure_control import apply_sdc
+
+
+@pytest.mark.parametrize("i,expected", [(6, 0), (7, 0), (8, 10)])
+def test_apply_sdc(i, expected):
+    assert apply_sdc(i) == expected
+
+
+@pytest.mark.parametrize("bad_value", [-1, 7.1])
+def test_apply_sdc_with_bad_value(bad_value):
+    with pytest.raises(AssertionError):
+        apply_sdc(bad_value)

--- a/tests/unit/measures/test_measures.py
+++ b/tests/unit/measures/test_measures.py
@@ -43,6 +43,8 @@ def test_define_measures():
         group_by={"style": patients.style},
     )
 
+    assert measures.disclosure_control_config.enabled
+
     assert len(measures) == 2
 
     assert list(measures) == [
@@ -90,6 +92,8 @@ def test_define_measures_with_default_group_by():
     measures.define_measure(
         name="test_2",
     )
+
+    assert measures.disclosure_control_config.enabled
 
     assert len(measures) == 2
 
@@ -285,3 +289,9 @@ def test_invalid_intervals_are_rejected(intervals, error):
             intervals=intervals,
             group_by={"category": patients.category},
         )
+
+
+def test_configure_disclosure_control():
+    measures = Measures()
+    measures.configure_disclosure_control(enabled=False)
+    assert not measures.disclosure_control_config.enabled

--- a/tests/unit/test_loaders.py
+++ b/tests/unit/test_loaders.py
@@ -8,6 +8,7 @@ import pytest
 
 from ehrql import loaders
 from ehrql.loaders import DefinitionError
+from ehrql.measures.measures import DisclosureControlConfig
 from ehrql.query_language import DummyDataConfig
 
 
@@ -74,9 +75,14 @@ def test_load_dataset_definition(funcs, capsys):
 
 def test_load_measure_definitions(funcs, capsys):
     filename = FIXTURES_GOOD / "measure_definitions.py"
-    measures, dummy_data_config = funcs.load_measure_definitions(filename)
+    (
+        measures,
+        dummy_data_config,
+        disclosure_control_config,
+    ) = funcs.load_measure_definitions(filename)
     assert isinstance(measures, list)
     assert isinstance(dummy_data_config, DummyDataConfig)
+    assert isinstance(disclosure_control_config, DisclosureControlConfig)
     # Check the subprocess doesn't emit warnings
     assert capsys.readouterr().err == ""
 


### PR DESCRIPTION
This adds disclosure control -- suppressing small numbers (less than or equal to seven) and then rounding numbers (to the nearest five) -- to the measures framework. The OpenSAFELY approach to disclosure control is documented in "[Updated disclosure control guidance][1]".

Disclosure control is enabled by default. It is disabled by calling:

```
measures.configure_disclosure_control(enabled=False)
```

[The OpenSAFELY docs][2] suggest suppressing small numbers by replacing them with `"[REDACTED]"` (i.e. a string). However, doing so adds complexity to the implementation, because some output formats have typed columns. I considered replacing small numbers with `None`, but this does the same: The complexity shifts from the output format to the calculation of the ratio.

Replacing small numbers with zeros doesn't add complexity to the implementation. As well as being of the same type, the calculation of the ratio before disclosure control is the same as the calculation of the ratio after disclosure control.

Consequently, small numbers are replaced with zeros.

[1]: https://www.opensafely.org/updated-output-checking-processes/
[2]: https://docs.opensafely.org/releasing-files/#redacting-counts-less-than-or-equal-to-7

Closes #1666.