### PR TITLE
Clean up logical terminology

### DIFF
--- a/docs/how-to/errors.md
+++ b/docs/how-to/errors.md
@@ -816,7 +816,7 @@ age = patients.age_on("2023-01-01")
 dataset.age_group = case(
    when(age < 10).then(1),
    when(age > 80).then(2),
-   default="unknown",
+   otherwise="unknown",
 )
 ```
 
@@ -842,7 +842,7 @@ age = patients.age_on("2023-01-01")
 dataset.age_group = case(
    when(age < 10).then(1),
    when(age > 80).then(2),
-   default=0,
+   otherwise=0,
 )
 ```
 

--- a/docs/how-to/examples.md
+++ b/docs/how-to/examples.md
@@ -107,7 +107,7 @@ dataset.age_band = case(
         when(age < 60).then("40-59"),
         when(age < 80).then("60-79"),
         when(age >= 80).then("80+"),
-        default="missing",
+        otherwise="missing",
 )
 dataset.define_population(patients.exists_for_patient())
 ```
@@ -227,7 +227,7 @@ dataset.imd_quintile = case(
     when(imd < int(32844 * 3 / 5)).then("3"),
     when(imd < int(32844 * 4 / 5)).then("4"),
     when(imd < int(32844 * 5 / 5)).then("5 (least deprived)"),
-    default="unknown"
+    otherwise="unknown"
 )
 dataset.define_population(patients.exists_for_patient())
 ```

--- a/docs/includes/generated_docs/language__functions.md
+++ b/docs/includes/generated_docs/language__functions.md
@@ -1,6 +1,6 @@
 
 <h4 class="attr-heading" id="case" data-toc-label="case" markdown>
-  <tt><strong>case</strong>(<em>*when_thens</em>, <em>default=None</em>)</tt>
+  <tt><strong>case</strong>(<em>*when_thens</em>, <em>otherwise=None</em>, <em>default=None</em>)</tt>
 </h4>
 <div markdown="block" class="indent">
 Take a sequence of condition-values of the form:
@@ -9,8 +9,8 @@ when(condition).then(value)
 ```
 
 And evaluate them in order, returning the value of the first condition which
-evaluates True. If no condition matches and a `default` is specified then return
-that, otherwise return NULL.
+evaluates True. If no condition matches, return the `otherwise` value; if no
+`otherwise` value is specified then return NULL.
 
 For example:
 ```py
@@ -18,7 +18,7 @@ category = case(
     when(size < 10).then("small"),
     when(size < 20).then("medium"),
     when(size >= 20).then("large"),
-    default="unknown",
+    otherwise="unknown",
 )
 ```
 
@@ -31,7 +31,7 @@ A simpler form is available when there is a single condition.  This example:
 ```py
 category = case(
     when(size < 15).then("small"),
-    default="large",
+    otherwise="large",
 )
 ```
 
@@ -39,6 +39,9 @@ can be rewritten as:
 ```py
 category = when(size < 15).then("small").otherwise("large")
 ```
+
+Note that the `default` argument is an older alias for `otherwise`: it will be
+removed in future versions of ehrQL and should not be used.
 </div>
 
 

--- a/docs/includes/generated_docs/language__series.md
+++ b/docs/includes/generated_docs/language__series.md
@@ -75,14 +75,24 @@ NULL, and False otherwise.
 Return the inverse of `is_null()` above.
 </div>
 
-<div class="attr-heading" id="BoolPatientSeries.if_null_then">
-  <tt><strong>if_null_then</strong>(<em>other</em>)</tt>
-  <a class="headerlink" href="#BoolPatientSeries.if_null_then" title="Permanent link">🔗</a>
+<div class="attr-heading" id="BoolPatientSeries.when_null_then">
+  <tt><strong>when_null_then</strong>(<em>other</em>)</tt>
+  <a class="headerlink" href="#BoolPatientSeries.when_null_then" title="Permanent link">🔗</a>
 </div>
 <div markdown="block" class="indent">
 Replace any NULL value in this series with the corresponding value in `other`.
 
 Note that `other` must be of the same type as this series.
+</div>
+
+<div class="attr-heading" id="BoolPatientSeries.if_null_then">
+  <tt><strong>if_null_then</strong>(<em>other</em>)</tt>
+  <a class="headerlink" href="#BoolPatientSeries.if_null_then" title="Permanent link">🔗</a>
+</div>
+<div markdown="block" class="indent">
+Deprecated alias for `when_null_then()`
+
+This will be removed in future versions of ehrQL and shoud not be used.
 </div>
 
 <div class="attr-heading" id="BoolPatientSeries.is_in">
@@ -199,14 +209,24 @@ NULL, and False otherwise.
 Return the inverse of `is_null()` above.
 </div>
 
-<div class="attr-heading" id="BoolEventSeries.if_null_then">
-  <tt><strong>if_null_then</strong>(<em>other</em>)</tt>
-  <a class="headerlink" href="#BoolEventSeries.if_null_then" title="Permanent link">🔗</a>
+<div class="attr-heading" id="BoolEventSeries.when_null_then">
+  <tt><strong>when_null_then</strong>(<em>other</em>)</tt>
+  <a class="headerlink" href="#BoolEventSeries.when_null_then" title="Permanent link">🔗</a>
 </div>
 <div markdown="block" class="indent">
 Replace any NULL value in this series with the corresponding value in `other`.
 
 Note that `other` must be of the same type as this series.
+</div>
+
+<div class="attr-heading" id="BoolEventSeries.if_null_then">
+  <tt><strong>if_null_then</strong>(<em>other</em>)</tt>
+  <a class="headerlink" href="#BoolEventSeries.if_null_then" title="Permanent link">🔗</a>
+</div>
+<div markdown="block" class="indent">
+Deprecated alias for `when_null_then()`
+
+This will be removed in future versions of ehrQL and shoud not be used.
 </div>
 
 <div class="attr-heading" id="BoolEventSeries.is_in">
@@ -340,14 +360,24 @@ NULL, and False otherwise.
 Return the inverse of `is_null()` above.
 </div>
 
-<div class="attr-heading" id="StrPatientSeries.if_null_then">
-  <tt><strong>if_null_then</strong>(<em>other</em>)</tt>
-  <a class="headerlink" href="#StrPatientSeries.if_null_then" title="Permanent link">🔗</a>
+<div class="attr-heading" id="StrPatientSeries.when_null_then">
+  <tt><strong>when_null_then</strong>(<em>other</em>)</tt>
+  <a class="headerlink" href="#StrPatientSeries.when_null_then" title="Permanent link">🔗</a>
 </div>
 <div markdown="block" class="indent">
 Replace any NULL value in this series with the corresponding value in `other`.
 
 Note that `other` must be of the same type as this series.
+</div>
+
+<div class="attr-heading" id="StrPatientSeries.if_null_then">
+  <tt><strong>if_null_then</strong>(<em>other</em>)</tt>
+  <a class="headerlink" href="#StrPatientSeries.if_null_then" title="Permanent link">🔗</a>
+</div>
+<div markdown="block" class="indent">
+Deprecated alias for `when_null_then()`
+
+This will be removed in future versions of ehrQL and shoud not be used.
 </div>
 
 <div class="attr-heading" id="StrPatientSeries.is_in">
@@ -481,14 +511,24 @@ NULL, and False otherwise.
 Return the inverse of `is_null()` above.
 </div>
 
-<div class="attr-heading" id="StrEventSeries.if_null_then">
-  <tt><strong>if_null_then</strong>(<em>other</em>)</tt>
-  <a class="headerlink" href="#StrEventSeries.if_null_then" title="Permanent link">🔗</a>
+<div class="attr-heading" id="StrEventSeries.when_null_then">
+  <tt><strong>when_null_then</strong>(<em>other</em>)</tt>
+  <a class="headerlink" href="#StrEventSeries.when_null_then" title="Permanent link">🔗</a>
 </div>
 <div markdown="block" class="indent">
 Replace any NULL value in this series with the corresponding value in `other`.
 
 Note that `other` must be of the same type as this series.
+</div>
+
+<div class="attr-heading" id="StrEventSeries.if_null_then">
+  <tt><strong>if_null_then</strong>(<em>other</em>)</tt>
+  <a class="headerlink" href="#StrEventSeries.if_null_then" title="Permanent link">🔗</a>
+</div>
+<div markdown="block" class="indent">
+Deprecated alias for `when_null_then()`
+
+This will be removed in future versions of ehrQL and shoud not be used.
 </div>
 
 <div class="attr-heading" id="StrEventSeries.is_in">
@@ -708,14 +748,24 @@ NULL, and False otherwise.
 Return the inverse of `is_null()` above.
 </div>
 
-<div class="attr-heading" id="IntPatientSeries.if_null_then">
-  <tt><strong>if_null_then</strong>(<em>other</em>)</tt>
-  <a class="headerlink" href="#IntPatientSeries.if_null_then" title="Permanent link">🔗</a>
+<div class="attr-heading" id="IntPatientSeries.when_null_then">
+  <tt><strong>when_null_then</strong>(<em>other</em>)</tt>
+  <a class="headerlink" href="#IntPatientSeries.when_null_then" title="Permanent link">🔗</a>
 </div>
 <div markdown="block" class="indent">
 Replace any NULL value in this series with the corresponding value in `other`.
 
 Note that `other` must be of the same type as this series.
+</div>
+
+<div class="attr-heading" id="IntPatientSeries.if_null_then">
+  <tt><strong>if_null_then</strong>(<em>other</em>)</tt>
+  <a class="headerlink" href="#IntPatientSeries.if_null_then" title="Permanent link">🔗</a>
+</div>
+<div markdown="block" class="indent">
+Deprecated alias for `when_null_then()`
+
+This will be removed in future versions of ehrQL and shoud not be used.
 </div>
 
 <div class="attr-heading" id="IntPatientSeries.is_in">
@@ -913,14 +963,24 @@ NULL, and False otherwise.
 Return the inverse of `is_null()` above.
 </div>
 
-<div class="attr-heading" id="IntEventSeries.if_null_then">
-  <tt><strong>if_null_then</strong>(<em>other</em>)</tt>
-  <a class="headerlink" href="#IntEventSeries.if_null_then" title="Permanent link">🔗</a>
+<div class="attr-heading" id="IntEventSeries.when_null_then">
+  <tt><strong>when_null_then</strong>(<em>other</em>)</tt>
+  <a class="headerlink" href="#IntEventSeries.when_null_then" title="Permanent link">🔗</a>
 </div>
 <div markdown="block" class="indent">
 Replace any NULL value in this series with the corresponding value in `other`.
 
 Note that `other` must be of the same type as this series.
+</div>
+
+<div class="attr-heading" id="IntEventSeries.if_null_then">
+  <tt><strong>if_null_then</strong>(<em>other</em>)</tt>
+  <a class="headerlink" href="#IntEventSeries.if_null_then" title="Permanent link">🔗</a>
+</div>
+<div markdown="block" class="indent">
+Deprecated alias for `when_null_then()`
+
+This will be removed in future versions of ehrQL and shoud not be used.
 </div>
 
 <div class="attr-heading" id="IntEventSeries.is_in">
@@ -1163,14 +1223,24 @@ NULL, and False otherwise.
 Return the inverse of `is_null()` above.
 </div>
 
-<div class="attr-heading" id="FloatPatientSeries.if_null_then">
-  <tt><strong>if_null_then</strong>(<em>other</em>)</tt>
-  <a class="headerlink" href="#FloatPatientSeries.if_null_then" title="Permanent link">🔗</a>
+<div class="attr-heading" id="FloatPatientSeries.when_null_then">
+  <tt><strong>when_null_then</strong>(<em>other</em>)</tt>
+  <a class="headerlink" href="#FloatPatientSeries.when_null_then" title="Permanent link">🔗</a>
 </div>
 <div markdown="block" class="indent">
 Replace any NULL value in this series with the corresponding value in `other`.
 
 Note that `other` must be of the same type as this series.
+</div>
+
+<div class="attr-heading" id="FloatPatientSeries.if_null_then">
+  <tt><strong>if_null_then</strong>(<em>other</em>)</tt>
+  <a class="headerlink" href="#FloatPatientSeries.if_null_then" title="Permanent link">🔗</a>
+</div>
+<div markdown="block" class="indent">
+Deprecated alias for `when_null_then()`
+
+This will be removed in future versions of ehrQL and shoud not be used.
 </div>
 
 <div class="attr-heading" id="FloatPatientSeries.is_in">
@@ -1368,14 +1438,24 @@ NULL, and False otherwise.
 Return the inverse of `is_null()` above.
 </div>
 
-<div class="attr-heading" id="FloatEventSeries.if_null_then">
-  <tt><strong>if_null_then</strong>(<em>other</em>)</tt>
-  <a class="headerlink" href="#FloatEventSeries.if_null_then" title="Permanent link">🔗</a>
+<div class="attr-heading" id="FloatEventSeries.when_null_then">
+  <tt><strong>when_null_then</strong>(<em>other</em>)</tt>
+  <a class="headerlink" href="#FloatEventSeries.when_null_then" title="Permanent link">🔗</a>
 </div>
 <div markdown="block" class="indent">
 Replace any NULL value in this series with the corresponding value in `other`.
 
 Note that `other` must be of the same type as this series.
+</div>
+
+<div class="attr-heading" id="FloatEventSeries.if_null_then">
+  <tt><strong>if_null_then</strong>(<em>other</em>)</tt>
+  <a class="headerlink" href="#FloatEventSeries.if_null_then" title="Permanent link">🔗</a>
+</div>
+<div markdown="block" class="indent">
+Deprecated alias for `when_null_then()`
+
+This will be removed in future versions of ehrQL and shoud not be used.
 </div>
 
 <div class="attr-heading" id="FloatEventSeries.is_in">
@@ -1594,14 +1674,24 @@ NULL, and False otherwise.
 Return the inverse of `is_null()` above.
 </div>
 
-<div class="attr-heading" id="DatePatientSeries.if_null_then">
-  <tt><strong>if_null_then</strong>(<em>other</em>)</tt>
-  <a class="headerlink" href="#DatePatientSeries.if_null_then" title="Permanent link">🔗</a>
+<div class="attr-heading" id="DatePatientSeries.when_null_then">
+  <tt><strong>when_null_then</strong>(<em>other</em>)</tt>
+  <a class="headerlink" href="#DatePatientSeries.when_null_then" title="Permanent link">🔗</a>
 </div>
 <div markdown="block" class="indent">
 Replace any NULL value in this series with the corresponding value in `other`.
 
 Note that `other` must be of the same type as this series.
+</div>
+
+<div class="attr-heading" id="DatePatientSeries.if_null_then">
+  <tt><strong>if_null_then</strong>(<em>other</em>)</tt>
+  <a class="headerlink" href="#DatePatientSeries.if_null_then" title="Permanent link">🔗</a>
+</div>
+<div markdown="block" class="indent">
+Deprecated alias for `when_null_then()`
+
+This will be removed in future versions of ehrQL and shoud not be used.
 </div>
 
 <div class="attr-heading" id="DatePatientSeries.is_in">
@@ -1844,14 +1934,24 @@ NULL, and False otherwise.
 Return the inverse of `is_null()` above.
 </div>
 
-<div class="attr-heading" id="DateEventSeries.if_null_then">
-  <tt><strong>if_null_then</strong>(<em>other</em>)</tt>
-  <a class="headerlink" href="#DateEventSeries.if_null_then" title="Permanent link">🔗</a>
+<div class="attr-heading" id="DateEventSeries.when_null_then">
+  <tt><strong>when_null_then</strong>(<em>other</em>)</tt>
+  <a class="headerlink" href="#DateEventSeries.when_null_then" title="Permanent link">🔗</a>
 </div>
 <div markdown="block" class="indent">
 Replace any NULL value in this series with the corresponding value in `other`.
 
 Note that `other` must be of the same type as this series.
+</div>
+
+<div class="attr-heading" id="DateEventSeries.if_null_then">
+  <tt><strong>if_null_then</strong>(<em>other</em>)</tt>
+  <a class="headerlink" href="#DateEventSeries.if_null_then" title="Permanent link">🔗</a>
+</div>
+<div markdown="block" class="indent">
+Deprecated alias for `when_null_then()`
+
+This will be removed in future versions of ehrQL and shoud not be used.
 </div>
 
 <div class="attr-heading" id="DateEventSeries.is_in">
@@ -2081,14 +2181,24 @@ NULL, and False otherwise.
 Return the inverse of `is_null()` above.
 </div>
 
-<div class="attr-heading" id="CodePatientSeries.if_null_then">
-  <tt><strong>if_null_then</strong>(<em>other</em>)</tt>
-  <a class="headerlink" href="#CodePatientSeries.if_null_then" title="Permanent link">🔗</a>
+<div class="attr-heading" id="CodePatientSeries.when_null_then">
+  <tt><strong>when_null_then</strong>(<em>other</em>)</tt>
+  <a class="headerlink" href="#CodePatientSeries.when_null_then" title="Permanent link">🔗</a>
 </div>
 <div markdown="block" class="indent">
 Replace any NULL value in this series with the corresponding value in `other`.
 
 Note that `other` must be of the same type as this series.
+</div>
+
+<div class="attr-heading" id="CodePatientSeries.if_null_then">
+  <tt><strong>if_null_then</strong>(<em>other</em>)</tt>
+  <a class="headerlink" href="#CodePatientSeries.if_null_then" title="Permanent link">🔗</a>
+</div>
+<div markdown="block" class="indent">
+Deprecated alias for `when_null_then()`
+
+This will be removed in future versions of ehrQL and shoud not be used.
 </div>
 
 <div class="attr-heading" id="CodePatientSeries.is_in">
@@ -2181,14 +2291,24 @@ NULL, and False otherwise.
 Return the inverse of `is_null()` above.
 </div>
 
-<div class="attr-heading" id="CodeEventSeries.if_null_then">
-  <tt><strong>if_null_then</strong>(<em>other</em>)</tt>
-  <a class="headerlink" href="#CodeEventSeries.if_null_then" title="Permanent link">🔗</a>
+<div class="attr-heading" id="CodeEventSeries.when_null_then">
+  <tt><strong>when_null_then</strong>(<em>other</em>)</tt>
+  <a class="headerlink" href="#CodeEventSeries.when_null_then" title="Permanent link">🔗</a>
 </div>
 <div markdown="block" class="indent">
 Replace any NULL value in this series with the corresponding value in `other`.
 
 Note that `other` must be of the same type as this series.
+</div>
+
+<div class="attr-heading" id="CodeEventSeries.if_null_then">
+  <tt><strong>if_null_then</strong>(<em>other</em>)</tt>
+  <a class="headerlink" href="#CodeEventSeries.if_null_then" title="Permanent link">🔗</a>
+</div>
+<div markdown="block" class="indent">
+Deprecated alias for `when_null_then()`
+
+This will be removed in future versions of ehrQL and shoud not be used.
 </div>
 
 <div class="attr-heading" id="CodeEventSeries.is_in">

--- a/docs/includes/generated_docs/schemas/beta.tpp.md
+++ b/docs/includes/generated_docs/schemas/beta.tpp.md
@@ -57,7 +57,7 @@ from which other larger geographic representations can be derived
         when(imd < int(32844 * 3 / 5)).then("3"),
         when(imd < int(32844 * 4 / 5)).then("4"),
         when(imd < int(32844 * 5 / 5)).then("5 (least deprived)"),
-        default="unknown"
+        otherwise="unknown"
     )
     ```
 
@@ -241,7 +241,7 @@ spanning_addrs = addresses.where(addresses.start_date <= date).except_where(
     addresses.end_date < date
 )
 ordered_addrs = spanning_addrs.sort_by(
-    case(when(addresses.has_postcode).then(1), default=0),
+    case(when(addresses.has_postcode).then(1), otherwise=0),
     addresses.start_date,
     addresses.end_date,
     addresses.address_id,

--- a/docs/includes/generated_docs/specs.md
+++ b/docs/includes/generated_docs/specs.md
@@ -1262,7 +1262,7 @@ returns the following patient series:
 ### 6.4 Replace missing values
 
 
-#### 6.4.1 If null then integer column
+#### 6.4.1 When null then integer column
 
 This example makes use of a patient-level table named `p` containing the following data:
 
@@ -1274,7 +1274,7 @@ This example makes use of a patient-level table named `p` containing the followi
 | 4| |
 
 ```python
-p.i1.if_null_then(0)
+p.i1.when_null_then(0)
 ```
 returns the following patient series:
 
@@ -1287,7 +1287,7 @@ returns the following patient series:
 
 
 
-#### 6.4.2 If null then boolean column
+#### 6.4.2 When null then boolean column
 
 This example makes use of a patient-level table named `p` containing the following data:
 
@@ -1299,7 +1299,7 @@ This example makes use of a patient-level table named `p` containing the followi
 | 4| |
 
 ```python
-p.i1.is_in([101, 201]).if_null_then(False)
+p.i1.is_in([101, 201]).when_null_then(False)
 ```
 returns the following patient series:
 
@@ -2760,7 +2760,7 @@ This example makes use of a patient-level table named `p` containing the followi
 case(
     when(p.i1 < 8).then(p.i1),
     when(p.i1 > 8).then(100),
-    default=0,
+    otherwise=0,
 )
 ```
 returns the following patient series:

--- a/ehrql/query_language.py
+++ b/ehrql/query_language.py
@@ -203,7 +203,7 @@ class BaseSeries:
         """
         return self.is_null().__invert__()
 
-    def if_null_then(self, other):
+    def when_null_then(self, other):
         """
         Replace any NULL value in this series with the corresponding value in `other`.
 
@@ -213,6 +213,14 @@ class BaseSeries:
             when(self.is_not_null()).then(self),
             otherwise=self._cast(other),
         )
+
+    def if_null_then(self, other):
+        """
+        Deprecated alias for `when_null_then()`
+
+        This will be removed in future versions of ehrQL and shoud not be used.
+        """
+        return self.when_null_then(other)
 
     def is_in(self, other):
         """

--- a/ehrql/tables/beta/tpp.py
+++ b/ehrql/tables/beta/tpp.py
@@ -61,7 +61,7 @@ class addresses(EventFrame):
             when(imd < int(32844 * 3 / 5)).then("3"),
             when(imd < int(32844 * 4 / 5)).then("4"),
             when(imd < int(32844 * 5 / 5)).then("5 (least deprived)"),
-            default="unknown"
+            otherwise="unknown"
         )
         ```
 
@@ -152,7 +152,7 @@ class addresses(EventFrame):
             self.end_date < date
         )
         ordered_addrs = spanning_addrs.sort_by(
-            case(when(self.has_postcode).then(1), default=0),
+            case(when(self.has_postcode).then(1), otherwise=0),
             self.start_date,
             self.end_date,
             self.address_id,

--- a/tests/spec/case_expressions/test_case.py
+++ b/tests/spec/case_expressions/test_case.py
@@ -41,7 +41,7 @@ def test_case_with_default(spec_test):
         case(
             when(p.i1 < 8).then(p.i1),
             when(p.i1 > 8).then(100),
-            default=0,
+            otherwise=0,
         ),
         {
             1: 6,

--- a/tests/spec/series_ops/test_when_null_then.py
+++ b/tests/spec/series_ops/test_when_null_then.py
@@ -15,10 +15,10 @@ table_data = {
 }
 
 
-def test_if_null_then_integer_column(spec_test):
+def test_when_null_then_integer_column(spec_test):
     spec_test(
         table_data,
-        p.i1.if_null_then(0),
+        p.i1.when_null_then(0),
         {
             1: 101,
             2: 201,
@@ -28,10 +28,10 @@ def test_if_null_then_integer_column(spec_test):
     )
 
 
-def test_if_null_then_boolean_column(spec_test):
+def test_when_null_then_boolean_column(spec_test):
     spec_test(
         table_data,
-        p.i1.is_in([101, 201]).if_null_then(False),
+        p.i1.is_in([101, 201]).when_null_then(False),
         {
             1: True,
             2: True,

--- a/tests/spec/toc.py
+++ b/tests/spec/toc.py
@@ -32,7 +32,7 @@ contents = {
         "test_equality",
         "test_containment",
         "test_map_values",
-        "test_if_null_then",
+        "test_when_null_then",
         "test_maximum_of_and_minimum_of_patient_series",
         "test_maximum_of_and_minimum_of_event_series",
     ],

--- a/tests/unit/test_query_language.py
+++ b/tests/unit/test_query_language.py
@@ -781,3 +781,10 @@ def test_case_accepts_default_as_alias_for_otherwise():
 def test_case_rejects_default_and_otherwise_supplied_together():
     with pytest.raises(ValueError, match="Use `otherwise` instead of `default`"):
         case(when(events.f > 10).then("foo"), default="bar", otherwise="baz")
+
+
+def test_if_null_then_alias():
+    if_null = events.f.if_null_then(0.0)
+    when_null = events.f.when_null_then(0.0)
+
+    assert if_null._qm_node == when_null._qm_node

--- a/tests/unit/test_query_language.py
+++ b/tests/unit/test_query_language.py
@@ -759,19 +759,11 @@ def test_duration_generate_intervals_rejects_invalid_arguments(
     ],
 )
 def test_count_episodes_for_patient_rejects_invalid_arguments(maximum_gap, error):
-    @table
-    class e(EventFrame):
-        d = Series(date)
-
     with pytest.raises((TypeError, ValueError), match=error):
-        e.d.count_episodes_for_patient(maximum_gap)
+        events.event_date.count_episodes_for_patient(maximum_gap)
 
 
 def test_count_episodes_for_patient_handles_weeks():
-    @table
-    class e(EventFrame):
-        d = Series(date)
-
-    using_days = e.d.count_episodes_for_patient(days(14))
-    using_weeks = e.d.count_episodes_for_patient(weeks(2))
+    using_days = events.event_date.count_episodes_for_patient(days(14))
+    using_weeks = events.event_date.count_episodes_for_patient(weeks(2))
     assert using_days._qm_node == using_weeks._qm_node

--- a/tests/unit/test_query_language.py
+++ b/tests/unit/test_query_language.py
@@ -27,6 +27,7 @@ from ehrql.query_language import (
     Series,
     StrEventSeries,
     StrPatientSeries,
+    case,
     compile,
     create_dataset,
     days,
@@ -36,6 +37,7 @@ from ehrql.query_language import (
     table_from_file,
     table_from_rows,
     weeks,
+    when,
     years,
 )
 from ehrql.query_model.column_specs import ColumnSpec
@@ -767,3 +769,15 @@ def test_count_episodes_for_patient_handles_weeks():
     using_days = events.event_date.count_episodes_for_patient(days(14))
     using_weeks = events.event_date.count_episodes_for_patient(weeks(2))
     assert using_days._qm_node == using_weeks._qm_node
+
+
+def test_case_accepts_default_as_alias_for_otherwise():
+    case_otherwise = case(when(events.f > 10).then("foo"), otherwise="bar")
+    case_default = case(when(events.f > 10).then("foo"), default="bar")
+
+    assert case_otherwise._qm_node == case_default._qm_node
+
+
+def test_case_rejects_default_and_otherwise_supplied_together():
+    with pytest.raises(ValueError, match="Use `otherwise` instead of `default`"):
+        case(when(events.f > 10).then("foo"), default="bar", otherwise="baz")


### PR DESCRIPTION
This makes two changes to our logical functions:
 * Replaces `case(..., default=...)` with `case(..., otherwise=...)`
 * Replaces `if_null_then()` with `when_null_then()`

In both cases this gives us better consistency of terminology. The old functions/arguments are retained as aliases for now so there are no backwards compatibility concerns.

We plan to remove the aliases when we release `v1`.

Closes #1439
Closes #1621