### PR TITLE
Support `add_column()`

### DIFF
--- a/docs/how-to/assign-multiple-columns.md
+++ b/docs/how-to/assign-multiple-columns.md
@@ -1,0 +1,55 @@
+# How to assign multiple columns to a dataset programmatically
+
+To include columns in your output for further analysis, these columns need to be added to the dataset.
+If you need to add multiple similar columns to your dataset it could be more efficient to do this programmatically instead of adding each column manually.
+For example, you might want to count the number of medications each patient received across different codelists.
+This guide first shows you how to use `dataset.add_column` to assign one new column to the dataset, followed by an example how to assign multiple columns programmatically.
+
+## Assign one column to the dataset
+
+As mentioned in the tutorial on "[Writing a more complex dataset definition](/tutorial/writing-a-more-complex-dataset-definition/#assign-variables-to-the-dataset)",
+we can assign a variable to the dataset by adding a dot and the name of the variable to the dataset,
+followed by an equals sign and the definition of the variable.
+In the following example, the name of the variable is `my_variable`
+and the definition of the variable is `...`.
+
+``` { .python .no-copy }
+dataset.my_variable = ...
+```
+
+Similarly, we can assign a variable using `dataset.add_column`, where the first argument is the
+name of the new column as a string and the second argument is the definition of the variable.
+
+``` { .python .no-copy }
+dataset.add_column("my_variable", ...)
+```
+
+## Assign multiple columns to the dataset
+
+To add multiple variables to a dataset, we can use a dictionary to map new column names to codelists (`medication_codelists`).
+First, create an ehrQL query to count each patient's medications (`count_medications_query`).
+Then, iterate over this dictionary, using `dataset.add_column` to add each new variable to the dataset.
+You can also add a prefix or suffix to the new column names (e.g., `_count`).
+This example adds two new columns to the dataset: `asthma_meds_count` and `other_meds_count`.
+
+```ehrql
+from ehrql import create_dataset
+from ehrql.tables.beta.core import patients, medications
+
+asthma_codelist = ["39113311000001107", "39113611000001102"]
+other_codelist = ["10000000000000001", "10000000000000002"]
+
+dataset = create_dataset()
+dataset.define_population(patients.exists_for_patient())
+
+medication_codelists = {
+    "asthma_meds": asthma_codelist,
+    "other_meds": other_codelist,
+}
+
+for med_name, med_codelist in medication_codelists.items():
+    count_medications_query = medications.where(
+        medications.dmd_code.is_in(med_codelist)
+    ).count_for_patient()
+    dataset.add_column(f"{med_name}_count", count_medications_query)
+```

--- a/docs/how-to/index.md
+++ b/docs/how-to/index.md
@@ -4,3 +4,4 @@ The how-to guides provide practical steps for working with ehrQL in your project
 * [Resolving ehrQL errors](errors.md)
 * [How to use dummy data in an ehrQL dataset definition](dummy-data.md)
 * [How to use dummy data in an ehrQL measures definition](dummy-measures-data.md)
+* [How to assign multiple columns to a dataset programmatically](assign-multiple-columns.md)

--- a/docs/includes/generated_docs/language__dataset.md
+++ b/docs/includes/generated_docs/language__dataset.md
@@ -38,6 +38,25 @@ dataset.define_population(patients.date_of_birth < "1990-01-01")
 ```
 </div>
 
+<div class="attr-heading" id="Dataset.add_column">
+  <tt><strong>add_column</strong>(<em>column_name</em>, <em>ehrql_query</em>)</tt>
+  <a class="headerlink" href="#Dataset.add_column" title="Permanent link">🔗</a>
+</div>
+<div markdown="block" class="indent">
+Add a column to the dataset
+
+_column_name_<br>
+The name of the new column, as a string.
+
+_ehrql_query_<br>
+An ehrQL query that returns one row per patient.
+
+Using `.add_column` is equivalent to `=` for adding a single column
+but can also be used to add multiple columns, for example by iterating
+over a dictionary. For more details see the guide on
+"[How to assign multiple columns to a dataset programmatically](/how-to/assign-multiple-columns)".
+</div>
+
 <div class="attr-heading" id="Dataset.configure_dummy_data">
   <tt><strong>configure_dummy_data</strong>(<em>population_size</em>)</tt>
   <a class="headerlink" href="#Dataset.configure_dummy_data" title="Permanent link">🔗</a>

--- a/ehrql/query_language.py
+++ b/ehrql/query_language.py
@@ -70,6 +70,23 @@ class Dataset:
         validate_population_definition(population_condition._qm_node)
         self.variables["population"] = population_condition
 
+    def add_column(self, column_name: str, ehrql_query):
+        """
+        Add a column to the dataset
+
+        _column_name_<br>
+        The name of the new column, as a string.
+
+        _ehrql_query_<br>
+        An ehrQL query that returns one row per patient.
+
+        Using `.add_column` is equivalent to `=` for adding a single column
+        but can also be used to add multiple columns, for example by iterating
+        over a dictionary. For more details see the guide on
+        "[How to assign multiple columns to a dataset programmatically](/how-to/assign-multiple-columns)".
+        """
+        setattr(self, column_name, ehrql_query)
+
     def configure_dummy_data(self, *, population_size):
         """
         Configure the dummy data to be generated.

--- a/tests/unit/test_query_language.py
+++ b/tests/unit/test_query_language.py
@@ -125,6 +125,13 @@ def test_dataset_accepts_valid_variable_names(name):
     setattr(Dataset(), name, patients.i)
 
 
+def test_add_column():
+    dataset = Dataset()
+    dataset.add_column("foo", patients.i)
+    variables = list(compile(dataset).keys())
+    assert variables == ["foo"]
+
+
 @pytest.mark.parametrize(
     "variable_name,error",
     [


### PR DESCRIPTION
This is a wrapper for `setattr()` to make it easier for users to add columns dynamically to a dataset.

The docstring includes the most important information about how `.add_column` can be used but no code examples. A more detailed example with code is in the how-to guide on _"How to assign multiple columns to a dataset programmatically"_.

Closes #1767 