### PR TITLE
fix: Population can only be defined once

### DIFF
--- a/ehrql/query_language.py
+++ b/ehrql/query_language.py
@@ -63,6 +63,10 @@ class Dataset:
         dataset.define_population(patients.date_of_birth < "1990-01-01")
         ```
         """
+        if "population" in self.variables:
+            raise AttributeError(
+                "define_population() should be called no more than once"
+            )
         validate_population_definition(population_condition._qm_node)
         self.variables["population"] = population_condition
 

--- a/tests/unit/test_query_language.py
+++ b/tests/unit/test_query_language.py
@@ -145,6 +145,13 @@ def test_dataset_rejects_invalid_variable_names(variable_name, error):
         setattr(Dataset(), variable_name, patients.i)
 
 
+def test_cannot_define_population_more_than_once():
+    dataset = Dataset()
+    dataset.define_population(patients.exists_for_patient())
+    with pytest.raises(AttributeError, match="no more than once"):
+        dataset.define_population(patients.exists_for_patient())
+
+
 def test_cannot_reassign_dataset_variable():
     dataset = Dataset()
     dataset.foo = patients.date_of_birth.year


### PR DESCRIPTION
Currently `.define_population(...)` can be used multiple times in a dataset definition and only the last call defines the dataset. This raises an error if `.define_population(...)` is used more than once.

I didn't think we need to mention this in the docs, but we could add a short note to `define_population()`?

Fixes #775