### PR TITLE
Expose additional columns from EMIS patient table

### DIFF
--- a/docs/includes/generated_docs/schemas/emis.md
+++ b/docs/includes/generated_docs/schemas/emis.md
@@ -372,25 +372,9 @@ Medical condition mentioned on the death certificate.
 
 Patients in primary care.
 
-### Representativeness
-
-You can find out more about the representativeness of these data in the
-OpenSAFELY-TPP backend in:
-
-> The OpenSAFELY Collaborative, Colm D. Andrews, Anna Schultze, Helen J. Curtis, William J. Hulme, John Tazare, Stephen J. W. Evans, _et al._ 2022.
-> "OpenSAFELY: Representativeness of Electronic Health Record Platform OpenSAFELY-TPP Data Compared to the Population of England."
-> Wellcome Open Res 2022, 7:191.
-> <https://doi.org/10.12688/wellcomeopenres.18010.1>
-
-
-### Orphan records
-
-If a practice becomes aware that a patient has moved house,
-then the practice _deducts_, or removes, the patient's records from their register.
-If the patient doesn't register with a new practice within a given amount of time
-(normally from four to eight weeks),
-then the patient's records are permanently deducted and are _orphan records_.
-There are roughly 1.6 million orphan records.
+In the EMIS backend, this table also includes information about the patient's
+current practice registration. Historical practice registration data is not
+currently available.
 
 ### Recording of death in primary care
 
@@ -402,7 +386,7 @@ based on these MCCDs.
 There is generally a lag between the death being recorded in ONS data and it
 appearing in the primary care record, but the coverage or recorded death is almost
 complete and the date of death is usually reliable when it appears. There is
-also a lag in ONS death recording (see [`ons_deaths`](/reference/schemas/core/#ons_deaths) below
+also a lag in ONS death recording (see [`ons_deaths`](/reference/schemas/core/#ons_deaths)
 for more detail). You can find out more about the accuracy of date of death
 recording in primary care in:
 
@@ -410,9 +394,6 @@ recording in primary care in:
 > Practice Research Datalink GOLD database in England compared with the Office for National Statistics death registrations.
 > Pharmacoepidemiol. Drug Saf. 28, 563–569.
 > <https://doi.org/10.1002/pds.4747>
-
-By contrast, cause of death is often not accurate in the primary care record so we
-don't make it available to query here.
 <div markdown="block" class="definition-list-wrapper">
   <div class="title">Columns</div>
   <dl markdown="block">
@@ -439,7 +420,7 @@ Patient's date of birth.
   <dd markdown="block">
 Patient's sex.
 
- * Possible values: `female`, `male`, `intersex`, `unknown`
+ * Possible values: `female`, `male`, `unknown`
  * Never `NULL`
   </dd>
 </div>
@@ -453,6 +434,82 @@ Patient's sex.
   <dd markdown="block">
 Patient's date of death.
 
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="patients.registration_start_date">
+    <strong>registration_start_date</strong>
+    <a class="headerlink" href="#patients.registration_start_date" title="Permanent link">🔗</a>
+    <code>date</code>
+  </dt>
+  <dd markdown="block">
+Date patient joined practice.
+
+ * Never `NULL`
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="patients.registration_end_date">
+    <strong>registration_end_date</strong>
+    <a class="headerlink" href="#patients.registration_end_date" title="Permanent link">🔗</a>
+    <code>date</code>
+  </dt>
+  <dd markdown="block">
+Date patient left practice.
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="patients.practice_pseudo_id">
+    <strong>practice_pseudo_id</strong>
+    <a class="headerlink" href="#patients.practice_pseudo_id" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+Pseudonymised practice identifier.
+
+ * Never `NULL`
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="patients.rural_urban_classification">
+    <strong>rural_urban_classification</strong>
+    <a class="headerlink" href="#patients.rural_urban_classification" title="Permanent link">🔗</a>
+    <code>integer</code>
+  </dt>
+  <dd markdown="block">
+Rural urban classification:
+
+* 1 - Urban major conurbation
+* 2 - Urban minor conurbation
+* 3 - Urban city and town
+* 4 - Urban city and town in a sparse setting
+* 5 - Rural town and fringe
+* 6 - Rural town and fringe in a sparse setting
+* 7 - Rural village and dispersed
+* 8 - Rural village and dispersed in a sparse setting
+
+ * Always >= 1 and <= 8
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="patients.imd_rounded">
+    <strong>imd_rounded</strong>
+    <a class="headerlink" href="#patients.imd_rounded" title="Permanent link">🔗</a>
+    <code>integer</code>
+  </dt>
+  <dd markdown="block">
+[Index of Multiple Deprivation][addresses_imd] (IMD)
+rounded to the nearest 100, where lower values represent more deprived areas.
+
+[addresses_imd]: https://www.gov.uk/government/statistics/english-indices-of-deprivation-2019
+
+ * Always >= 0, <= 32800, and a multiple of 100
   </dd>
 </div>
 
@@ -478,6 +535,28 @@ patient's date of birth.
     <summary>View method definition</summary>
 ```py
 return (date - patients.date_of_birth).years
+
+```
+    </details>
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="patients.has_practice_registration_spanning">
+    <strong>has_practice_registration_spanning(</strong>start_date, end_date<strong>)</strong>
+    <a class="headerlink" href="#patients.has_practice_registration_spanning" title="Permanent link">🔗</a>
+    <code></code>
+  </dt>
+  <dd markdown="block">
+Whether a patient's registration spans the entire period between
+`start_date` and `end_date`.
+    <details markdown="block">
+    <summary>View method definition</summary>
+```py
+return patients.registration_start_date.is_on_or_before(start_date) & (
+    patients.registration_end_date.is_after(end_date)
+    | patients.registration_end_date.is_null()
+)
 
 ```
     </details>

--- a/ehrql/backends/emis.py
+++ b/ehrql/backends/emis.py
@@ -80,7 +80,12 @@ class EMISBackend(SQLBackend):
                 ELSE 'unknown'
             END AS sex,
             date_of_birth,
-            date_of_death
+            date_of_death,
+            registered_date AS registration_start_date,
+            registration_end_date as registration_end_date,
+            hashed_organisation AS practice_pseudo_id,
+            imd_rank AS imd_rounded,
+            rural_urban AS rural_urban_classification
         FROM patient_all_orgs_v2
         WHERE registration_id NOT IN (
             SELECT registration_id

--- a/ehrql/tables/emis.py
+++ b/ehrql/tables/emis.py
@@ -3,7 +3,10 @@ This schema defines the data (both primary care and externally linked) available
 OpenSAFELY-EMIS backend. For more information about this backend, see
 "[EMIS Primary Care](https://docs.opensafely.org/data-sources/emis/)".
 """
-from ehrql.tables.core import clinical_events, medications, ons_deaths, patients
+import datetime
+
+from ehrql.tables import Constraint, PatientFrame, Series, table
+from ehrql.tables.core import clinical_events, medications, ons_deaths
 
 
 __all__ = [
@@ -12,3 +15,112 @@ __all__ = [
     "ons_deaths",
     "patients",
 ]
+
+
+@table
+class patients(PatientFrame):
+    """
+    Patients in primary care.
+
+    In the EMIS backend, this table also includes information about the patient's
+    current practice registration. Historical practice registration data is not
+    currently available.
+
+    ### Recording of death in primary care
+
+    In England, it is the statutory duty of the doctor who had attended in the last
+    illness to complete a medical certificate of cause of death (MCCD). ONS death data
+    are considered the gold standard for identifying patient deaths because they are
+    based on these MCCDs.
+
+    There is generally a lag between the death being recorded in ONS data and it
+    appearing in the primary care record, but the coverage or recorded death is almost
+    complete and the date of death is usually reliable when it appears. There is
+    also a lag in ONS death recording (see [`ons_deaths`](/reference/schemas/core/#ons_deaths)
+    for more detail). You can find out more about the accuracy of date of death
+    recording in primary care in:
+
+    > Gallagher, A. M., Dedman, D., Padmanabhan, S., Leufkens, H. G. M. & de Vries, F 2019. The accuracy of date of death recording in the Clinical
+    > Practice Research Datalink GOLD database in England compared with the Office for National Statistics death registrations.
+    > Pharmacoepidemiol. Drug Saf. 28, 563–569.
+    > <https://doi.org/10.1002/pds.4747>
+    """
+
+    date_of_birth = Series(
+        datetime.date,
+        description="Patient's date of birth.",
+        constraints=[Constraint.FirstOfMonth(), Constraint.NotNull()],
+    )
+    sex = Series(
+        str,
+        description="Patient's sex.",
+        constraints=[
+            Constraint.Categorical(["female", "male", "unknown"]),
+            Constraint.NotNull(),
+        ],
+    )
+    date_of_death = Series(
+        datetime.date,
+        description="Patient's date of death.",
+    )
+    registration_start_date = Series(
+        datetime.date,
+        constraints=[Constraint.NotNull()],
+        description="Date patient joined practice.",
+    )
+    registration_end_date = Series(
+        datetime.date,
+        description="Date patient left practice.",
+    )
+    practice_pseudo_id = Series(
+        str,
+        constraints=[Constraint.NotNull()],
+        description="Pseudonymised practice identifier.",
+    )
+    rural_urban_classification = Series(
+        int,
+        description="""
+            Rural urban classification:
+
+            * 1 - Urban major conurbation
+            * 2 - Urban minor conurbation
+            * 3 - Urban city and town
+            * 4 - Urban city and town in a sparse setting
+            * 5 - Rural town and fringe
+            * 6 - Rural town and fringe in a sparse setting
+            * 7 - Rural village and dispersed
+            * 8 - Rural village and dispersed in a sparse setting
+        """,
+        constraints=[Constraint.ClosedRange(1, 8)],
+    )
+    imd_rounded = Series(
+        int,
+        description="""
+            [Index of Multiple Deprivation][addresses_imd] (IMD)
+            rounded to the nearest 100, where lower values represent more deprived areas.
+
+            [addresses_imd]: https://www.gov.uk/government/statistics/english-indices-of-deprivation-2019
+        """,
+        constraints=[Constraint.ClosedRange(0, 32_800, 100)],
+    )
+
+    def age_on(self, date):
+        """
+        Patient's age as an integer, in whole elapsed calendar years, as it would be on
+        the given date.
+
+        This method takes no account of whether the patient is alive on the given date.
+        In particular, it may return negative values if the given date is before the
+        patient's date of birth.
+        """
+        return (date - self.date_of_birth).years
+
+    def has_practice_registration_spanning(self, start_date, end_date):
+        """
+        Whether a patient's registration spans the entire period between
+        `start_date` and `end_date`.
+        """
+        return self.registration_start_date.is_on_or_before(start_date) & (
+            self.registration_end_date.is_after(end_date)
+            | self.registration_end_date.is_null()
+        )

--- a/tests/integration/backends/helpers.py
+++ b/tests/integration/backends/helpers.py
@@ -50,7 +50,7 @@ def types_compatible(database, column_type, column_args):
         # Current no non-mssql backends (i.e. emis) have boolean column types
         return column_args["type"] == "boolean"  # pragma: no cover
     elif isinstance(column_type, sqlalchemy.Integer):
-        return column_args["type"] in ("int", "bigint")
+        return column_args["type"] in ("int", "integer", "bigint")
     elif isinstance(column_type, sqlalchemy.Float):
         return column_args["type"] == "real"
     elif isinstance(column_type, sqlalchemy.Date):

--- a/tests/integration/backends/test_emis.py
+++ b/tests/integration/backends/test_emis.py
@@ -352,47 +352,101 @@ def test_ons_deaths_raw(select_all_emis):
 @register_test_for(emis.patients)
 def test_patients(select_all_emis):
     results = select_all_emis(
-        PatientAllOrgsV2(registration_id="1", date_of_birth=date(2020, 1, 1), gender=1),
+        PatientAllOrgsV2(
+            registration_id="1",
+            date_of_birth=date(2020, 1, 1),
+            gender=1,
+            hashed_organisation="1A2B3C",
+            registered_date=date(2021, 3, 1),
+            rural_urban=1,
+            imd_rank=500,
+        ),
         # duplicate registration ids are ignored
-        PatientAllOrgsV2(registration_id="2", date_of_birth=date(2020, 1, 1), gender=1),
-        PatientAllOrgsV2(registration_id="2", date_of_birth=date(2020, 1, 1), gender=1),
+        PatientAllOrgsV2(
+            registration_id="2",
+            date_of_birth=date(2020, 1, 1),
+            gender=1,
+            hashed_organisation="1A2B3C",
+            registered_date=date(2021, 3, 1),
+        ),
+        PatientAllOrgsV2(
+            registration_id="2",
+            date_of_birth=date(2020, 1, 1),
+            gender=1,
+            hashed_organisation="1A2B3C",
+            registered_date=date(2021, 3, 1),
+        ),
         PatientAllOrgsV2(
             registration_id="3",
             date_of_birth=date(1960, 1, 1),
             date_of_death=date(2020, 1, 1),
             gender=2,
+            hashed_organisation="1A2B3C",
+            registered_date=date(1960, 3, 1),
         ),
-        PatientAllOrgsV2(registration_id="4", date_of_birth=date(2020, 1, 1), gender=0),
         PatientAllOrgsV2(
-            registration_id="5", date_of_birth=date(1978, 10, 13), gender=9
+            registration_id="4",
+            date_of_birth=date(2020, 1, 1),
+            gender=0,
+            hashed_organisation="1A2B3C",
+            registered_date=date(2021, 3, 1),
+        ),
+        PatientAllOrgsV2(
+            registration_id="5",
+            date_of_birth=date(1978, 10, 13),
+            gender=9,
+            hashed_organisation="1A2B3C",
+            registered_date=date(2021, 3, 1),
         ),
     )
-    assert results == [
+
+    expected = [
         {
             "patient_id": "1",
             "date_of_birth": date(2020, 1, 1),
             "sex": "male",
             "date_of_death": None,
+            "registration_start_date": date(2021, 3, 1),
+            "registration_end_date": None,
+            "practice_pseudo_id": "1A2B3C",
+            "rural_urban_classification": 1,
+            "imd_rounded": 500,
         },
         {
             "patient_id": "3",
             "date_of_birth": date(1960, 1, 1),
             "sex": "female",
             "date_of_death": date(2020, 1, 1),
+            "registration_start_date": date(1960, 3, 1),
+            "registration_end_date": None,
+            "practice_pseudo_id": "1A2B3C",
+            "rural_urban_classification": None,
+            "imd_rounded": None,
         },
         {
             "patient_id": "4",
             "date_of_birth": date(2020, 1, 1),
             "sex": "unknown",
             "date_of_death": None,
+            "registration_start_date": date(2021, 3, 1),
+            "registration_end_date": None,
+            "practice_pseudo_id": "1A2B3C",
+            "rural_urban_classification": None,
+            "imd_rounded": None,
         },
         {
             "patient_id": "5",
             "date_of_birth": date(1978, 10, 13),
             "sex": "unknown",
             "date_of_death": None,
+            "registration_start_date": date(2021, 3, 1),
+            "registration_end_date": None,
+            "practice_pseudo_id": "1A2B3C",
+            "rural_urban_classification": None,
+            "imd_rounded": None,
         },
     ]
+    assert results == expected
 
 
 def test_registered_tests_are_exhaustive():

--- a/tests/integration/tables/test_emis.py
+++ b/tests/integration/tables/test_emis.py
@@ -1,0 +1,97 @@
+from datetime import date
+
+from ehrql import Dataset
+from ehrql.tables import emis
+
+
+def test_patients_age_on(in_memory_engine):
+    in_memory_engine.populate(
+        {
+            emis.patients: [
+                dict(patient_id=1, date_of_birth=date(1980, 1, 1)),
+                dict(patient_id=2, date_of_birth=date(1800, 1, 1)),
+                dict(patient_id=3, date_of_birth=date(2010, 1, 1)),
+                dict(patient_id=4, date_of_birth=date(2010, 1, 2)),
+            ]
+        }
+    )
+
+    dataset = Dataset()
+    dataset.define_population(emis.patients.exists_for_patient())
+    dataset.age_2010 = emis.patients.age_on("2010-01-01")
+    results = in_memory_engine.extract(dataset)
+
+    assert results == [
+        {"patient_id": 1, "age_2010": 30},
+        {"patient_id": 2, "age_2010": 210},
+        {"patient_id": 3, "age_2010": 0},
+        {"patient_id": 4, "age_2010": -1},
+    ]
+
+
+def test_practice_registrations_spanning(
+    in_memory_engine,
+):
+    in_memory_engine.populate(
+        # Registrations before time period
+        {
+            emis.patients: [
+                dict(
+                    patient_id="1",
+                    registration_start_date=date(2000, 1, 1),
+                    registration_end_date=date(2005, 1, 1),
+                ),
+            ]
+        },
+        # Registration from before time period, and with NULL end date
+        {
+            emis.patients: [
+                dict(
+                    patient_id="2",
+                    registration_start_date=date(2000, 1, 1),
+                    registration_end_date=None,
+                ),
+            ]
+        },
+        # Registration with end date after time period ends
+        {
+            emis.patients: [
+                dict(
+                    patient_id="3",
+                    registration_start_date=date(2000, 1, 1),
+                    registration_end_date=date(2020, 1, 1),
+                ),
+            ]
+        },
+        # Registration with start date after time period starts
+        {
+            emis.patients: [
+                dict(
+                    patient_id="4",
+                    registration_start_date=date(2010, 2, 1),
+                    registration_end_date=date(2020, 1, 1),
+                ),
+            ]
+        },
+        # Registration with start date and end date inside time period
+        {
+            emis.patients: [
+                dict(
+                    patient_id="5",
+                    registration_start_date=date(2010, 2, 1),
+                    registration_end_date=date(2010, 12, 1),
+                ),
+            ]
+        },
+    )
+
+    dataset = Dataset()
+    dataset.define_population(
+        emis.patients.has_practice_registration_spanning("2010-01-01", "2011-01-01")
+    )
+    results = in_memory_engine.extract(dataset)
+
+    assert results == [
+        {"patient_id": "2"},
+        {"patient_id": "3"},
+    ]

--- a/tests/lib/emis_schema.py
+++ b/tests/lib/emis_schema.py
@@ -17,6 +17,11 @@ class PatientAllOrgsV2(Base):
     gender = mapped_column(t.Integer)
     date_of_birth = mapped_column(t.Date)
     date_of_death = mapped_column(t.Date)
+    hashed_organisation = mapped_column(t.VARCHAR)
+    registered_date = mapped_column(t.Date)
+    registration_end_date = mapped_column(t.Date)
+    rural_urban = mapped_column(t.Integer)
+    imd_rank = mapped_column(t.BigInteger)
 
 
 class ObservationAllOrgsV2(Base):


### PR DESCRIPTION
In EMIS the patient table contains various practice registration type fields
(for the current registration only). It doesn't contain any historical
practice registration info.

In order to include these fields, EMIS needs to have its own patient
table, rather than the core table.

Additional fields included are registration start/end date, plus a
method for identifying whether a patient's registration spans a given
period, imd, practice pseudo id, and rural_urban_classification.  The
latter 3 are given the same names as the TPP equivalents.  This also
required duplicating the `age_on` method.

The EMIS patient table also contains an MSOA code and STP code which are
not implemented yet; MSOA because it contains Scottish and Welsh codes
as well as English (unlike TPP), and STP code because it is not the ONS
code that TPP uses. This may be fine, but they can wait until we can
document clearly their sources.