### PR TITLE
Exclude internal methods from docs

### DIFF
--- a/ehrql/docs/backends.py
+++ b/ehrql/docs/backends.py
@@ -4,9 +4,9 @@ from pathlib import Path
 import ehrql
 import ehrql.tables
 from ehrql.utils.module_utils import get_sibling_subclasses
-from ehrql.utils.string_utils import strip_indent
 
 from ..backends.base import SQLBackend
+from .common import get_docstring
 
 
 SORT_ORDER = {k: i for i, k in enumerate(["TPP", "EMIS"])}
@@ -26,7 +26,7 @@ def build_backends():
                 "name": backend.display_name,
                 "dotted_path": f"{backend.__module__}.{backend.__qualname__}",
                 "file_path": relative_file_path(backend.__module__),
-                "docstring": strip_indent(backend.__doc__),
+                "docstring": get_docstring(backend),
                 "implements": implements,
             }
         )

--- a/ehrql/docs/common.py
+++ b/ehrql/docs/common.py
@@ -5,6 +5,7 @@ import textwrap
 from collections import ChainMap
 
 from ehrql.codes import BaseCode
+from ehrql.utils.string_utils import strip_indent
 
 
 def get_class_attrs(cls):
@@ -14,6 +15,16 @@ def get_class_attrs(cls):
     # `object` as we want methods in the order _we_ define them, not those in which they
     # happen to be defined on `object`.
     return dict(ChainMap(*[vars(base) for base in cls.__mro__ if base is not object]))
+
+
+def get_docstring(obj, default=None):
+    docstring = obj.__doc__
+    if not docstring:
+        if default is None:
+            raise ValueError(f"No docstring defined for public object {obj}")
+        else:
+            docstring = default
+    return strip_indent(docstring)
 
 
 def get_arguments(function, ignore_self=False):

--- a/ehrql/docs/schemas.py
+++ b/ehrql/docs/schemas.py
@@ -95,7 +95,9 @@ def build_table_methods(table_name, cls):
     return [
         build_method(table_name, name, attr)
         for name, attr in get_class_attrs(cls).items()
-        if name not in base_attrs and inspect.isfunction(attr)
+        if name not in base_attrs
+        and not name.startswith("_")
+        and inspect.isfunction(attr)
     ]
 
 

--- a/ehrql/docs/schemas.py
+++ b/ehrql/docs/schemas.py
@@ -10,11 +10,11 @@ from ehrql.query_language import (
     get_tables_from_namespace,
 )
 from ehrql.utils.module_utils import get_submodules
-from ehrql.utils.string_utils import strip_indent
 
 from .common import (
     get_arguments,
     get_class_attrs,
+    get_docstring,
     get_function_body,
     get_name_for_type,
 )
@@ -32,7 +32,7 @@ def build_schemas(backends=()):
         if not module_tables:
             continue
 
-        docstring = strip_indent(module.__doc__)
+        docstring = get_docstring(module)
         dotted_path = module.__name__
         hierarchy = dotted_path.removeprefix(f"{tables.__name__}.").split(".")
         name = ".".join(hierarchy)
@@ -66,7 +66,7 @@ def build_module_name_to_backend_map(backends):
 def build_tables(module):
     for name, table in get_tables_from_namespace(module):
         cls = table.__class__
-        docstring = strip_indent(cls.__doc__ or "")
+        docstring = get_docstring(cls, default="")
         columns = [
             build_column(name, series)
             for name, series in get_all_series_from_class(cls).items()
@@ -102,7 +102,7 @@ def build_table_methods(table_name, cls):
 def build_method(table_name, name, method):
     return {
         "name": name,
-        "docstring": strip_indent(method.__doc__),
+        "docstring": get_docstring(method),
         "arguments": get_arguments(method, ignore_self=True),
         # Replace the `self` argument with the table name so the resulting code makes
         # more sense in isolation

--- a/tests/unit/docs/test_common.py
+++ b/tests/unit/docs/test_common.py
@@ -1,6 +1,6 @@
 import pytest
 
-from ehrql.docs.common import get_function_body
+from ehrql.docs.common import get_docstring, get_function_body
 
 
 class ExampleClass:
@@ -48,3 +48,21 @@ return "foo"
 )
 def test_get_function_body(method, expected):
     assert get_function_body(method) == expected
+
+
+def test_get_docstring():
+    assert (
+        get_docstring(ExampleClass.example_method_with_docstring)
+        == "Docstring goes here"
+    )
+
+
+def test_get_docstring_with_default():
+    assert (
+        get_docstring(ExampleClass.example_method_no_docstring, default="foo") == "foo"
+    )
+
+
+def test_get_docstring_with_error():
+    with pytest.raises(ValueError, match="No docstring defined for public object"):
+        get_docstring(ExampleClass.example_method_no_docstring)


### PR DESCRIPTION
This excludes internal methods (i.e. where the name has a leading underscore) from the documentation and also raises a more helpful error message when a method which _should_ be in the documentation is missing a docstring.

Closes #1772