### PR TITLE
Add gentest developer tooling

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -119,11 +119,33 @@ You can get Hypothesis to dump statistics at the end of the run with `--hypothes
 or (more usefully) dump some of our own statistics about the generated data and queries by setting `GENTEST_DEBUG=t`.
 
 When debugging a failure you'll probably want to reproduce it.
+Hypothesis often struggles to shrink the examples it finds, and even
+small examples can appear overwhelmingly verbose due to the repetitive
+nature of query model reprs. To help with this there is some tooling,
+and a process to follow:
 
- * Hypothesis keeps some history and will _tend_ to re-run recent failure cases. So just re-running may be good enough.
- * The output from the failing test includes the examples in a form where they can be copy-pasted into the test code as arguments to a `@hyp.example()` decorator for the test.
-   (You'll need to add some imports to get it to run.) This allows you to get the failure case running in a debugger
-   (and also to get the example nicely formatted to help understand it).
+ * Copy the `population`, `variable` and `data` arguments from the
+   example that Hypothesis displays and paste them into a new file.
+   (Don't worry about stripping indentation or trailing commas here.)
+
+ * Run the command:
+   ```
+   just gentest-example-simplify PATH_TO_FILE.py
+   ```
+   This should transform the copied code into a valid test example and
+   pull out some of the repeated elements into variables.
+
+ * Run the command:
+   ```
+   just gentest-example-run PATH_TO_FILE.py
+   ```
+   This should execute the example and confirm that the test fails in
+   the expected way.
+
+ * To further simplify the example you can copy a repeated element,
+   assign it to a variable and then re-run `gentest-example-simplify` on
+   the file. This will replace occurances of that element with a
+   reference to the variable.
 
 Hypothesis can generate query graphs that are very deeply nested; after 100 draws in a test example, hypothesis will return the example as invalid.  In order to avoid this, the
 variable strategies check for a maximum depth and return a terminal node if the maximum depth is exceeded (A `SelectColumn` node for a series strategy, and a `SelectTable` or `SelectPatientTable` for a table strategy). The max depth defaults to 15 and can be overridden with environment variable `GENTEST_MAX_DEPTH`.

--- a/Justfile
+++ b/Justfile
@@ -229,6 +229,11 @@ test-generative *ARGS: devenv
     $BIN/python -m pytest --doctest-modules ehrql
     [[ -v CI ]]  && echo "::endgroup::" || echo ""
 
+# Take a raw failing example from Hypothesis's output and transform it into
+# something valid and tractable
+gentest-example-simplify *ARGS: devenv
+    $BIN/python -m tests.lib.gentest_example_simplify {{ ARGS }}
+
 generate-docs OUTPUT_DIR="docs/includes/generated_docs": devenv
     $BIN/python -m ehrql.docs {{ OUTPUT_DIR }}
     echo "Generated data for documentation in {{ OUTPUT_DIR }}"

--- a/Justfile
+++ b/Justfile
@@ -234,6 +234,13 @@ test-generative *ARGS: devenv
 gentest-example-simplify *ARGS: devenv
     $BIN/python -m tests.lib.gentest_example_simplify {{ ARGS }}
 
+# Run a generative test example defined in the supplied file
+gentest-example-run example *ARGS: devenv
+    GENTEST_EXAMPLE_FILE='{{example}}' \
+    $BIN/python -m pytest \
+        tests/generative/test_query_model.py::test_query_model_example_file \
+            {{ ARGS }}
+
 generate-docs OUTPUT_DIR="docs/includes/generated_docs": devenv
     $BIN/python -m ehrql.docs {{ OUTPUT_DIR }}
     echo "Generated data for documentation in {{ OUTPUT_DIR }}"

--- a/tests/generative/example.py
+++ b/tests/generative/example.py
@@ -1,0 +1,21 @@
+# A tiny example of a generative test case defined in a standalone file so that we can
+# check that the `test_query_model_example_file` function works correctly
+from ehrql.query_model.nodes import (
+    AggregateByPatient,
+    Column,
+    SelectColumn,
+    SelectPatientTable,
+    TableSchema,
+)
+
+
+p0 = SelectPatientTable(
+    "p0",
+    TableSchema(
+        i1=Column(int),
+    ),
+)
+
+population = AggregateByPatient.Exists(p0)
+variable = SelectColumn(p0, "i1")
+data = []

--- a/tests/lib/gentest_example_simplify.py
+++ b/tests/lib/gentest_example_simplify.py
@@ -1,0 +1,231 @@
+"""
+Attempts to de-duplicate query model structures by extracting repeated elements into
+variables.
+
+Usage looks like:
+
+    * Copy the query model example (the `population`, `variable` and `data` arguments)
+      into a file. Just copy the arguments as-is: don't worry about indendation,
+      trailing commas or missing imports.
+
+    * Run `python -m tests.lib.gentest_example_simplify PATH_TO_FILE`.
+
+    * If the output looks vaguely sensible run the command again with the `--inplace`
+      option to update the original file.
+
+    * Table and column definitions should be automatically extracted, but other kinds of
+      repeated structure will need to be extracted by hand. To do this: copy the
+      structure, assign it to a variable, and re-run the above command.
+"""
+import argparse
+import ast
+import dataclasses
+import pathlib
+import re
+import typing
+from collections import defaultdict
+from functools import singledispatchmethod
+
+import black
+
+import ehrql.query_model.nodes
+from ehrql.query_model.nodes import (
+    InlinePatientTable,
+    Node,
+    SelectColumn,
+    SelectPatientTable,
+    SelectTable,
+)
+
+
+TABLE_TYPES = SelectTable | SelectPatientTable | InlinePatientTable
+
+
+VARIABLE_NAMES = ["population", "variable", "data"]
+
+
+def main(filename, inplace=False):  # pragma: no cover
+    contents = filename.read_text()
+    code = simplify(contents)
+    if inplace:
+        filename.write_text(code)
+        return ""
+    else:
+        return code
+
+
+def simplify(contents):
+    contents = fix_up_module(contents)
+    namespace = {}
+    exec(contents, namespace)
+    variables = {
+        name: fix_accidental_tuple(namespace.pop(name))
+        for name in VARIABLE_NAMES
+        if name in namespace
+    }
+    qm_repr = QueryModelRepr(namespace)
+    variable_reprs = {name: qm_repr(value) for name, value in variables.items()}
+    output = [get_imports(contents)]
+    output.extend(
+        [
+            f"{name} = {reference_repr}"
+            for name, reference_repr in qm_repr.reference_reprs.items()
+        ]
+    )
+    for name, variable_repr in variable_reprs.items():
+        output.append(f"{name} = {variable_repr}")
+    code = "\n\n".join(output)
+    code = black.format_str(code, mode=black.Mode())
+    return code
+
+
+def fix_accidental_tuple(value):
+    # Fix values where copying the Hypothesis example has left a trailing comma
+    # resulting in an accidental tuple. The specific values we apply this to are never
+    # intended to be tuples so we don't need to worry about false positives.
+    if isinstance(value, tuple) and len(value) == 1:
+        return value[0]
+    return value
+
+
+def fix_up_module(contents):
+    "Apply some basic fixes to the module to make it importable"
+    # If it has imports we assume it's been fixed up already
+    if re.search(r"\bimport\b", contents):  # pragma: no cover
+        return contents
+    # Strip leading indentation
+    for name in VARIABLE_NAMES:
+        contents = re.sub(
+            rf"^\s+{name}\s*=\s*", f"{name} = ", contents, flags=re.MULTILINE
+        )
+    # Add imports (many of these will be unnecessary but that's fine)
+    imports = [
+        "import datetime",
+        "from tests.generative.test_query_model import data_setup",
+        f"from ehrql.query_model.nodes import ({', '.join(ehrql.query_model.nodes.__all__)})",
+    ]
+    contents = "\n".join(imports) + "\n" + contents
+    return contents
+
+
+class QueryModelRepr:  # pragma: no cover
+    def __init__(self, namespace):
+        # Create an inverse mapping which maps each (hashable) value in the namespace to
+        # the first name to which it's bound
+        self.valuespace = {}
+        for key, value in namespace.items():
+            if not key.startswith("__") and isinstance(value, typing.Hashable):
+                self.valuespace.setdefault(value, key)
+        # Dict to record the repr of every value we use in `valuespace`
+        self.reference_reprs = {}
+        self.inline_table_number = defaultdict(iter(range(2**32)).__next__)
+
+    def __call__(self, value):
+        return self.repr(value)
+
+    def repr(self, value):  # noqa: A003
+        # If the value is already in the provided namespace then just use its name as
+        # the repr
+        if isinstance(value, typing.Hashable) and value in self.valuespace:
+            name = self.valuespace[value]
+            # Record the original repr of the value being referenced
+            if name not in self.reference_reprs:
+                self.reference_reprs[name] = self.repr_value(value)
+            return name
+        # Automatically create references for table definitions to avoid repeating them
+        elif isinstance(value, TABLE_TYPES):
+            self.valuespace[value] = self.table_name(value)
+            return self.repr(value)
+        # Automatically create references where columns are selected directly from
+        # tables
+        elif isinstance(value, SelectColumn) and isinstance(value.source, TABLE_TYPES):
+            self.valuespace[value] = f"{self.table_name(value.source)}_{value.name}"
+            return self.repr(value)
+        else:
+            return self.repr_value(value)
+
+    def table_name(self, value):
+        if isinstance(value, InlinePatientTable):
+            return f"inline_{self.inline_table_number[value]}"
+        else:
+            return value.name
+
+    @singledispatchmethod
+    def repr_value(self, value):
+        return repr(value)
+
+    @repr_value.register(type)
+    def repr_type(self, value):
+        return f"{value.__module__}.{value.__qualname__}"
+
+    @repr_value.register(Node)
+    def repr_node(self, value):
+        args = []
+        kwargs = {}
+        for field in dataclasses.fields(value):
+            if field.default is dataclasses.MISSING:
+                assert (
+                    not kwargs
+                ), "Required fields must come before all optional fields"
+                args.append(getattr(value, field.name))
+            else:
+                kwargs[field.name] = getattr(value, field.name)
+        return self.repr_init(value, args, kwargs)
+
+    @repr_value.register(list)
+    def repr_list(self, value):
+        elements = [self.repr(v) for v in value]
+        return f"[{', '.join(elements)}]"
+
+    @repr_value.register(dict)
+    def repr_dict(self, value):
+        elements = [f"{self.repr(k)}: {self.repr(v)}" for k, v in value.items()]
+        return f"{{{', '.join(elements)}}}"
+
+    @repr_value.register(frozenset)
+    def repr_frozenset(self, value):
+        elements = [self.repr(v) for v in value]
+        return f"frozenset({{{','.join(elements)}}})"
+
+    @repr_value.register(tuple)
+    def repr_tuple(self, value):
+        elements = [self.repr(v) for v in value]
+        if len(elements) == 1:
+            return f"({elements[0]},)"
+        else:
+            return f"({','.join(elements)})"
+
+    def repr_init(self, obj, args, kwargs):
+        all_args = [self.repr(arg) for arg in args]
+        all_args.extend(f"{key}={self.repr(value)}" for key, value in kwargs.items())
+        name = obj.__class__.__qualname__
+        return f"{name}({', '.join(all_args)})"
+
+
+def get_imports(contents):
+    imports = []
+    for element in ast.parse(contents).body:
+        if isinstance(element, ast.Import | ast.ImportFrom):
+            imports.append(ast.unparse(element))
+    return "\n".join(imports)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawTextHelpFormatter,
+    )
+    parser.add_argument(
+        "filename",
+        type=pathlib.Path,
+        help="Path to a Python file containing a generative test example",
+    )
+    parser.add_argument(
+        "-i,--inplace",
+        dest="inplace",
+        action="store_true",
+        help="Update the file in-place",
+    )
+    args = parser.parse_args()
+    output = main(**vars(args))
+    print(output, end="")

--- a/tests/lib/test_gentest_example_simplify.py
+++ b/tests/lib/test_gentest_example_simplify.py
@@ -1,0 +1,23 @@
+import textwrap
+
+from tests.lib.gentest_example_simplify import simplify
+
+
+# Basic smoketest as a crude guard against breakage
+def test_gentest_example_simplify():
+    example = textwrap.dedent(
+        """\
+        # As copied directly from Hypothesis output
+          population=AggregateByPatient.Exists(
+              SelectPatientTable("p0", TableSchema(i1=Column(int)))
+          ),
+          variable=SelectColumn(
+              SelectPatientTable("p0", TableSchema(i1=Column(int))), "i1"
+          )
+          data=[
+              {"type": data_setup.P0, "patient_id": 1},
+          ],
+        """
+    )
+    result = simplify(example)
+    assert "variable = p0_i1" in result


### PR DESCRIPTION
Adds two new commands:
 * `just gentest-example-simplify PATH_TO_FILE.py`
 * `just gentest-example-run PATH_TO_FILE.py`

The notes in `DEVELOPERS.md` explain their usage.