### PR TITLE
Add EMIS vaccinations table

### DIFF
--- a/docs/includes/generated_docs/schemas/emis.md
+++ b/docs/includes/generated_docs/schemas/emis.md
@@ -12,6 +12,7 @@ from ehrql.tables.emis import (
     medications,
     ons_deaths,
     patients,
+    vaccinations,
 )
 ```
 
@@ -560,6 +561,48 @@ return patients.registration_start_date.is_on_or_before(start_date) & (
 
 ```
     </details>
+  </dd>
+</div>
+
+  </dl>
+</div>
+
+
+<p class="dimension-indicator"><code>many rows per patient</code></p>
+## vaccinations
+
+This table contains information on administered vaccinations,
+identified using SNOMED-CT codes for the vaccination procedure.
+
+Vaccinations may also be queried by product code using the
+[medications table](#medications).
+
+Vaccinations that were administered at work or in a pharmacy might not be
+included in this table.
+<div markdown="block" class="definition-list-wrapper">
+  <div class="title">Columns</div>
+  <dl markdown="block">
+<div markdown="block">
+  <dt id="vaccinations.date">
+    <strong>date</strong>
+    <a class="headerlink" href="#vaccinations.date" title="Permanent link">🔗</a>
+    <code>date</code>
+  </dt>
+  <dd markdown="block">
+The date the vaccination was administered.
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="vaccinations.procedure_code">
+    <strong>procedure_code</strong>
+    <a class="headerlink" href="#vaccinations.procedure_code" title="Permanent link">🔗</a>
+    <code>SNOMED-CT code</code>
+  </dt>
+  <dd markdown="block">
+
+
   </dd>
 </div>
 

--- a/ehrql/backends/emis.py
+++ b/ehrql/backends/emis.py
@@ -240,3 +240,13 @@ class EMISBackend(SQLBackend):
             WHERE t.rownum = 1
         """
     )
+
+    vaccinations = QueryTable(
+        """
+        SELECT
+            registration_id AS patient_id,
+            CAST(effective_date AS date) as date,
+            CAST(snomed_concept_id AS varchar) AS procedure_code
+        FROM immunisation_all_orgs_v2
+        """
+    )

--- a/ehrql/tables/emis.py
+++ b/ehrql/tables/emis.py
@@ -5,7 +5,8 @@ OpenSAFELY-EMIS backend. For more information about this backend, see
 """
 import datetime
 
-from ehrql.tables import Constraint, PatientFrame, Series, table
+from ehrql.codes import SNOMEDCTCode
+from ehrql.tables import Constraint, EventFrame, PatientFrame, Series, table
 from ehrql.tables.core import clinical_events, medications, ons_deaths
 
 
@@ -14,6 +15,7 @@ __all__ = [
     "medications",
     "ons_deaths",
     "patients",
+    "vaccinations",
 ]
 
 
@@ -124,3 +126,24 @@ class patients(PatientFrame):
             self.registration_end_date.is_after(end_date)
             | self.registration_end_date.is_null()
         )
+
+
+@table
+class vaccinations(EventFrame):
+    """
+    This table contains information on administered vaccinations,
+    identified using SNOMED-CT codes for the vaccination procedure.
+
+    Vaccinations may also be queried by product code using the
+    [medications table](#medications).
+
+    Vaccinations that were administered at work or in a pharmacy might not be
+    included in this table.
+
+    """
+
+    date = Series(
+        datetime.date,
+        description="The date the vaccination was administered.",
+    )
+    procedure_code = Series(SNOMEDCTCode)

--- a/tests/integration/backends/test_emis.py
+++ b/tests/integration/backends/test_emis.py
@@ -10,6 +10,7 @@ from ehrql.tables import PatientFrame, Series, emis, table_from_rows
 from ehrql.tables.raw import emis as emis_raw
 from ehrql.utils.sqlalchemy_query_utils import CreateTableAs, GeneratedTable
 from tests.lib.emis_schema import (
+    ImmunisationAllOrgsV2,
     MedicationAllOrgsV2,
     ObservationAllOrgsV2,
     OnsView,
@@ -447,6 +448,47 @@ def test_patients(select_all_emis):
         },
     ]
     assert results == expected
+
+
+@register_test_for(emis.vaccinations)
+def test_vaccinations(select_all_emis):
+    results = select_all_emis(
+        PatientAllOrgsV2(registration_id="1"),
+        PatientAllOrgsV2(registration_id="2"),
+        PatientAllOrgsV2(registration_id="3"),
+        ImmunisationAllOrgsV2(
+            registration_id="1",
+            effective_date=datetime(2020, 10, 20, 14, 30, 5),
+            snomed_concept_id=123,
+        ),
+        ImmunisationAllOrgsV2(
+            registration_id="2",
+            effective_date=datetime(2021, 3, 23, 23, 30, 5),
+            snomed_concept_id=456,
+        ),
+        ImmunisationAllOrgsV2(
+            registration_id="2",
+            effective_date=datetime(2022, 1, 15, 12, 30, 5),
+            snomed_concept_id=567,
+        ),
+    )
+    assert results == [
+        {
+            "patient_id": "1",
+            "date": date(2020, 10, 20),
+            "procedure_code": "123",
+        },
+        {
+            "patient_id": "2",
+            "date": date(2021, 3, 23),
+            "procedure_code": "456",
+        },
+        {
+            "patient_id": "2",
+            "date": date(2022, 1, 15),
+            "procedure_code": "567",
+        },
+    ]
 
 
 def test_registered_tests_are_exhaustive():

--- a/tests/lib/emis_schema.py
+++ b/tests/lib/emis_schema.py
@@ -8,6 +8,15 @@ class Base(DeclarativeBase):
     "Common base class to signal that models below belong to the same database"
 
 
+class ImmunisationAllOrgsV2(Base):
+    __tablename__ = "immunisation_all_orgs_v2"
+    _pk = mapped_column(t.Integer, primary_key=True)
+
+    registration_id = mapped_column(t.VARCHAR(128))
+    snomed_concept_id = mapped_column(t.BigInteger)
+    effective_date = mapped_column(t.DateTime)
+
+
 class PatientAllOrgsV2(Base):
     __tablename__ = "patient_all_orgs_v2"
     _pk = mapped_column(t.Integer, primary_key=True)
@@ -39,7 +48,7 @@ class MedicationAllOrgsV2(Base):
     _pk = mapped_column(t.Integer, primary_key=True)
 
     registration_id = mapped_column(t.VARCHAR(128))
-    snomed_concept_id = mapped_column(t.Integer)
+    snomed_concept_id = mapped_column(t.BigInteger)
     effective_date = mapped_column(t.DateTime)
 
 


### PR DESCRIPTION
Adds the EMIS vaccinations table. In cohort-extractor, the method to
query vaccinations also allowed querying by product code, but it did
so by inner joining the medications table on the immunisation table.
That gives us all medications for patients who also had a vaccination
procedure, which isn't the right thing to do here - a lot of those
medications will not be vaccination-related. In order to get the
same behaviour as cohort-extractor, users can query this vaccinations
table with a codelist for vaccination procedure codes, and the
medications table with a codelist for vaccination product codes.

Closes #797 