### PR TITLE
Add patients and clinical events tables for EMIS backend

### DIFF
--- a/docs/includes/generated_docs/backends.md
+++ b/docs/includes/generated_docs/backends.md
@@ -40,4 +40,5 @@ This backend implements the following table schemas:
 
  * [beta.core](../schemas/beta.core/)
  * [beta.raw.core](../schemas/beta.raw.core/)
+ * [beta.emis](../schemas/beta.emis/)
  * [beta.smoketest](../schemas/beta.smoketest/)

--- a/docs/includes/generated_docs/schemas.md
+++ b/docs/includes/generated_docs/schemas.md
@@ -20,6 +20,17 @@ This schema defines the core tables and columns which should be available in any
 providing primary care data, allowing dataset definitions written using this schema to
 run across multiple backends.
 
+## [beta.emis](./beta.emis/)
+<small class="subtitle">
+  <a href="./beta.emis/"> view details → </a>
+</small>
+
+Available on backends: [**EMIS**](../backends#emis)
+
+This schema defines the data (both primary care and externally linked) available in the
+OpenSAFELY-EMIS backend. For more information about this backend, see
+"[EMIS Primary Care](https://docs.opensafely.org/data-sources/emis/)".
+
 ## [beta.raw.core](./beta.raw.core/)
 <small class="subtitle">
   <a href="./beta.raw.core/"> view details → </a>

--- a/docs/includes/generated_docs/schemas/beta.emis.md
+++ b/docs/includes/generated_docs/schemas/beta.emis.md
@@ -1,0 +1,185 @@
+# <strong>beta.emis</strong> schema
+
+Available on backends: [**EMIS**](../../backends#emis)
+
+This schema defines the data (both primary care and externally linked) available in the
+OpenSAFELY-EMIS backend. For more information about this backend, see
+"[EMIS Primary Care](https://docs.opensafely.org/data-sources/emis/)".
+
+``` {.python .copy title='To use this schema in an ehrQL file:'}
+from ehrql.tables.beta.emis import (
+    clinical_events,
+    patients,
+)
+```
+
+<p class="dimension-indicator"><code>many rows per patient</code></p>
+## clinical_events
+
+Each record corresponds to a single clinical or consultation event for a patient.
+
+Note that event codes do not change in this table. If an event code in the coding
+system becomes inactive, the event will still be coded to the inactive code.
+As such, codelists should include all relevant inactive codes.
+<div markdown="block" class="definition-list-wrapper">
+  <div class="title">Columns</div>
+  <dl markdown="block">
+<div markdown="block">
+  <dt id="clinical_events.date">
+    <strong>date</strong>
+    <a class="headerlink" href="#clinical_events.date" title="Permanent link">🔗</a>
+    <code>date</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="clinical_events.snomedct_code">
+    <strong>snomedct_code</strong>
+    <a class="headerlink" href="#clinical_events.snomedct_code" title="Permanent link">🔗</a>
+    <code>SNOMED-CT code</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="clinical_events.numeric_value">
+    <strong>numeric_value</strong>
+    <a class="headerlink" href="#clinical_events.numeric_value" title="Permanent link">🔗</a>
+    <code>float</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+  </dl>
+</div>
+
+
+<p class="dimension-indicator"><code>one row per patient</code></p>
+## patients
+
+Patients in primary care.
+
+### Representativeness
+
+You can find out more about the representativeness of these data in the
+OpenSAFELY-TPP backend in:
+
+> The OpenSAFELY Collaborative, Colm D. Andrews, Anna Schultze, Helen J. Curtis, William J. Hulme, John Tazare, Stephen J. W. Evans, _et al._ 2022.
+> "OpenSAFELY: Representativeness of Electronic Health Record Platform OpenSAFELY-TPP Data Compared to the Population of England."
+> Wellcome Open Res 2022, 7:191.
+> <https://doi.org/10.12688/wellcomeopenres.18010.1>
+
+
+### Orphan records
+
+If a practice becomes aware that a patient has moved house,
+then the practice _deducts_, or removes, the patient's records from their register.
+If the patient doesn't register with a new practice within a given amount of time
+(normally from four to eight weeks),
+then the patient's records are permanently deducted and are _orphan records_.
+There are roughly 1.6 million orphan records.
+
+### Recording of death in primary care
+
+In England, it is the statutory duty of the doctor who had attended in the last
+illness to complete a medical certificate of cause of death (MCCD). ONS death data
+are considered the gold standard for identifying patient deaths because they are
+based on these MCCDs.
+
+There is generally a lag between the death being recorded in ONS data and it
+appearing in the primary care record, but the coverage or recorded death is almost
+complete and the date of death is usually reliable when it appears. There is
+also a lag in ONS death recording (see [`ons_deaths`](/reference/schemas/beta.core/#ons_deaths) below
+for more detail). You can find out more about the accuracy of date of death
+recording in primary care in:
+
+> Gallagher, A. M., Dedman, D., Padmanabhan, S., Leufkens, H. G. M. & de Vries, F 2019. The accuracy of date of death recording in the Clinical
+> Practice Research Datalink GOLD database in England compared with the Office for National Statistics death registrations.
+> Pharmacoepidemiol. Drug Saf. 28, 563–569.
+> <https://doi.org/10.1002/pds.4747>
+
+By contrast, cause of death is often not accurate in the primary care record so we
+don't make it available to query here.
+<div markdown="block" class="definition-list-wrapper">
+  <div class="title">Columns</div>
+  <dl markdown="block">
+<div markdown="block">
+  <dt id="patients.date_of_birth">
+    <strong>date_of_birth</strong>
+    <a class="headerlink" href="#patients.date_of_birth" title="Permanent link">🔗</a>
+    <code>date</code>
+  </dt>
+  <dd markdown="block">
+Patient's date of birth.
+
+ * Always the first day of a month
+ * Never `NULL`
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="patients.sex">
+    <strong>sex</strong>
+    <a class="headerlink" href="#patients.sex" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+Patient's sex.
+
+ * Possible values: `female`, `male`, `intersex`, `unknown`
+ * Never `NULL`
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="patients.date_of_death">
+    <strong>date_of_death</strong>
+    <a class="headerlink" href="#patients.date_of_death" title="Permanent link">🔗</a>
+    <code>date</code>
+  </dt>
+  <dd markdown="block">
+Patient's date of death.
+
+  </dd>
+</div>
+
+  </dl>
+</div>
+<div markdown="block" class="definition-list-wrapper">
+  <div class="title">Methods</div>
+  <dl markdown="block">
+<div markdown="block">
+  <dt id="patients.age_on">
+    <strong>age_on(</strong>date<strong>)</strong>
+    <a class="headerlink" href="#patients.age_on" title="Permanent link">🔗</a>
+    <code></code>
+  </dt>
+  <dd markdown="block">
+Patient's age as an integer, in whole elapsed calendar years, as it would be on
+the given date.
+
+This method takes no account of whether the patient is alive on the given date.
+In particular, it may return negative values if the given date is before the
+patient's date of birth.
+    <details markdown="block">
+    <summary>View method definition</summary>
+```py
+return (date - patients.date_of_birth).years
+
+```
+    </details>
+  </dd>
+</div>
+
+  </dl>
+</div>

--- a/ehrql/tables/beta/emis.py
+++ b/ehrql/tables/beta/emis.py
@@ -1,0 +1,12 @@
+"""
+This schema defines the data (both primary care and externally linked) available in the
+OpenSAFELY-EMIS backend. For more information about this backend, see
+"[EMIS Primary Care](https://docs.opensafely.org/data-sources/emis/)".
+"""
+from ehrql.tables.beta.core import clinical_events, patients
+
+
+__all__ = [
+    "clinical_events",
+    "patients",
+]

--- a/tests/integration/backends/test_emis.py
+++ b/tests/integration/backends/test_emis.py
@@ -1,0 +1,245 @@
+from datetime import date, datetime
+
+import pytest
+import sqlalchemy
+
+from ehrql.backends.emis import EMISBackend
+from ehrql.query_language import get_tables_from_namespace
+from ehrql.tables.beta import emis
+from ehrql.utils.sqlalchemy_query_utils import CreateTableAs, GeneratedTable
+from tests.lib.emis_schema import (
+    ObservationAllOrgsV2,
+    PatientAllOrgsV2,
+)
+
+
+REGISTERED_TABLES = set()
+
+
+# This slightly odd way of supplying the table object to the test function makes the
+# tests introspectable in such a way that we can confirm that every table in the module
+# is covered by a test
+def register_test_for(table):
+    def annotate_test_function(fn):
+        REGISTERED_TABLES.add(table)
+        fn._table = table
+        return fn
+
+    return annotate_test_function
+
+
+@pytest.fixture
+def select_all(request, trino_database):
+    try:
+        ql_table = request.function._table
+    except AttributeError:  # pragma: no cover
+        raise RuntimeError(
+            f"Function '{request.function.__name__}' needs the "
+            f"`@register_test_for(table)` decorator applied"
+        )
+
+    qm_table = ql_table._qm_node
+    backend = EMISBackend()
+    sql_table = backend.get_table_expression(qm_table.name, qm_table.schema)
+    columns = [
+        # Using `type_coerce(..., None)` like this strips the type information from the
+        # SQLAlchemy column meaning we get back the type that the column actually is in
+        # database, not the type we've told SQLAlchemy it is.
+        sqlalchemy.type_coerce(column, None).label(column.key)
+        for column in sql_table.columns
+    ]
+    select_all_query = sqlalchemy.select(*columns)
+
+    def _select_all(*input_data):
+        trino_database.setup(*input_data)
+        with trino_database.engine().connect() as connection:
+            results = connection.execute(select_all_query)
+            return sorted(
+                [row._asdict() for row in results], key=lambda x: x["patient_id"]
+            )
+
+    return _select_all
+
+
+def test_backend_columns_have_correct_types(trino_database):
+    columns_with_types = get_all_backend_columns_with_types(trino_database)
+    mismatched = [
+        f"{table}.{column} expects {column_type!r} but got {column_args!r}"
+        for table, column, column_type, column_args in columns_with_types
+        if not types_compatible(column_type, column_args)
+    ]
+    nl = "\n"
+    assert not mismatched, (
+        f"Mismatch between columns returned by backend queries"
+        f" queries and those expected:\n{nl.join(mismatched)}\n\n"
+    )
+
+
+def types_compatible(column_type, column_args):
+    """
+    Is this given SQLAlchemy type instance compatible with the supplied dictionary of
+    column arguments?
+    """
+    # It seems we use this sometimes for the patient ID column where we don't care what
+    # type it is
+    if isinstance(column_type, sqlalchemy.sql.sqltypes.NullType):
+        return True
+    elif isinstance(column_type, sqlalchemy.Float):
+        return column_args["type"] == "real"
+    elif isinstance(column_type, sqlalchemy.Date):
+        return column_args["type"] == "date"
+    elif isinstance(column_type, sqlalchemy.String):
+        return column_args["type"].startswith("varchar")
+    else:
+        assert False, f"Unhandled type: {column_type}"
+
+
+def get_all_backend_columns_with_types(trino_database):
+    """
+    For every column on every table we expose in the backend, yield the SQLAlchemy type
+    instance we expect to use for that column together with the type information that
+    database has for that column so we can check they're compatible
+    """
+    table_names = set()
+    column_types = {}
+    queries = []
+    for table, columns in get_all_backend_columns():
+        table_names.add(table)
+        column_types.update({(table, c.key): c.type for c in columns})
+        # Construct a query which selects every column in the table
+        select_query = sqlalchemy.select(*[c.label(c.key) for c in columns])
+        # Write the results of that query into a temporary table (it will be empty but
+        # that's fine, we just want the types)
+        # Trino doesn't support actual temporary tables, so really this temp table is
+        # a real table that we drop after the test
+        temp_table_name = f"temp_{table}"
+        temp_table = GeneratedTable.from_query(temp_table_name, select_query)
+        queries.append(
+            (temp_table_name, temp_table, CreateTableAs(temp_table, select_query))
+        )
+    # Create all the underlying tables in the database without populating them
+    trino_database.setup(metadata=PatientAllOrgsV2.metadata)
+    with trino_database.engine().connect() as connection:
+        # Create our "temporary" tables
+        for temp_table_name, temp_table, query in queries:
+            connection.execute(query)
+            # Get the column names, types and collations for all columns in those tables
+            query = sqlalchemy.text(
+                """
+                SELECT column_name, data_type
+                FROM information_schema.columns
+                WHERE table_name=:t
+                """
+            )
+            results = list(connection.execute(query, {"t": temp_table_name}))
+            table_name = temp_table_name.replace("temp_", "")
+            for column, type_name in results:
+                column_type = column_types[table_name, column]
+                column_args = {"type": type_name}
+                yield table_name, column, column_type, column_args
+
+            # Drop the temp table
+            temp_table.drop(trino_database.engine())
+
+
+def get_all_backend_columns():
+    backend = EMISBackend()
+    for _, table in get_all_tables():
+        qm_table = table._qm_node
+        table_expr = backend.get_table_expression(qm_table.name, qm_table.schema)
+        yield qm_table.name, table_expr.columns
+
+
+@register_test_for(emis.clinical_events)
+def test_clinical_events(select_all):
+    results = select_all(
+        PatientAllOrgsV2(registration_id="1"),
+        PatientAllOrgsV2(registration_id="2"),
+        ObservationAllOrgsV2(
+            registration_id="1",
+            effective_date=datetime(2020, 10, 20, 14, 30, 5),
+            snomed_concept_id=123,
+            value_pq_1=0.5,
+        ),
+        ObservationAllOrgsV2(
+            registration_id="2",
+            effective_date=datetime(2022, 1, 15, 12, 30, 5),
+            snomed_concept_id=567,
+            value_pq_1=None,
+        ),
+    )
+    assert results == [
+        {
+            "patient_id": "1",
+            "date": date(2020, 10, 20),
+            "snomedct_code": "123",
+            "numeric_value": 0.5,
+        },
+        {
+            "patient_id": "2",
+            "date": date(2022, 1, 15),
+            "snomedct_code": "567",
+            "numeric_value": None,
+        },
+    ]
+
+
+@register_test_for(emis.patients)
+def test_patients(select_all):
+    results = select_all(
+        PatientAllOrgsV2(registration_id="1", date_of_birth=date(2020, 1, 1), gender=1),
+        # duplicate registration ids are ignored
+        PatientAllOrgsV2(registration_id="2", date_of_birth=date(2020, 1, 1), gender=1),
+        PatientAllOrgsV2(registration_id="2", date_of_birth=date(2020, 1, 1), gender=1),
+        PatientAllOrgsV2(
+            registration_id="3",
+            date_of_birth=date(1960, 1, 1),
+            date_of_death=date(2020, 1, 1),
+            gender=2,
+        ),
+        PatientAllOrgsV2(registration_id="4", date_of_birth=date(2020, 1, 1), gender=0),
+        PatientAllOrgsV2(
+            registration_id="5", date_of_birth=date(1978, 10, 13), gender=9
+        ),
+    )
+    assert results == [
+        {
+            "patient_id": "1",
+            "date_of_birth": date(2020, 1, 1),
+            "sex": "male",
+            "date_of_death": None,
+        },
+        {
+            "patient_id": "3",
+            "date_of_birth": date(1960, 1, 1),
+            "sex": "female",
+            "date_of_death": date(2020, 1, 1),
+        },
+        {
+            "patient_id": "4",
+            "date_of_birth": date(2020, 1, 1),
+            "sex": "unknown",
+            "date_of_death": None,
+        },
+        {
+            "patient_id": "5",
+            "date_of_birth": date(1978, 10, 13),
+            "sex": "unknown",
+            "date_of_death": None,
+        },
+    ]
+
+
+def test_registered_tests_are_exhaustive():
+    missing = [
+        name for name, table in get_all_tables() if table not in REGISTERED_TABLES
+    ]
+    assert not missing, f"No tests for tables: {', '.join(missing)}"
+
+
+def get_all_tables():
+    # in future we're likely to need to get tables from more than one
+    # module (e.g. emis.raw)
+    for module in [emis]:
+        for name, table in get_tables_from_namespace(module):
+            yield f"{module.__name__}.{name}", table

--- a/tests/lib/emis_schema.py
+++ b/tests/lib/emis_schema.py
@@ -1,0 +1,28 @@
+# This file is manually created, unlike tpp_schema.py
+
+from sqlalchemy import types as t
+from sqlalchemy.orm import DeclarativeBase, mapped_column
+
+
+class Base(DeclarativeBase):
+    "Common base class to signal that models below belong to the same database"
+
+
+class PatientAllOrgsV2(Base):
+    __tablename__ = "patient_all_orgs_v2"
+    _pk = mapped_column(t.Integer, primary_key=True)
+
+    registration_id = mapped_column(t.VARCHAR(128))
+    gender = mapped_column(t.Integer)
+    date_of_birth = mapped_column(t.Date)
+    date_of_death = mapped_column(t.Date)
+
+
+class ObservationAllOrgsV2(Base):
+    __tablename__ = "observation_all_orgs_v2"
+    _pk = mapped_column(t.Integer, primary_key=True)
+
+    registration_id = mapped_column(t.VARCHAR(128))
+    snomed_concept_id = mapped_column(t.Integer)
+    effective_date = mapped_column(t.DateTime)
+    value_pq_1 = mapped_column(t.DECIMAL(20, 2))


### PR DESCRIPTION
The first part of #797 
- updates the patients and clinicial_events tables in the EMIS backend to use the correct source tables and columns
- adds tables.beta.emis with patients and clinical events tables
- sets up the test framework for emis tests
