### PR TITLE
Fix accidental use of monospace

### DIFF
--- a/docs/includes/generated_docs/schemas/beta.raw.tpp.md
+++ b/docs/includes/generated_docs/schemas/beta.raw.tpp.md
@@ -26,7 +26,7 @@ from ehrql.tables.beta.raw.tpp import (
 
 This table contains some historical APCS cost data.
 
-    It has been exposed to users for data exploration, and may be removed in future.
+It has been exposed to users for data exploration, and may be removed in future.
 <div markdown="block" class="definition-list-wrapper">
   <div class="title">Columns</div>
   <dl markdown="block">
@@ -112,7 +112,7 @@ This table contains some historical APCS cost data.
 
 This table contains some historical APCS data.
 
-    It has been exposed to users for data exploration, and may be removed in future.
+It has been exposed to users for data exploration, and may be removed in future.
 <div markdown="block" class="definition-list-wrapper">
   <div class="title">Columns</div>
   <dl markdown="block">

--- a/ehrql/tables/beta/raw/tpp.py
+++ b/ehrql/tables/beta/raw/tpp.py
@@ -341,7 +341,8 @@ wl_openpathways = table(wl_openpathways_raw)
 
 @table
 class apcs_historical(EventFrame):
-    """This table contains some historical APCS data.
+    """
+    This table contains some historical APCS data.
 
     It has been exposed to users for data exploration, and may be removed in future.
     """
@@ -363,7 +364,8 @@ class apcs_historical(EventFrame):
 
 @table
 class apcs_cost_historical(EventFrame):
-    """This table contains some historical APCS cost data.
+    """
+    This table contains some historical APCS cost data.
 
     It has been exposed to users for data exploration, and may be removed in future.
     """


### PR DESCRIPTION
...for `apcs_historical` and `apcs_cost_historical`.

Before: https://docs.opensafely.org/ehrql/reference/schemas/beta.raw.tpp/#apcs_cost_historical

After: https://iaindillingham-fix-accidenta.databuilder.pages.dev/reference/schemas/beta.raw.tpp/#apcs_cost_historical