### PR TITLE
fix: `UnboundLocalError` in `MeasureTimer`

### DIFF
--- a/ehrql/measures/calculate.py
+++ b/ehrql/measures/calculate.py
@@ -68,7 +68,7 @@ class MeasureTimer:
         self.counter = 0
 
     @classmethod
-    def from_grouped(csl, timeout, grouped):
+    def from_grouped(cls, timeout, grouped):
         num_iterations = sum(
             [len(intervals) for denominator, intervals in grouped.keys()]
         )
@@ -81,15 +81,15 @@ class MeasureTimer:
 
     def check_timeout(self, interval):
         if interval != self.previous_interval:
-            elapsed_time = time.time() - self.start_time
             self.counter += 1
             self.previous_interval = interval
-        if self.counter >= 12:
-            projected_time = elapsed_time / self.counter * self.num_iterations
-            if projected_time > self.timeout:
-                raise MeasuresTimeout(
-                    f"Generating measures exceeded {self.timeout}s time limit."
-                )
+            if self.counter >= 12:
+                self.elapsed_time = time.time() - self.start_time
+                projected_time = self.elapsed_time / self.counter * self.num_iterations
+                if projected_time > self.timeout:
+                    raise MeasuresTimeout(
+                        f"Generating measures exceeded {self.timeout}s time limit."
+                    )
 
 
 class MeasureCalculator:

--- a/tests/integration/measures/test_calculate.py
+++ b/tests/integration/measures/test_calculate.py
@@ -115,13 +115,15 @@ def test_get_measure_results_with_timeout(patched_time, in_memory_engine):
         numerator=foo_event_count,
         denominator=event_count,
         intervals=intervals,
+        group_by=dict(
+            sex=patients.sex,
+        ),
     )
 
     patient_data, _, event_data = generate_data(intervals)
     in_memory_engine.populate({patients: patient_data, events: event_data})
 
-    mock_short_queries = [6500.0 + i * 500 for i in range(11)]
-    patched_time.time.side_effect = [0.0] + [6000.0] + mock_short_queries + [100000.0]
+    patched_time.time.side_effect = [0.0, 1000.0, 1000000.0]
     results = get_measure_results(in_memory_engine.query_engine(), measures)
     with pytest.raises(MeasuresTimeout, match="time limit"):
         results = list(results)


### PR DESCRIPTION
Andrea noticed an error[^1] that we didn't catch in the initial release of `MeasureTimer` in  #1757. Making `elapsed_time` an instance variable (`self.elapsed_time`) should fix the error I think? This also changes the name of the first argument of the `@classmethod` to the convention `cls`.

`UnboundLocalError: cannot access local variable 'elapsed_time' where it is not associated with a value`

[^1]: https://bennettoxford.slack.com/archives/C04DVD1UQC9/p1701258939491439