### PR TITLE
Add `count_episodes_for_patient()`

### DIFF
--- a/docs/includes/generated_docs/language__series.md
+++ b/docs/includes/generated_docs/language__series.md
@@ -2001,6 +2001,39 @@ Return the maximum value in the series for each patient (or NULL if the patient
 has no values).
 </div>
 
+<div class="attr-heading" id="DateEventSeries.count_episodes_for_patient">
+  <tt><strong>count_episodes_for_patient</strong>(<em>maximum_gap</em>)</tt>
+  <a class="headerlink" href="#DateEventSeries.count_episodes_for_patient" title="Permanent link">🔗</a>
+</div>
+<div markdown="block" class="indent">
+Counts the number of "episodes" for each patient where dates which are no more
+than `maximum_gap` apart (specified in [`days()`](#days) or [`weeks()`](#weeks))
+are considered part of the same episode.
+
+For example, suppose a patient has the following sequence of events:
+
+Event ID | Date
+-- | --
+A | 2020-01-01
+B | 2020-01-04
+C | 2020-01-06
+D | 2020-01-10
+E | 2020-01-12
+
+And suppose we count the episodes here using a maximum gap of three days:
+```python
+.count_episodes_for_patient(days(3))
+```
+
+We will get an episode count of two: events A, B and C are considered as one
+episode and events D and E as another.
+
+Note that events A and C are considered part of the same episode even though
+they are more than three days apart because event B is no more than three days
+apart from both of them. That is, the clock restarts with each new event in an
+episode rather than running from the first event in an episode.
+</div>
+
 </div>
 
 

--- a/docs/includes/generated_docs/specs.md
+++ b/docs/includes/generated_docs/specs.md
@@ -3630,6 +3630,41 @@ returns the following patient series:
 
 
 
+### 11.4 Aggregations which apply to all series containing dates
+
+
+#### 11.4.1 Count episodes
+
+This example makes use of an event-level table named `e` containing the following data:
+
+| patient|d1 |
+| - | - |
+| 1|2020-01-01 |
+| 1|2020-01-04 |
+| 1|2020-01-06 |
+| 1|2020-01-10 |
+| 1|2020-01-12 |
+| 2|2020-01-01 |
+| 3| |
+| 4|2020-01-10 |
+| 4| |
+| 4| |
+| 4|2020-01-01 |
+
+```python
+e.d1.count_episodes_for_patient(days(3))
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1|2 |
+| 2|1 |
+| 3|0 |
+| 4|2 |
+
+
+
 ## 12 Operations on all series containing strings
 
 

--- a/ehrql/query_engines/in_memory.py
+++ b/ehrql/query_engines/in_memory.py
@@ -146,6 +146,19 @@ class InMemoryQueryEngine(BaseQueryEngine):
         col = self.visit(node.source)
         return col.aggregate_values(count_distinct, default=0)
 
+    def visit_CountEpisodes(self, node):
+        def count_episodes(dates):
+            # The `aggregate_values` method below filters out Nones and handles empty
+            # lists so we don't need to deal with those here
+            dates = sorted(dates)
+            return 1 + sum(
+                1 if (dates[i] - dates[i - 1]).days > node.maximum_gap_days else 0
+                for i in range(1, len(dates))
+            )
+
+        col = self.visit(node.source)
+        return col.aggregate_values(count_episodes, default=0)
+
     def visit_Min(self, node):
         col = self.visit(node.source)
         return col.aggregate_values(min, default=None)

--- a/ehrql/query_model/nodes.py
+++ b/ehrql/query_model/nodes.py
@@ -262,6 +262,11 @@ class AggregateByPatient:
     class CountDistinct(AggregatedSeries[int]):
         source: Series[Any]
 
+    class CountEpisodes(AggregatedSeries[int]):
+        source: Series[Any]
+        # Note this is `int` not `Series[int]`: we only accept a fixed value here
+        maximum_gap_days: int
+
     class Min(AggregatedSeries[Comparable]):
         source: Series[Comparable]
 

--- a/ehrql/query_model/query_graph_rewriter.py
+++ b/ehrql/query_model/query_graph_rewriter.py
@@ -49,7 +49,7 @@ class QueryGraphRewriter:
         elif isinstance(obj, frozenset | tuple):
             # As do frozensets and tuples
             return obj.__class__(self._rewrite(v, replacements) for v in obj)
-        elif isinstance(obj, NoneType | str | qm.Position | qm.TableSchema):
+        elif isinstance(obj, NoneType | int | str | qm.Position | qm.TableSchema):
             # Other expected types we return unchanged
             return obj
         else:

--- a/tests/generative/variable_strategies.py
+++ b/tests/generative/variable_strategies.py
@@ -142,6 +142,7 @@ def population_and_variable(patient_tables, event_tables, schema, value_strategi
             date_difference_in_years: ({int}, DomainConstraint.ANY),
             date_difference_in_months: ({int}, DomainConstraint.ANY),
             date_difference_in_days: ({int}, DomainConstraint.ANY),
+            count_episodes: ({int}, DomainConstraint.PATIENT),
             case: ({int, float, bool, datetime.date}, DomainConstraint.ANY),
             maximum_of: (COMPARABLE_TYPES, DomainConstraint.ANY),
             minimum_of: (COMPARABLE_TYPES, DomainConstraint.ANY),
@@ -179,6 +180,13 @@ def population_and_variable(patient_tables, event_tables, schema, value_strategi
         type_ = draw(any_type())
         frame = draw(many_rows_per_patient_frame())
         return AggregateByPatient.CountDistinct(draw(series(type_, frame)))
+
+    @st.composite
+    def count_episodes(draw, _type, _frame):
+        frame = draw(many_rows_per_patient_frame())
+        date_series = draw(series(datetime.date, frame))
+        maximum_gap_days = draw(st.integers(1, 5))
+        return AggregateByPatient.CountEpisodes(date_series, maximum_gap_days)
 
     def min_(type_, _frame):
         return aggregation_operation(type_, AggregateByPatient.Min)

--- a/tests/spec/date_series_ops/test_date_aggregations.py
+++ b/tests/spec/date_series_ops/test_date_aggregations.py
@@ -1,0 +1,37 @@
+from ehrql import days
+
+from ..tables import e
+
+
+title = "Aggregations which apply to all series containing dates"
+
+
+def test_count_episodes(spec_test):
+    table_data = {
+        e: """
+              |     d1
+            --+------------
+            1 | 2020-01-01
+            1 | 2020-01-04
+            1 | 2020-01-06
+            1 | 2020-01-10
+            1 | 2020-01-12
+            2 | 2020-01-01
+            3 |
+            4 | 2020-01-10
+            4 |
+            4 |
+            4 | 2020-01-01
+            """,
+    }
+
+    spec_test(
+        table_data,
+        e.d1.count_episodes_for_patient(days(3)),
+        {
+            1: 2,
+            2: 1,
+            3: 0,
+            4: 2,
+        },
+    )

--- a/tests/spec/toc.py
+++ b/tests/spec/toc.py
@@ -55,6 +55,7 @@ contents = {
         "test_date_series_ops",
         "test_date_comparisons",
         "test_date_comparison_types",
+        "test_date_aggregations",
     ],
     "str_series_ops": [
         "test_contains",

--- a/tests/unit/test_query_language.py
+++ b/tests/unit/test_query_language.py
@@ -738,3 +738,33 @@ def test_duration_generate_intervals_rejects_invalid_arguments(
 ):
     with pytest.raises((TypeError, ValueError), match=error):
         weeks(value).starting_on(start_date)
+
+
+@pytest.mark.parametrize(
+    "maximum_gap,error",
+    [
+        (10, r"must be supplied as `days\(\)` or `weeks\(\)`"),
+        (patients.i, r"must be supplied as `days\(\)` or `weeks\(\)`"),
+        (months(2), r"must be supplied as `days\(\)` or `weeks\(\)`"),
+        (years(2), r"must be supplied as `days\(\)` or `weeks\(\)`"),
+        (days(patients.i), "must be a single, fixed number of days"),
+        (weeks(patients.i), "must be a single, fixed number of weeks"),
+    ],
+)
+def test_count_episodes_for_patient_rejects_invalid_arguments(maximum_gap, error):
+    @table
+    class e(EventFrame):
+        d = Series(date)
+
+    with pytest.raises((TypeError, ValueError), match=error):
+        e.d.count_episodes_for_patient(maximum_gap)
+
+
+def test_count_episodes_for_patient_handles_weeks():
+    @table
+    class e(EventFrame):
+        d = Series(date)
+
+    using_days = e.d.count_episodes_for_patient(days(14))
+    using_weeks = e.d.count_episodes_for_patient(weeks(2))
+    assert using_days._qm_node == using_weeks._qm_node


### PR DESCRIPTION
I've taken the decision to only accept a fixed "maximum gap" duration here i.e. you can't have a gap size which varies dynamically for each patient. I don't think it would actually be that difficult to support this if we had to, but it would require some thought and I don't feel like it would be worth it at this stage. 

I've let Hypothesis have a good run at this locally and, apart from a silly bug in the query rewriter which I'd forgotten to update, it didn't find issues.

Closes #678