### PR TITLE
Fix long running gentests

### DIFF
--- a/.github/workflows/generative-tests.yml
+++ b/.github/workflows/generative-tests.yml
@@ -47,12 +47,12 @@ jobs:
 
             # Do the actual testing
             set +e
-            just test tests/generative/test_query_model.py
+            just test tests/generative/test_query_model.py::test_query_model
             rc=$?
             set -e
 
             # 6 == dead database error, continue to remove db containers and start new batch
-            if [ $rc -ne 0] && [ $rc -ne 6 ]; then
+            if [[ $rc -ne 0 && $rc -ne 6 ]]; then
               exit $rc
             fi
 

--- a/tests/generative/test_query_model.py
+++ b/tests/generative/test_query_model.py
@@ -180,6 +180,7 @@ def instantiate(data):
 
 
 def run_with(engine, instances, variables):
+    error_type = None
     try:
         engine.setup(instances, metadata=sqla_metadata)
         return engine.extract_qm(
@@ -201,7 +202,8 @@ def run_with(engine, instances, variables):
             return error_type
         raise
     finally:
-        engine.teardown()
+        if error_type is not IgnoredError.CONNECTION_ERROR:  # pragma: no cover
+            engine.teardown()
 
 
 def run_dummy_data_test(population, variable):


### PR DESCRIPTION
This adds a few follow up fixes to #1760:

 * Replace the `::test_query_model` test specifier which was accidentally removed.
 * Fix the bash conditional syntax (there was a missing space between `0` and `]`, but modern bash tends to favour the double bracket syntax in any case.)
 * Don't attempt database teardown on a broken connection (this was generating new failures which then prevented the test from exiting in the way we intended.)