### PR TITLE
fix: Only encode categorical strings as Arrow dictionaries

### DIFF
--- a/ehrql/file_formats/arrow.py
+++ b/ehrql/file_formats/arrow.py
@@ -73,7 +73,9 @@ def get_field_and_convertor(name, spec):
     else:
         type_ = PYARROW_TYPE_MAP[spec.type]()
 
-    if spec.categories is not None:
+    # Arrow supports creating dictionaries of any type, but downstream software often
+    # only expects strings here so we restrict dictionaries to strings only
+    if spec.type is str and spec.categories is not None:
         # Although pyarrow.dictionary indices can obviously never be negative we use
         # `-1` as the minimum below so we always get a signed type; this is because
         # Pandas can't read dictionaries with unsigned index types. See:

--- a/tests/integration/file_formats/test_arrow.py
+++ b/tests/integration/file_formats/test_arrow.py
@@ -10,11 +10,12 @@ def test_write_dataset_arrow(tmp_path):
         "patient_id": ColumnSpec(int),
         "year_of_birth": ColumnSpec(int, min_value=1900, max_value=2100),
         "sex": ColumnSpec(str, categories=("M", "F", "I")),
+        "risk_score": ColumnSpec(float, categories=(0.0, 0.5, 1.0)),
     }
     results = [
-        (123, 1980, "F"),
-        (456, None, None),
-        (789, 1999, "M"),
+        (123, 1980, "F", 0.0),
+        (456, None, None, 0.5),
+        (789, 1999, "M", 1.0),
     ]
     write_dataset(filename, results, column_specs)
 
@@ -30,3 +31,6 @@ def test_write_dataset_arrow(tmp_path):
     assert index_type == pyarrow.int8()
     assert table.column("patient_id").type == pyarrow.int64()
     assert table.column("year_of_birth").type == pyarrow.uint16()
+    # This column has categories, but it's not a string so we shouldn't encode it as a
+    # dictionary
+    assert not pyarrow.types.is_dictionary(table.column("risk_score").type)


### PR DESCRIPTION
ehrQL's notion of "categorical" covers variables of any type which take only an explicitly enumerated set of values, and Arrow supports creating dictionaries of any type. But non-string categoricals are unusual, not all that useful, and can cause problems with downstream software so we no longer create them.