### PR TITLE
Further fixes to gentest tooling

### DIFF
--- a/tests/lib/gentest_example_simplify.py
+++ b/tests/lib/gentest_example_simplify.py
@@ -30,6 +30,8 @@ import black
 
 import ehrql.query_model.nodes
 from ehrql.query_model.nodes import (
+    AggregateByPatient,
+    Function,
     InlinePatientTable,
     Node,
     SelectColumn,
@@ -93,11 +95,13 @@ def fix_up_module(contents):
     # If it has imports we assume it's been fixed up already
     if re.search(r"\bimport\b", contents):  # pragma: no cover
         return contents
+    names = "|".join(map(re.escape, VARIABLE_NAMES))
     # Strip leading indentation
-    for name in VARIABLE_NAMES:
-        contents = re.sub(
-            rf"^\s+{name}\s*=\s*", f"{name} = ", contents, flags=re.MULTILINE
-        )
+    contents = re.sub(rf"^\s+({names})\s*=\s*", r"\1 = ", contents, flags=re.MULTILINE)
+    # Fix up outermost function reprs
+    contents = re.sub(
+        rf"^({names}) = (\w+)", fix_up_function_reprs, contents, flags=re.MULTILINE
+    )
     # Add imports (many of these will be unnecessary but that's fine)
     imports = [
         "import datetime",
@@ -106,6 +110,21 @@ def fix_up_module(contents):
     ]
     contents = "\n".join(imports) + "\n" + contents
     return contents
+
+
+def fix_up_function_reprs(match):  # pragma: no cover
+    # Hypothesis seems to use its own repr for the outermost value in its example which
+    # means it misses off the namespace and renders e.g. `Function.Not` as `Not`. We fix
+    # that here.
+    name, func_name = match.groups()
+    if func_name not in ehrql.query_model.nodes.__all__:
+        for namespace in [AggregateByPatient, Function]:
+            if hasattr(namespace, func_name):
+                func_name = f"{namespace.__name__}.{func_name}"
+                break
+        else:
+            raise ValueError(f"Unknown function in: {name} = {func_name}")
+    return f"{name} = {func_name}"
 
 
 class QueryModelRepr:  # pragma: no cover

--- a/tests/lib/test_gentest_example_simplify.py
+++ b/tests/lib/test_gentest_example_simplify.py
@@ -11,8 +11,10 @@ def test_gentest_example_simplify():
           population=AggregateByPatient.Exists(
               SelectPatientTable("p0", TableSchema(i1=Column(int)))
           ),
-          variable=SelectColumn(
-              SelectPatientTable("p0", TableSchema(i1=Column(int))), "i1"
+          variable=Negate(
+              SelectColumn(
+                  SelectPatientTable("p0", TableSchema(i1=Column(int))), "i1"
+              )
           )
           data=[
               {"type": data_setup.P0, "patient_id": 1},
@@ -20,4 +22,4 @@ def test_gentest_example_simplify():
         """
     )
     result = simplify(example)
-    assert "variable = p0_i1" in result
+    assert "variable = Function.Negate(p0_i1)" in result


### PR DESCRIPTION
Hypothesis seems to use its own repr for the outermost value in its example which means it misses off the namespace and renders e.g. `Function.Not` as `Not`. We fix that here.