### PR TITLE
Assign categories to categorical columns

### DIFF
--- a/docs/includes/generated_docs/schemas/beta.tpp.md
+++ b/docs/includes/generated_docs/schemas/beta.tpp.md
@@ -108,8 +108,13 @@ Date patient moved out of address.
     <code>integer</code>
   </dt>
   <dd markdown="block">
-Type of address.
+Type of address:
 
+* 0 - Permanent
+* 1 - Temporary
+* 3 - Correspondence only
+
+ * Possible values: `0`, `1`, `3`
   </dd>
 </div>
 
@@ -641,6 +646,7 @@ The date the patient self presented at the accident & emergency department, or a
   <dd markdown="block">
 The core Healthcare Resource Group (HRG) code derived by sus+, used for tariff application.
 
+ * Matches regular expression: `[a-zA-Z]{2}[0-9]{2}[a-zA-Z]`
   </dd>
 </div>
 
@@ -1709,6 +1715,7 @@ An indication of whether a patient is making a first attendance or contact; or a
   <dd markdown="block">
 The Healthcare Resource Group (HRG) code assigned to the activity, used to assign baseline tariff costs.
 
+ * Matches regular expression: `[a-zA-Z]{2}[0-9]{2}[a-zA-Z]`
   </dd>
 </div>
 

--- a/ehrql/tables/beta/tpp.py
+++ b/ehrql/tables/beta/tpp.py
@@ -82,7 +82,14 @@ class addresses(EventFrame):
     )
     address_type = Series(
         int,
-        description="Type of address.",
+        description="""
+            Type of address:
+
+            * 0 - Permanent
+            * 1 - Temporary
+            * 3 - Correspondence only
+        """,
+        constraints=[Constraint.Categorical([0, 1, 3])],
     )
     rural_urban_classification = Series(
         int,

--- a/ehrql/tables/beta/tpp.py
+++ b/ehrql/tables/beta/tpp.py
@@ -615,6 +615,9 @@ class opa(EventFrame):
             "The Healthcare Resource Group (HRG) code assigned to the activity, "
             "used to assign baseline tariff costs."
         ),
+        # For the format of an HRG code, see:
+        # https://en.wikipedia.org/wiki/Healthcare_Resource_Group
+        constraints=[Constraint.Regex(r"[a-zA-Z]{2}[0-9]{2}[a-zA-Z]")],
     )
     treatment_function_code = Series(
         str,

--- a/ehrql/tables/beta/tpp.py
+++ b/ehrql/tables/beta/tpp.py
@@ -390,6 +390,9 @@ class ec(EventFrame):
             "The core Healthcare Resource Group (HRG) code derived by sus+, "
             "used for tariff application."
         ),
+        # For the format of an HRG code, see:
+        # https://en.wikipedia.org/wiki/Healthcare_Resource_Group
+        constraints=[Constraint.Regex(r"[a-zA-Z]{2}[0-9]{2}[a-zA-Z]")],
     )
 
 

--- a/tests/unit/test_tables.py
+++ b/tests/unit/test_tables.py
@@ -20,6 +20,7 @@ def test___all__(module):
 
 valid_examples_for_regex_constraints = [
     (tpp.addresses, "msoa_code", "E02012345"),
+    (tpp.ec, "sus_hrg_code", "AA00A"),
     (tpp.practice_registrations, "practice_stp", "E54000012"),
     (tpp.wl_clockstops, "activity_treatment_function_code", "AB1"),
     (tpp.wl_openpathways, "activity_treatment_function_code", "AB1"),
@@ -28,6 +29,7 @@ valid_examples_for_regex_constraints = [
 
 invalid_examples_for_regex_constraints = [
     (tpp.addresses, "msoa_code", "X02012345"),
+    (tpp.ec, "sus_hrg_code", "AA000A"),
     (tpp.practice_registrations, "practice_stp", "X54000012"),
     (tpp.wl_clockstops, "activity_treatment_function_code", "AB10"),
     (tpp.wl_openpathways, "activity_treatment_function_code", "AB10"),

--- a/tests/unit/test_tables.py
+++ b/tests/unit/test_tables.py
@@ -1,7 +1,11 @@
+import re
+
 import pytest
 
 import ehrql.tables
 from ehrql.query_language import get_tables_from_namespace
+from ehrql.tables import Constraint
+from ehrql.tables.beta import tpp
 from ehrql.utils.module_utils import get_submodules
 
 
@@ -12,3 +16,64 @@ def test___all__(module):
         pytest.skip(f"{module.__name__} has no tables")
     assert module.__all__ == sorted(module.__all__)
     assert table_names == set(module.__all__)
+
+
+valid_examples_for_regex_constraints = [
+    (tpp.addresses, "msoa_code", "E02012345"),
+    (tpp.practice_registrations, "practice_stp", "E54000012"),
+    (tpp.wl_clockstops, "activity_treatment_function_code", "AB1"),
+    (tpp.wl_openpathways, "activity_treatment_function_code", "AB1"),
+    (tpp.wl_openpathways, "source_of_referral", "A1"),
+]
+
+invalid_examples_for_regex_constraints = [
+    (tpp.addresses, "msoa_code", "X02012345"),
+    (tpp.practice_registrations, "practice_stp", "X54000012"),
+    (tpp.wl_clockstops, "activity_treatment_function_code", "AB10"),
+    (tpp.wl_openpathways, "activity_treatment_function_code", "AB10"),
+    (tpp.wl_openpathways, "source_of_referral", "A10"),
+]
+
+
+@pytest.mark.parametrize(
+    "table,column_name,example", valid_examples_for_regex_constraints
+)
+def test_regex_constraints_match_valid_examples(table, column_name, example):
+    regex = get_regex_constraint(table, column_name)
+    assert bool(re.fullmatch(regex, example))
+
+
+@pytest.mark.parametrize(
+    "table,column_name,example", invalid_examples_for_regex_constraints
+)
+def test_regex_constraints_do_not_match_invalid_examples(table, column_name, example):
+    regex = get_regex_constraint(table, column_name)
+    assert not bool(re.fullmatch(regex, example))
+
+
+@pytest.mark.parametrize(
+    "examples",
+    [valid_examples_for_regex_constraints, invalid_examples_for_regex_constraints],
+)
+def test_all_regex_constraints_are_tested(examples):
+    tables = {
+        table
+        for module in get_submodules(ehrql.tables)
+        for _, table in get_tables_from_namespace(module)
+    }
+    tables_column_names = {
+        (table, column_name)
+        for table in tables
+        for column_name in table._qm_node.schema.column_names
+        if get_regex_constraint(table, column_name)
+    }
+
+    assert tables_column_names == {
+        (table, column_name) for table, column_name, _ in examples
+    }
+
+
+def get_regex_constraint(table, column_name):
+    schema = table._qm_node.schema
+    constraint = schema.get_column_constraint_by_type(column_name, Constraint.Regex)
+    return getattr(constraint, "regex", None)

--- a/tests/unit/test_tables.py
+++ b/tests/unit/test_tables.py
@@ -21,6 +21,7 @@ def test___all__(module):
 valid_examples_for_regex_constraints = [
     (tpp.addresses, "msoa_code", "E02012345"),
     (tpp.ec, "sus_hrg_code", "AA00A"),
+    (tpp.opa, "hrg_code", "AA00A"),
     (tpp.practice_registrations, "practice_stp", "E54000012"),
     (tpp.wl_clockstops, "activity_treatment_function_code", "AB1"),
     (tpp.wl_openpathways, "activity_treatment_function_code", "AB1"),
@@ -30,6 +31,7 @@ valid_examples_for_regex_constraints = [
 invalid_examples_for_regex_constraints = [
     (tpp.addresses, "msoa_code", "X02012345"),
     (tpp.ec, "sus_hrg_code", "AA000A"),
+    (tpp.opa, "hrg_code", "AA000A"),
     (tpp.practice_registrations, "practice_stp", "X54000012"),
     (tpp.wl_clockstops, "activity_treatment_function_code", "AB10"),
     (tpp.wl_openpathways, "activity_treatment_function_code", "AB10"),


### PR DESCRIPTION
I've reworked this PR. Originally, it added several categorical constraints that reflected the current state of the OpenSAFELY TPP database ❄️. Now, it adds one categorical constraint and two regex constraints that do not. Because I'm not confident that I can write a regex correctly, I also added three tests 🧞:

1. test columns with regex constraints against valid examples;
2. test columns with regex constraints against invalid examples;
3. test all columns with regex constraints are tested against valid and invalid examples.

For evidence that that constraints added in this PR hold with respect to the data in the OpenSAFELY TPP database, then please see the released outputs of the [tpp-database-categorical-columns][1] workspace.

[1]: https://jobs.opensafely.org/opensafely-internal/tpp-database-categorical-columns/