### PR TITLE
Support passing a series to `is_in()`

### DIFF
--- a/docs/includes/generated_docs/language__series.md
+++ b/docs/includes/generated_docs/language__series.md
@@ -102,7 +102,7 @@ This will be removed in future versions of ehrQL and shoud not be used.
 <div markdown="block" class="indent">
 Return a boolean series which is True for each value in this series which is
 contained in `other`, where `other` can be any of the standard "container"
-types: tuple, list, set, frozenset, or dict.
+types (tuple, list, set, frozenset, or dict) or another event series.
 </div>
 
 <div class="attr-heading" id="BoolPatientSeries.is_not_in">
@@ -236,7 +236,7 @@ This will be removed in future versions of ehrQL and shoud not be used.
 <div markdown="block" class="indent">
 Return a boolean series which is True for each value in this series which is
 contained in `other`, where `other` can be any of the standard "container"
-types: tuple, list, set, frozenset, or dict.
+types (tuple, list, set, frozenset, or dict) or another event series.
 </div>
 
 <div class="attr-heading" id="BoolEventSeries.is_not_in">
@@ -387,7 +387,7 @@ This will be removed in future versions of ehrQL and shoud not be used.
 <div markdown="block" class="indent">
 Return a boolean series which is True for each value in this series which is
 contained in `other`, where `other` can be any of the standard "container"
-types: tuple, list, set, frozenset, or dict.
+types (tuple, list, set, frozenset, or dict) or another event series.
 </div>
 
 <div class="attr-heading" id="StrPatientSeries.is_not_in">
@@ -538,7 +538,7 @@ This will be removed in future versions of ehrQL and shoud not be used.
 <div markdown="block" class="indent">
 Return a boolean series which is True for each value in this series which is
 contained in `other`, where `other` can be any of the standard "container"
-types: tuple, list, set, frozenset, or dict.
+types (tuple, list, set, frozenset, or dict) or another event series.
 </div>
 
 <div class="attr-heading" id="StrEventSeries.is_not_in">
@@ -775,7 +775,7 @@ This will be removed in future versions of ehrQL and shoud not be used.
 <div markdown="block" class="indent">
 Return a boolean series which is True for each value in this series which is
 contained in `other`, where `other` can be any of the standard "container"
-types: tuple, list, set, frozenset, or dict.
+types (tuple, list, set, frozenset, or dict) or another event series.
 </div>
 
 <div class="attr-heading" id="IntPatientSeries.is_not_in">
@@ -990,7 +990,7 @@ This will be removed in future versions of ehrQL and shoud not be used.
 <div markdown="block" class="indent">
 Return a boolean series which is True for each value in this series which is
 contained in `other`, where `other` can be any of the standard "container"
-types: tuple, list, set, frozenset, or dict.
+types (tuple, list, set, frozenset, or dict) or another event series.
 </div>
 
 <div class="attr-heading" id="IntEventSeries.is_not_in">
@@ -1250,7 +1250,7 @@ This will be removed in future versions of ehrQL and shoud not be used.
 <div markdown="block" class="indent">
 Return a boolean series which is True for each value in this series which is
 contained in `other`, where `other` can be any of the standard "container"
-types: tuple, list, set, frozenset, or dict.
+types (tuple, list, set, frozenset, or dict) or another event series.
 </div>
 
 <div class="attr-heading" id="FloatPatientSeries.is_not_in">
@@ -1465,7 +1465,7 @@ This will be removed in future versions of ehrQL and shoud not be used.
 <div markdown="block" class="indent">
 Return a boolean series which is True for each value in this series which is
 contained in `other`, where `other` can be any of the standard "container"
-types: tuple, list, set, frozenset, or dict.
+types (tuple, list, set, frozenset, or dict) or another event series.
 </div>
 
 <div class="attr-heading" id="FloatEventSeries.is_not_in">
@@ -1701,7 +1701,7 @@ This will be removed in future versions of ehrQL and shoud not be used.
 <div markdown="block" class="indent">
 Return a boolean series which is True for each value in this series which is
 contained in `other`, where `other` can be any of the standard "container"
-types: tuple, list, set, frozenset, or dict.
+types (tuple, list, set, frozenset, or dict) or another event series.
 </div>
 
 <div class="attr-heading" id="DatePatientSeries.is_not_in">
@@ -1961,7 +1961,7 @@ This will be removed in future versions of ehrQL and shoud not be used.
 <div markdown="block" class="indent">
 Return a boolean series which is True for each value in this series which is
 contained in `other`, where `other` can be any of the standard "container"
-types: tuple, list, set, frozenset, or dict.
+types (tuple, list, set, frozenset, or dict) or another event series.
 </div>
 
 <div class="attr-heading" id="DateEventSeries.is_not_in">
@@ -2208,7 +2208,7 @@ This will be removed in future versions of ehrQL and shoud not be used.
 <div markdown="block" class="indent">
 Return a boolean series which is True for each value in this series which is
 contained in `other`, where `other` can be any of the standard "container"
-types: tuple, list, set, frozenset, or dict.
+types (tuple, list, set, frozenset, or dict) or another event series.
 </div>
 
 <div class="attr-heading" id="CodePatientSeries.is_not_in">
@@ -2318,7 +2318,7 @@ This will be removed in future versions of ehrQL and shoud not be used.
 <div markdown="block" class="indent">
 Return a boolean series which is True for each value in this series which is
 contained in `other`, where `other` can be any of the standard "container"
-types: tuple, list, set, frozenset, or dict.
+types (tuple, list, set, frozenset, or dict) or another event series.
 </div>
 
 <div class="attr-heading" id="CodeEventSeries.is_not_in">

--- a/docs/includes/generated_docs/specs.md
+++ b/docs/includes/generated_docs/specs.md
@@ -1231,10 +1231,147 @@ returns the following patient series:
 
 
 
-### 6.3 Map from one set of values to another
+#### 6.2.3 Is in empty list
+
+This example makes use of a patient-level table named `p` containing the following data:
+
+| patient|i1 |
+| - | - |
+| 1|101 |
+| 2|201 |
+| 3|301 |
+| 4| |
+
+```python
+p.i1.is_in([])
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1|F |
+| 2|F |
+| 3|F |
+| 4|F |
 
 
-#### 6.3.1 Map values
+
+#### 6.2.4 Is not in empty list
+
+This example makes use of a patient-level table named `p` containing the following data:
+
+| patient|i1 |
+| - | - |
+| 1|101 |
+| 2|201 |
+| 3|301 |
+| 4| |
+
+```python
+p.i1.is_not_in([])
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1|T |
+| 2|T |
+| 3|T |
+| 4|T |
+
+
+
+### 6.3 Testing for containment in another series
+
+
+#### 6.3.1 Is in series
+
+This example makes use of a patient-level table named `p` and an event-level table named `e` containing the following data:
+
+| patient|i1 |
+| - | - |
+| 1|101 |
+| 2|201 |
+| 3|301 |
+| 4| |
+| 5|501 |
+| 6| |
+
+| patient|i1 |
+| - | - |
+| 1|101 |
+| 2|201 |
+| 2|203 |
+| 2|301 |
+| 3|333 |
+| 3|334 |
+| 4| |
+| 4|401 |
+| 5| |
+| 5|101 |
+
+```python
+p.i1.is_in(e.i1)
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1|T |
+| 2|T |
+| 3|F |
+| 4| |
+| 5|F |
+| 6|F |
+
+
+
+#### 6.3.2 Is not in series
+
+This example makes use of a patient-level table named `p` and an event-level table named `e` containing the following data:
+
+| patient|i1 |
+| - | - |
+| 1|101 |
+| 2|201 |
+| 3|301 |
+| 4| |
+| 5|501 |
+| 6| |
+
+| patient|i1 |
+| - | - |
+| 1|101 |
+| 2|201 |
+| 2|203 |
+| 2|301 |
+| 3|333 |
+| 3|334 |
+| 4| |
+| 4|401 |
+| 5| |
+| 5|101 |
+
+```python
+p.i1.is_not_in(e.i1)
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1|F |
+| 2|F |
+| 3|T |
+| 4| |
+| 5|T |
+| 6|T |
+
+
+
+### 6.4 Map from one set of values to another
+
+
+#### 6.4.1 Map values
 
 This example makes use of a patient-level table named `p` containing the following data:
 
@@ -1259,10 +1396,10 @@ returns the following patient series:
 
 
 
-### 6.4 Replace missing values
+### 6.5 Replace missing values
 
 
-#### 6.4.1 When null then integer column
+#### 6.5.1 When null then integer column
 
 This example makes use of a patient-level table named `p` containing the following data:
 
@@ -1287,7 +1424,7 @@ returns the following patient series:
 
 
 
-#### 6.4.2 When null then boolean column
+#### 6.5.2 When null then boolean column
 
 This example makes use of a patient-level table named `p` containing the following data:
 
@@ -1312,10 +1449,10 @@ returns the following patient series:
 
 
 
-### 6.5 Minimum and maximum aggregations across Patient series
+### 6.6 Minimum and maximum aggregations across Patient series
 
 
-#### 6.5.1 Maximum of two integer patient series
+#### 6.6.1 Maximum of two integer patient series
 
 This example makes use of a patient-level table named `p` containing the following data:
 
@@ -1338,7 +1475,7 @@ returns the following patient series:
 
 
 
-#### 6.5.2 Minimum of two integer patient series
+#### 6.6.2 Minimum of two integer patient series
 
 This example makes use of a patient-level table named `p` containing the following data:
 
@@ -1361,7 +1498,7 @@ returns the following patient series:
 
 
 
-#### 6.5.3 Minimum of two integer patient series and a value
+#### 6.6.3 Minimum of two integer patient series and a value
 
 This example makes use of a patient-level table named `p` containing the following data:
 
@@ -1384,7 +1521,7 @@ returns the following patient series:
 
 
 
-#### 6.5.4 Maximum of two integer patient series and a value
+#### 6.6.4 Maximum of two integer patient series and a value
 
 This example makes use of a patient-level table named `p` containing the following data:
 
@@ -1407,7 +1544,7 @@ returns the following patient series:
 
 
 
-#### 6.5.5 Minimum of two date patient series
+#### 6.6.5 Minimum of two date patient series
 
 This example makes use of a patient-level table named `p` containing the following data:
 
@@ -1430,7 +1567,7 @@ returns the following patient series:
 
 
 
-#### 6.5.6 Maximum of two date patient series
+#### 6.6.6 Maximum of two date patient series
 
 This example makes use of a patient-level table named `p` containing the following data:
 
@@ -1453,7 +1590,7 @@ returns the following patient series:
 
 
 
-#### 6.5.7 Minimum of two date patient series and datetime a value
+#### 6.6.7 Minimum of two date patient series and datetime a value
 
 This example makes use of a patient-level table named `p` containing the following data:
 
@@ -1476,7 +1613,7 @@ returns the following patient series:
 
 
 
-#### 6.5.8 Maximum of two date patient series and datetime a value
+#### 6.6.8 Maximum of two date patient series and datetime a value
 
 This example makes use of a patient-level table named `p` containing the following data:
 
@@ -1499,7 +1636,7 @@ returns the following patient series:
 
 
 
-#### 6.5.9 Minimum of two date patient series and string a value
+#### 6.6.9 Minimum of two date patient series and string a value
 
 This example makes use of a patient-level table named `p` containing the following data:
 
@@ -1522,7 +1659,7 @@ returns the following patient series:
 
 
 
-#### 6.5.10 Maximum of two date patient series and string a value
+#### 6.6.10 Maximum of two date patient series and string a value
 
 This example makes use of a patient-level table named `p` containing the following data:
 
@@ -1545,7 +1682,7 @@ returns the following patient series:
 
 
 
-#### 6.5.11 Maximum of two float patient series
+#### 6.6.11 Maximum of two float patient series
 
 This example makes use of a patient-level table named `p` containing the following data:
 
@@ -1568,7 +1705,7 @@ returns the following patient series:
 
 
 
-#### 6.5.12 Minimum of two float patient series
+#### 6.6.12 Minimum of two float patient series
 
 This example makes use of a patient-level table named `p` containing the following data:
 
@@ -1591,7 +1728,7 @@ returns the following patient series:
 
 
 
-#### 6.5.13 Minimum of two float patient series and a value
+#### 6.6.13 Minimum of two float patient series and a value
 
 This example makes use of a patient-level table named `p` containing the following data:
 
@@ -1614,7 +1751,7 @@ returns the following patient series:
 
 
 
-#### 6.5.14 Maximum of two float patient series and a value
+#### 6.6.14 Maximum of two float patient series and a value
 
 This example makes use of a patient-level table named `p` containing the following data:
 
@@ -1637,7 +1774,7 @@ returns the following patient series:
 
 
 
-#### 6.5.15 Maximum of two string patient series
+#### 6.6.15 Maximum of two string patient series
 
 This example makes use of a patient-level table named `p` containing the following data:
 
@@ -1660,7 +1797,7 @@ returns the following patient series:
 
 
 
-#### 6.5.16 Minimum of two string patient series
+#### 6.6.16 Minimum of two string patient series
 
 This example makes use of a patient-level table named `p` containing the following data:
 
@@ -1683,7 +1820,7 @@ returns the following patient series:
 
 
 
-#### 6.5.17 Minimum of two string patient series and a value
+#### 6.6.17 Minimum of two string patient series and a value
 
 This example makes use of a patient-level table named `p` containing the following data:
 
@@ -1706,7 +1843,7 @@ returns the following patient series:
 
 
 
-#### 6.5.18 Maximum of two string patient series and a value
+#### 6.6.18 Maximum of two string patient series and a value
 
 This example makes use of a patient-level table named `p` containing the following data:
 
@@ -1729,7 +1866,7 @@ returns the following patient series:
 
 
 
-#### 6.5.19 Maximum of two integers all a values
+#### 6.6.19 Maximum of two integers all a values
 
 This example makes use of a patient-level table named `p` containing the following data:
 
@@ -1752,10 +1889,10 @@ returns the following patient series:
 
 
 
-### 6.6 Minimum and maximum aggregations across Event series
+### 6.7 Minimum and maximum aggregations across Event series
 
 
-#### 6.6.1 Maximum of two integer event series
+#### 6.7.1 Maximum of two integer event series
 
 This example makes use of an event-level table named `e` containing the following data:
 
@@ -1779,7 +1916,7 @@ returns the following patient series:
 
 
 
-#### 6.6.2 Minimum of two integer event series
+#### 6.7.2 Minimum of two integer event series
 
 This example makes use of an event-level table named `e` containing the following data:
 
@@ -1803,7 +1940,7 @@ returns the following patient series:
 
 
 
-#### 6.6.3 Minimum of two integer event series and a value
+#### 6.7.3 Minimum of two integer event series and a value
 
 This example makes use of an event-level table named `e` containing the following data:
 
@@ -1827,7 +1964,7 @@ returns the following patient series:
 
 
 
-#### 6.6.4 Maximum of two integer event series and a value
+#### 6.7.4 Maximum of two integer event series and a value
 
 This example makes use of an event-level table named `e` containing the following data:
 
@@ -1851,7 +1988,7 @@ returns the following patient series:
 
 
 
-#### 6.6.5 Minimum of two date event series
+#### 6.7.5 Minimum of two date event series
 
 This example makes use of an event-level table named `e` containing the following data:
 
@@ -1875,7 +2012,7 @@ returns the following patient series:
 
 
 
-#### 6.6.6 Maximum of two date event series
+#### 6.7.6 Maximum of two date event series
 
 This example makes use of an event-level table named `e` containing the following data:
 
@@ -1899,7 +2036,7 @@ returns the following patient series:
 
 
 
-#### 6.6.7 Minimum of two date event series and datetime a value
+#### 6.7.7 Minimum of two date event series and datetime a value
 
 This example makes use of an event-level table named `e` containing the following data:
 
@@ -1923,7 +2060,7 @@ returns the following patient series:
 
 
 
-#### 6.6.8 Maximum of two date event series and datetime a value
+#### 6.7.8 Maximum of two date event series and datetime a value
 
 This example makes use of an event-level table named `e` containing the following data:
 
@@ -1947,7 +2084,7 @@ returns the following patient series:
 
 
 
-#### 6.6.9 Minimum of two date event series and string a value
+#### 6.7.9 Minimum of two date event series and string a value
 
 This example makes use of an event-level table named `e` containing the following data:
 
@@ -1971,7 +2108,7 @@ returns the following patient series:
 
 
 
-#### 6.6.10 Maximum of two date event series and string a value
+#### 6.7.10 Maximum of two date event series and string a value
 
 This example makes use of an event-level table named `e` containing the following data:
 
@@ -1995,7 +2132,7 @@ returns the following patient series:
 
 
 
-#### 6.6.11 Maximum of two float event series
+#### 6.7.11 Maximum of two float event series
 
 This example makes use of an event-level table named `e` containing the following data:
 
@@ -2019,7 +2156,7 @@ returns the following patient series:
 
 
 
-#### 6.6.12 Minimum of two float event series
+#### 6.7.12 Minimum of two float event series
 
 This example makes use of an event-level table named `e` containing the following data:
 
@@ -2043,7 +2180,7 @@ returns the following patient series:
 
 
 
-#### 6.6.13 Minimum of two float event series and float a value
+#### 6.7.13 Minimum of two float event series and float a value
 
 This example makes use of an event-level table named `e` containing the following data:
 
@@ -2067,7 +2204,7 @@ returns the following patient series:
 
 
 
-#### 6.6.14 Maximum of two float event series and float a value
+#### 6.7.14 Maximum of two float event series and float a value
 
 This example makes use of an event-level table named `e` containing the following data:
 
@@ -2091,7 +2228,7 @@ returns the following patient series:
 
 
 
-#### 6.6.15 Minimum of two float event series and integer a value
+#### 6.7.15 Minimum of two float event series and integer a value
 
 This example makes use of an event-level table named `e` containing the following data:
 
@@ -2115,7 +2252,7 @@ returns the following patient series:
 
 
 
-#### 6.6.16 Maximum of two float event series and integer a value
+#### 6.7.16 Maximum of two float event series and integer a value
 
 This example makes use of an event-level table named `e` containing the following data:
 
@@ -2139,7 +2276,7 @@ returns the following patient series:
 
 
 
-#### 6.6.17 Maximum of two string event series
+#### 6.7.17 Maximum of two string event series
 
 This example makes use of an event-level table named `e` containing the following data:
 
@@ -2163,7 +2300,7 @@ returns the following patient series:
 
 
 
-#### 6.6.18 Minimum of two string event series
+#### 6.7.18 Minimum of two string event series
 
 This example makes use of an event-level table named `e` containing the following data:
 
@@ -2187,7 +2324,7 @@ returns the following patient series:
 
 
 
-#### 6.6.19 Minimum of two string event series and a value
+#### 6.7.19 Minimum of two string event series and a value
 
 This example makes use of an event-level table named `e` containing the following data:
 
@@ -2211,7 +2348,7 @@ returns the following patient series:
 
 
 
-#### 6.6.20 Maximum of two string event series and a value
+#### 6.7.20 Maximum of two string event series and a value
 
 This example makes use of an event-level table named `e` containing the following data:
 
@@ -2235,7 +2372,7 @@ returns the following patient series:
 
 
 
-#### 6.6.21 Maximum of nested aggregate
+#### 6.7.21 Maximum of nested aggregate
 
 This example makes use of an event-level table named `e` containing the following data:
 
@@ -2262,7 +2399,7 @@ returns the following patient series:
 
 
 
-#### 6.6.22 Maximum of nested aggregate and column and a value
+#### 6.7.22 Maximum of nested aggregate and column and a value
 
 This example makes use of an event-level table named `e` containing the following data:
 

--- a/ehrql/query_engines/base_sql.py
+++ b/ehrql/query_engines/base_sql.py
@@ -795,7 +795,16 @@ class BaseSQLQueryEngine(BaseQueryEngine):
         e.g. using `.alias()` to make a sub-query, using `.cte()` to make a Common Table
         Expression, or writing the results of the query to a temporary table.
         """
-        return query.cte(name=f"cte_{self.get_next_id()}")
+        cte = query.cte(name=f"cte_{self.get_next_id()}")
+        # We mark these CTEs as being non-traversible by our
+        # `replace_placeholder_references()` function. There's never a need to traverse
+        # them (reified queries are already processes and in their final form) and it
+        # can create problems with cloned, duplicate CTEs. See:
+        #
+        #   tests/integration/test_query_engines.py::test_sqlalchemy_compilation_edge_case
+        #
+        cte._no_replacement_traverse = True
+        return cte
 
     def get_select_query_for_node_domain(self, node):
         """
@@ -900,14 +909,18 @@ def replace_placeholder_references(query):
     # We use the convention that the column to be joined on is always the first selected
     # column. This avoids having to hardcode, or pass around, the name of the column.
     patient_id_column = query.selected_columns[0]
+
     # Replace any "placeholder" column references with the target column
-    return replacement_traverse(
-        query,
-        {},
-        replace=(
-            lambda obj: patient_id_column if obj is PLACEHOLDER_PATIENT_ID else None
-        ),
-    )
+    def replace(obj):
+        if obj is PLACEHOLDER_PATIENT_ID:
+            return patient_id_column
+        # Avoid cloning objects which aren't safe to be cloned
+        if getattr(obj, "_no_replacement_traverse", False):
+            return obj
+        else:
+            return None
+
+    return replacement_traverse(query, {}, replace=replace)
 
 
 def get_table_and_filter_conditions(frame):

--- a/ehrql/query_engines/in_memory.py
+++ b/ehrql/query_engines/in_memory.py
@@ -176,7 +176,8 @@ class InMemoryQueryEngine(BaseQueryEngine):
         return col.aggregate_values(statistics.fmean, default=None)
 
     def visit_CombineAsSet(self, node):
-        assert False
+        col = self.visit(node.source)
+        return col.aggregate_values(frozenset, default=frozenset())
 
     def visit_unary_op(self, node, op):
         series = self.visit(node.source)

--- a/ehrql/query_engines/in_memory.py
+++ b/ehrql/query_engines/in_memory.py
@@ -332,9 +332,14 @@ class InMemoryQueryEngine(BaseQueryEngine):
 
     def visit_In(self, node):
         def op(lhs, rhs):
-            return lhs in rhs
+            if len(rhs) == 0:
+                return False
+            elif lhs is None:
+                return None
+            else:
+                return lhs in rhs
 
-        return self.visit_binary_op_with_null(node, op)
+        return self.visit_binary_op(node, op)
 
     def visit_Case(self, node):
         cases = [

--- a/tests/generative/test_query_model.py
+++ b/tests/generative/test_query_model.py
@@ -292,7 +292,6 @@ def test_variable_strategy_is_comprehensive():
     record_operations_seen()
 
     known_missing_operations = {
-        AggregateByPatient.CombineAsSet,
         # Parameters don't themselves form part of valid queries: they are placeholders
         # which must all be replaced with Values before the query can be executed.
         Parameter,

--- a/tests/generative/variable_strategies.py
+++ b/tests/generative/variable_strategies.py
@@ -263,7 +263,7 @@ def population_and_variable(patient_tables, event_tables, schema, value_strategi
     def in_(draw, _type, frame):
         type_ = draw(any_type())
         values = Value(
-            frozenset(draw(st.sets(value_strategies[type_], min_size=1, max_size=5)))
+            frozenset(draw(st.sets(value_strategies[type_], min_size=0, max_size=5)))
         )
         return Function.In(draw(series(type_, frame)), values)
 

--- a/tests/generative/variable_strategies.py
+++ b/tests/generative/variable_strategies.py
@@ -197,6 +197,9 @@ def population_and_variable(patient_tables, event_tables, schema, value_strategi
     def sum_(type_, _frame):
         return aggregation_operation(type_, AggregateByPatient.Sum)
 
+    def combine_as_set(type_, _frame):
+        return aggregation_operation(type_, AggregateByPatient.CombineAsSet)
+
     @st.composite
     def mean(draw, _type, _frame):
         type_ = draw(any_numeric_type())
@@ -262,10 +265,15 @@ def population_and_variable(patient_tables, event_tables, schema, value_strategi
     @st.composite
     def in_(draw, _type, frame):
         type_ = draw(any_type())
-        values = Value(
-            frozenset(draw(st.sets(value_strategies[type_], min_size=0, max_size=5)))
-        )
-        return Function.In(draw(series(type_, frame)), values)
+        if not draw(st.booleans()):
+            rhs = Value(
+                frozenset(
+                    draw(st.sets(value_strategies[type_], min_size=0, max_size=5))
+                )
+            )
+        else:
+            rhs = draw(combine_as_set(type_, frame))
+        return Function.In(draw(series(type_, frame)), rhs)
 
     def and_(type_, frame):
         return binary_operation(type_, frame, Function.And, allow_value=False)

--- a/tests/integration/test_query_engines.py
+++ b/tests/integration/test_query_engines.py
@@ -4,7 +4,7 @@ from datetime import date
 import pytest
 import sqlalchemy
 
-from ehrql import Dataset
+from ehrql import create_dataset
 from ehrql.query_model.nodes import Function, Value
 from ehrql.tables import (
     EventFrame,
@@ -73,7 +73,7 @@ def test_handles_inline_patient_table(engine, tmp_path):
         s = Series(str)
         d = Series(date)
 
-    dataset = Dataset()
+    dataset = create_dataset()
     dataset.define_population(
         patients.exists_for_patient() & test_table.exists_for_patient()
     )
@@ -112,7 +112,7 @@ def test_handles_inline_patient_table_with_different_patients(engine):
     class test_table(PatientFrame):
         i = Series(int)
 
-    dataset = Dataset()
+    dataset = create_dataset()
     dataset.define_population(test_table.exists_for_patient())
     dataset.n = test_table.i + 100
     dataset.sex = patients.sex
@@ -151,7 +151,7 @@ def test_cleans_up_temporary_tables(engine):
     class inline_table(PatientFrame):
         i = Series(int)
 
-    dataset = Dataset()
+    dataset = create_dataset()
     dataset.define_population(events.exists_for_patient())
     dataset.n = events.count_for_patient()
     dataset.i = inline_table.i
@@ -223,7 +223,7 @@ def test_is_in_using_temporary_table(engine):
         }
     )
 
-    dataset = Dataset()
+    dataset = create_dataset()
     dataset.define_population(events.exists_for_patient())
     matching = events.code.is_in(
         ["123000", "123001", "123002", "123004"],

--- a/tests/spec/series_ops/test_containment.py
+++ b/tests/spec/series_ops/test_containment.py
@@ -49,7 +49,7 @@ def test_is_in_empty_list(spec_test):
             1: False,
             2: False,
             3: False,
-            4: None,
+            4: False,
         },
     )
 
@@ -62,6 +62,6 @@ def test_is_not_in_empty_list(spec_test):
             1: True,
             2: True,
             3: True,
-            4: None,
+            4: True,
         },
     )

--- a/tests/spec/series_ops/test_containment.py
+++ b/tests/spec/series_ops/test_containment.py
@@ -39,3 +39,29 @@ def test_is_not_in(spec_test):
             4: None,
         },
     )
+
+
+def test_is_in_empty_list(spec_test):
+    spec_test(
+        table_data,
+        p.i1.is_in([]),
+        {
+            1: False,
+            2: False,
+            3: False,
+            4: None,
+        },
+    )
+
+
+def test_is_not_in_empty_list(spec_test):
+    spec_test(
+        table_data,
+        p.i1.is_not_in([]),
+        {
+            1: True,
+            2: True,
+            3: True,
+            4: None,
+        },
+    )

--- a/tests/spec/series_ops/test_containment_with_series.py
+++ b/tests/spec/series_ops/test_containment_with_series.py
@@ -42,7 +42,7 @@ def test_is_in_series(spec_test):
             3: False,
             4: None,
             5: False,
-            6: None,
+            6: False,
         },
     )
 
@@ -57,6 +57,6 @@ def test_is_not_in_series(spec_test):
             3: True,
             4: None,
             5: True,
-            6: None,
+            6: True,
         },
     )

--- a/tests/spec/series_ops/test_containment_with_series.py
+++ b/tests/spec/series_ops/test_containment_with_series.py
@@ -1,0 +1,62 @@
+from ..tables import e, p
+
+
+title = "Testing for containment in another series"
+
+
+table_data = {
+    p: """
+          |  i1
+        --+-----
+        1 | 101
+        2 | 201
+        3 | 301
+        4 |
+        5 | 501
+        6 |
+        """,
+    e: """
+          |  i1
+        --+-----
+        1 | 101
+        2 | 201
+        2 | 203
+        2 | 301
+        3 | 333
+        3 | 334
+        4 |
+        4 | 401
+        5 |
+        5 | 101
+        """,
+}
+
+
+def test_is_in_series(spec_test):
+    spec_test(
+        table_data,
+        p.i1.is_in(e.i1),
+        {
+            1: True,
+            2: True,
+            3: False,
+            4: None,
+            5: False,
+            6: None,
+        },
+    )
+
+
+def test_is_not_in_series(spec_test):
+    spec_test(
+        table_data,
+        p.i1.is_not_in(e.i1),
+        {
+            1: False,
+            2: False,
+            3: True,
+            4: None,
+            5: True,
+            6: None,
+        },
+    )

--- a/tests/spec/toc.py
+++ b/tests/spec/toc.py
@@ -31,6 +31,7 @@ contents = {
     "series_ops": [
         "test_equality",
         "test_containment",
+        "test_containment_with_series",
         "test_map_values",
         "test_when_null_then",
         "test_maximum_of_and_minimum_of_patient_series",

--- a/tests/unit/test_query_language.py
+++ b/tests/unit/test_query_language.py
@@ -49,7 +49,6 @@ from ehrql.query_model.nodes import (
     SelectPatientTable,
     SelectTable,
     TableSchema,
-    TypeValidationError,
     Value,
 )
 
@@ -270,17 +269,14 @@ def test_automatic_cast(lhs, op, rhs, expected_type):
     assert isinstance(result, expected_type)
 
 
-def test_is_in():
-    int_series = IntEventSeries(qm_int_series)
-    assert_produces(
-        int_series.is_in([1, 2]), Function.In(qm_int_series, Value(frozenset([1, 2])))
-    )
+def test_is_in_rejects_unknown_types():
+    with pytest.raises(TypeError, match="Invalid argument type"):
+        patients.i.is_in(1)
 
 
-def test_passing_a_single_value_to_is_in_raises_error():
-    int_series = IntEventSeries(qm_int_series)
-    with pytest.raises(TypeValidationError):
-        int_series.is_in(1)
+def test_is_in_rejects_patient_series():
+    with pytest.raises(TypeError, match="must be an EventSeries"):
+        events.f.is_in(patients.f)
 
 
 def test_series_are_not_hashable():


### PR DESCRIPTION
This means we can now support queries like:
```py
a_events = events.where(event.code.is_in(codelist_a))
b_events = events.where(event.code.is_in(codelist_b))
co_occurring_events = a_events.where(a_events.date.is_in(b_events.date))
```

Closes #518