### PR TITLE
Remove some MkDocs log noise

### DIFF
--- a/docs/how-to/assign-multiple-columns.md
+++ b/docs/how-to/assign-multiple-columns.md
@@ -7,7 +7,7 @@ This guide first shows you how to use `dataset.add_column` to assign one new col
 
 ## Assign one column to the dataset
 
-As mentioned in the tutorial on "[Writing a more complex dataset definition](/tutorial/writing-a-more-complex-dataset-definition/#assign-variables-to-the-dataset)",
+As mentioned in the tutorial on "[Writing a more complex dataset definition](../tutorial/writing-a-more-complex-dataset-definition/index.md#assign-variables-to-the-dataset)",
 we can assign a variable to the dataset by adding a dot and the name of the variable to the dataset,
 followed by an equals sign and the definition of the variable.
 In the following example, the name of the variable is `my_variable`

--- a/docs/includes/generated_docs/backends.md
+++ b/docs/includes/generated_docs/backends.md
@@ -30,15 +30,15 @@ time. For instance, students are often registered with a practice at home and a
 practice at university.
 
 !!! warning
-    Refer to the [discussion of selecting populations for studies](../../explanation/selecting-populations-for-study.md).
+    Refer to the [discussion of selecting populations for studies](../explanation/selecting-populations-for-study.md).
 
 This backend implements the following table schemas:
 
- * [core](../schemas/core/)
- * [raw.core](../schemas/raw.core/)
- * [tpp](../schemas/tpp/)
- * [raw.tpp](../schemas/raw.tpp/)
- * [smoketest](../schemas/smoketest/)
+ * [core](schemas/core.md)
+ * [raw.core](schemas/raw.core.md)
+ * [tpp](schemas/tpp.md)
+ * [raw.tpp](schemas/raw.tpp.md)
+ * [smoketest](schemas/smoketest.md)
 
 ## EMIS
 <small class="subtitle">
@@ -60,8 +60,8 @@ from other sources.
 
 This backend implements the following table schemas:
 
- * [core](../schemas/core/)
- * [raw.core](../schemas/raw.core/)
- * [raw.emis](../schemas/raw.emis/)
- * [emis](../schemas/emis/)
- * [smoketest](../schemas/smoketest/)
+ * [core](schemas/core.md)
+ * [raw.core](schemas/raw.core.md)
+ * [raw.emis](schemas/raw.emis.md)
+ * [emis](schemas/emis.md)
+ * [smoketest](schemas/smoketest.md)

--- a/docs/includes/generated_docs/language__dataset.md
+++ b/docs/includes/generated_docs/language__dataset.md
@@ -54,7 +54,7 @@ An ehrQL query that returns one row per patient.
 Using `.add_column` is equivalent to `=` for adding a single column
 but can also be used to add multiple columns, for example by iterating
 over a dictionary. For more details see the guide on
-"[How to assign multiple columns to a dataset programmatically](/how-to/assign-multiple-columns)".
+"[How to assign multiple columns to a dataset programmatically](../how-to/assign-multiple-columns.md)".
 </div>
 
 <div class="attr-heading" id="Dataset.configure_dummy_data">

--- a/docs/includes/generated_docs/schemas/core.md
+++ b/docs/includes/generated_docs/schemas/core.md
@@ -98,7 +98,7 @@ registered at the same practice for the duration of the study period.
 
 Examples of using ehrQL to calculation such periods can be found in the documentation
 on how to
-[use ehrQL to answer specifc questions](../../../how-to/examples#excluding-medications-for-patients-who-have-transferred-between-practices).
+[use ehrQL to answer specific questions](../../how-to/examples.md#excluding-medications-for-patients-who-have-transferred-between-practices).
 <div markdown="block" class="definition-list-wrapper">
   <div class="title">Columns</div>
   <dl markdown="block">
@@ -155,7 +155,7 @@ The `ehrql.tables.raw.ons_deaths` table contains all registered deaths.
 
 !!! tip
     If you need to query for place of death, please note that
-    this is only available in the tpp backend"
+    this is only available in the `tpp` backend
 <div markdown="block" class="definition-list-wrapper">
   <div class="title">Columns</div>
   <dl markdown="block">
@@ -402,7 +402,7 @@ based on these MCCDs.
 There is generally a lag between the death being recorded in ONS data and it
 appearing in the primary care record, but the coverage or recorded death is almost
 complete and the date of death is usually reliable when it appears. There is
-also a lag in ONS death recording (see [`ons_deaths`](/reference/schemas/core/#ons_deaths) below
+also a lag in ONS death recording (see [`ons_deaths`](#ons_deaths) below
 for more detail). You can find out more about the accuracy of date of death
 recording in primary care in:
 

--- a/docs/includes/generated_docs/schemas/emis.md
+++ b/docs/includes/generated_docs/schemas/emis.md
@@ -99,7 +99,7 @@ registered at the same practice for the duration of the study period.
 
 Examples of using ehrQL to calculation such periods can be found in the documentation
 on how to
-[use ehrQL to answer specifc questions](../../../how-to/examples#excluding-medications-for-patients-who-have-transferred-between-practices).
+[use ehrQL to answer specific questions](../../how-to/examples.md#excluding-medications-for-patients-who-have-transferred-between-practices).
 <div markdown="block" class="definition-list-wrapper">
   <div class="title">Columns</div>
   <dl markdown="block">
@@ -156,7 +156,7 @@ The `ehrql.tables.raw.ons_deaths` table contains all registered deaths.
 
 !!! tip
     If you need to query for place of death, please note that
-    this is only available in the tpp backend"
+    this is only available in the `tpp` backend
 <div markdown="block" class="definition-list-wrapper">
   <div class="title">Columns</div>
   <dl markdown="block">

--- a/docs/includes/generated_docs/schemas/tpp.md
+++ b/docs/includes/generated_docs/schemas/tpp.md
@@ -1358,7 +1358,7 @@ registered at the same practice for the duration of the study period.
 
 Examples of using ehrQL to calculation such periods can be found in the documentation
 on how to
-[use ehrQL to answer specifc questions](../../../how-to/examples#excluding-medications-for-patients-who-have-transferred-between-practices).
+[use ehrQL to answer specific questions](../../how-to/examples.md#excluding-medications-for-patients-who-have-transferred-between-practices).
 <div markdown="block" class="definition-list-wrapper">
   <div class="title">Columns</div>
   <dl markdown="block">
@@ -2205,7 +2205,7 @@ based on these MCCDs.
 There is generally a lag between the death being recorded in ONS data and it
 appearing in the primary care record, but the coverage or recorded death is almost
 complete and the date of death is usually reliable when it appears. There is
-also a lag in ONS death recording (see [`ons_deaths`](/reference/schemas/core/#ons_deaths) below
+also a lag in ONS death recording (see [`ons_deaths`](#ons_deaths) below
 for more detail). You can find out more about the accuracy of date of death
 recording in primary care in:
 
@@ -2296,7 +2296,7 @@ return (date - patients.date_of_birth).years
 
 Each record corresponds to a patient's registration with a practice.
 
-See the [TPP backend information](../../backends.md#patients-included-in-the-tpp-backend)
+See the [TPP backend information](../backends.md#patients-included-in-the-tpp-backend)
 for details of which patients are included.
 <div markdown="block" class="definition-list-wrapper">
   <div class="title">Columns</div>

--- a/ehrql/backends/tpp.py
+++ b/ehrql/backends/tpp.py
@@ -40,7 +40,7 @@ class TPPBackend(SQLBackend):
     practice at university.
 
     !!! warning
-        Refer to the [discussion of selecting populations for studies](../../explanation/selecting-populations-for-study.md).
+        Refer to the [discussion of selecting populations for studies](../explanation/selecting-populations-for-study.md).
     """
 
     display_name = "TPP"

--- a/ehrql/docs/render_includes/backends.py
+++ b/ehrql/docs/render_includes/backends.py
@@ -19,7 +19,7 @@ def render_backends(backend_data):
         BACKEND_TEMPLATE.format(
             **backend,
             schema_list="\n".join(
-                f" * [{schema}](../schemas/{schema}/)"
+                f" * [{schema}](schemas/{schema}.md)"
                 for schema in backend["implements"]
             ),
         )

--- a/ehrql/query_language.py
+++ b/ehrql/query_language.py
@@ -82,7 +82,7 @@ class Dataset:
         Using `.add_column` is equivalent to `=` for adding a single column
         but can also be used to add multiple columns, for example by iterating
         over a dictionary. For more details see the guide on
-        "[How to assign multiple columns to a dataset programmatically](/how-to/assign-multiple-columns)".
+        "[How to assign multiple columns to a dataset programmatically](../how-to/assign-multiple-columns.md)".
         """
         setattr(self, column_name, ehrql_query)
 

--- a/ehrql/tables/core.py
+++ b/ehrql/tables/core.py
@@ -52,7 +52,7 @@ class patients(PatientFrame):
     There is generally a lag between the death being recorded in ONS data and it
     appearing in the primary care record, but the coverage or recorded death is almost
     complete and the date of death is usually reliable when it appears. There is
-    also a lag in ONS death recording (see [`ons_deaths`](/reference/schemas/core/#ons_deaths) below
+    also a lag in ONS death recording (see [`ons_deaths`](#ons_deaths) below
     for more detail). You can find out more about the accuracy of date of death
     recording in primary care in:
 

--- a/ehrql/tables/core.py
+++ b/ehrql/tables/core.py
@@ -246,7 +246,7 @@ class medications(EventFrame):
 
     Examples of using ehrQL to calculation such periods can be found in the documentation
     on how to
-    [use ehrQL to answer specifc questions](../../../how-to/examples#excluding-medications-for-patients-who-have-transferred-between-practices).
+    [use ehrQL to answer specifc questions](../../how-to/examples.md#excluding-medications-for-patients-who-have-transferred-between-practices).
     """
 
     date = Series(datetime.date)

--- a/ehrql/tables/core.py
+++ b/ehrql/tables/core.py
@@ -123,7 +123,7 @@ class ons_deaths(PatientFrame):
 
     !!! tip
         If you need to query for place of death, please note that
-        this is only available in the tpp backend"
+        this is only available in the `tpp` backend
 
     """
 

--- a/ehrql/tables/core.py
+++ b/ehrql/tables/core.py
@@ -246,7 +246,7 @@ class medications(EventFrame):
 
     Examples of using ehrQL to calculation such periods can be found in the documentation
     on how to
-    [use ehrQL to answer specifc questions](../../how-to/examples.md#excluding-medications-for-patients-who-have-transferred-between-practices).
+    [use ehrQL to answer specific questions](../../how-to/examples.md#excluding-medications-for-patients-who-have-transferred-between-practices).
     """
 
     date = Series(datetime.date)

--- a/ehrql/tables/tpp.py
+++ b/ehrql/tables/tpp.py
@@ -1025,7 +1025,7 @@ class practice_registrations(EventFrame):
     """
     Each record corresponds to a patient's registration with a practice.
 
-    See the [TPP backend information](../../backends.md#patients-included-in-the-tpp-backend)
+    See the [TPP backend information](../backends.md#patients-included-in-the-tpp-backend)
     for details of which patients are included.
     """
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -16,6 +16,9 @@ docs_dir: docs
 exclude_docs: |
   /includes/
 
+not_in_nav: |
+  /reference/schemas/
+
 nav:
   - ehrQL: index.md
   - Tutorial:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -28,6 +28,7 @@ nav:
     - Resolving ehrQL errors: how-to/errors.md
     - How to use dummy data in an ehrQL dataset definition: how-to/dummy-data.md
     - How to use dummy data in an ehrQL measures definition: how-to/dummy-measures-data.md
+    - How to assign multiple columns to a dataset programmatically: how-to/assign-multiple-columns.md
     - How to work with codelists: how-to/codelists.md
   - Reference:
     - Reference: reference/index.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,6 +10,12 @@ site_name: OpenSAFELY ehrQL documentation
 repo_url: https://github.com/opensafely-core/ehrql
 docs_dir: docs
 
+# Dotfiles/dotdirectories and the top-level templates directory
+# are implicit entries for exclude_docs.
+# https://www.mkdocs.org/user-guide/configuration/#exclude_docs
+exclude_docs: |
+  /includes/
+
 nav:
   - ehrQL: index.md
   - Tutorial:


### PR DESCRIPTION
The MkDocs logs when serving or building the documentation are noisy, and are at least a screenful of information for me on my display configuration.

This hides information that might actually be useful to people when working on the documentation: new problems that might have been introduced when editing aren't obvious.

This PR reduces, but does not entirely remove, the noise by:

* fixing up some of the issues associated with the logs; *some links were actually broken in the OpenSAFELY documentation site*
* removing some of the false positives by configuring MkDocs options to exclude certain paths from checks

## Other notes

* The logs are now much cleaner when using `just docs-serve --clean` — this takes account of the `exclude_docs` option I've configured in `mkdocs.yml`. This excludes the `includes/` directory, which is a source of multiple false positives. **Perhaps we should make `--clean` the default in `just docs-serve`?** (Sometimes people might want to preview excluded documents, such as a `drafts/` directory, which is why this is not the default MkDocs behaviour.)
* There's a quirk where some URLs work in the ehrQL documentation preview, but not OpenSAFELY's documentation. The difference is that the ehrQL preview uses paths to pages like `/how-to/…`, while the OpenSAFELY site has paths like `/ehrql/how-to/…`. Because of this, some links — either from absolute paths or from relative paths that reach the URL root — work in the ehrQL preview, but are broken on the OpenSAFELY site. I'm not sure why the OpenSAFELY [link check doesn't catch these](https://github.com/opensafely/documentation/issues/1403). I opened [an issue](https://github.com/opensafely-core/ehrql/issues/1817) for restructuring the ehrQL preview.
* The OpenSAFELY documentation site has the same problem with including the ehrQL `includes/` as accessible pages. Because we still have the quirk of having to duplicate our configuration, we should [configure it there too](https://github.com/opensafely/documentation/issues/1402).
* The remaining issues are primarily around how relative paths are automatically generated in the Python code inside `ehrql/docs`. This might be a little bit trickier to get right, so I've [opened an issue to document the problem](https://github.com/opensafely-core/ehrql/issues/1818), and it can be a separate PR.