### PR TITLE
test: Expand documentation checks to measures

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -322,16 +322,16 @@ generated markdown files. It is a developer's responsibility to update the gener
 their PR if required. There is also a CI step that will check that the documentation is up to
 date.
 
-### Testing dataset definitions included in the documentation
+### Testing ehrQL definitions included in the documentation
 
 All of the example tests can be run with:
 
     just test-docs-examples
 
-* Examples to be tested run with `generate_dataset()`.
-* Dataset definitions may be included inline in Markdown files in `docs/`,
+Dataset and measures definitions may be included:
+* inline in Markdown files in `docs/`,
   labelled as code blocks with the `ehrql` syntax,
-  or as Python `.py` files in `docs/`.
+* or as Python `.py` files in `docs/`.
 
 #### Examples using `codelist_from_csv()`
 
@@ -356,9 +356,9 @@ This will still highlight the code as if it were Python.
 We use the SuperFences extension for extracting Markdown fences.
 Refer to the [SuperFences documentation](https://facelessuser.github.io/pymdown-extensions/extensions/superfences/#nested-fence-format) for more details of the fence format.
 
-#### Dataset definitions as included Python files
+#### ehrQL definitions as included Python files
 
-Python files in the `docs/` directory are assumed to be working dataset definitions.
+Python files in the `docs/` directory are assumed to be working ehrQL dataset or measures definitions.
 
 They are also tested in the test suite.
 

--- a/docs/explanation/measures.md
+++ b/docs/explanation/measures.md
@@ -15,7 +15,7 @@ Suppose we want to know what proportion of the patients prescribed atorvastatin 
 
 ### Code
 
-```python
+```ehrql
 from ehrql import INTERVAL, case, create_measures, months, when
 from ehrql.tables.core import medications, patients
 

--- a/docs/how-to/dummy-measures-data.md
+++ b/docs/how-to/dummy-measures-data.md
@@ -44,7 +44,7 @@ above.
 
 For example, take this simple measures definition:
 
-```python
+```ehrql
 from ehrql import create_measures, years
 from ehrql.measures import INTERVAL
 from ehrql.tables.core import patients, clinical_events

--- a/tests/docs/test_complete_examples.py
+++ b/tests/docs/test_complete_examples.py
@@ -134,8 +134,8 @@ def find_complete_ehrql_examples_in_markdown(file):
         if fence.language == "ehrql":
             example = DatasetDefinitionExample(
                 path=Path(file.name),
-                source=fence.source,
                 fence_number=fence_number,
+                source=fence.source,
             )
             yield example
 

--- a/tests/docs/test_find_docs_examples.py
+++ b/tests/docs/test_find_docs_examples.py
@@ -117,10 +117,14 @@ from . import test_complete_examples
             ),
             [
                 test_complete_examples.EhrqlExample(
-                    path=Path("test"), fence_number=1, source="some code"
+                    path=Path("test"),
+                    fence_number=1,
+                    source="some code",
                 ),
                 test_complete_examples.EhrqlExample(
-                    path=Path("test"), fence_number=2, source="more code"
+                    path=Path("test"),
+                    fence_number=2,
+                    source="more code",
                 ),
             ],
             id="multiple fences",
@@ -135,7 +139,9 @@ from . import test_complete_examples
             ),
             [
                 test_complete_examples.EhrqlExample(
-                    path=Path("test"), fence_number=1, source="some code"
+                    path=Path("test"),
+                    fence_number=1,
+                    source="some code",
                 ),
             ],
             id="fence in quote",
@@ -156,7 +162,9 @@ from . import test_complete_examples
             ),
             [
                 test_complete_examples.EhrqlExample(
-                    path=Path("test"), fence_number=1, source="some code"
+                    path=Path("test"),
+                    fence_number=1,
+                    source="some code",
                 ),
             ],
             id="fence in list",

--- a/tests/docs/test_find_docs_examples.py
+++ b/tests/docs/test_find_docs_examples.py
@@ -12,7 +12,7 @@ from . import test_complete_examples
 # and are to help document and catch changes in behaviour
 # that we may be interested in.
 @pytest.mark.parametrize(
-    "fence,expected_dataset_definition_example",
+    "fence,expected_example",
     [
         pytest.param(
             textwrap.dedent(
@@ -22,7 +22,7 @@ from . import test_complete_examples
                 """
             ),
             [
-                test_complete_examples.DatasetDefinitionExample(
+                test_complete_examples.EhrqlExample(
                     path=Path("test"),
                     fence_number=1,
                     source="",
@@ -39,7 +39,7 @@ from . import test_complete_examples
                 """
             ),
             [
-                test_complete_examples.DatasetDefinitionExample(
+                test_complete_examples.EhrqlExample(
                     path=Path("test"),
                     fence_number=1,
                     source="some code",
@@ -57,7 +57,7 @@ from . import test_complete_examples
                 """
             ),
             [
-                test_complete_examples.DatasetDefinitionExample(
+                test_complete_examples.EhrqlExample(
                     path=Path("test"),
                     fence_number=1,
                     source="some code\nmore code",
@@ -76,7 +76,7 @@ from . import test_complete_examples
                 """
             ),
             [
-                test_complete_examples.DatasetDefinitionExample(
+                test_complete_examples.EhrqlExample(
                     path=Path("test"),
                     fence_number=1,
                     source="some code\n```ehrql\nmore code",
@@ -95,7 +95,7 @@ from . import test_complete_examples
                 """
             ),
             [
-                test_complete_examples.DatasetDefinitionExample(
+                test_complete_examples.EhrqlExample(
                     path=Path("test"),
                     fence_number=1,
                     source="some code",
@@ -116,10 +116,10 @@ from . import test_complete_examples
                 """
             ),
             [
-                test_complete_examples.DatasetDefinitionExample(
+                test_complete_examples.EhrqlExample(
                     path=Path("test"), fence_number=1, source="some code"
                 ),
-                test_complete_examples.DatasetDefinitionExample(
+                test_complete_examples.EhrqlExample(
                     path=Path("test"), fence_number=2, source="more code"
                 ),
             ],
@@ -134,7 +134,7 @@ from . import test_complete_examples
                 """
             ),
             [
-                test_complete_examples.DatasetDefinitionExample(
+                test_complete_examples.EhrqlExample(
                     path=Path("test"), fence_number=1, source="some code"
                 ),
             ],
@@ -155,7 +155,7 @@ from . import test_complete_examples
                 """
             ),
             [
-                test_complete_examples.DatasetDefinitionExample(
+                test_complete_examples.EhrqlExample(
                     path=Path("test"), fence_number=1, source="some code"
                 ),
             ],
@@ -184,7 +184,7 @@ from . import test_complete_examples
         ),
     ],
 )
-def test_find_docs_examples(fence, expected_dataset_definition_example):
+def test_find_docs_examples(fence, expected_example):
     example = StringIO(fence)
     # Unlike file objects, StringIO objects do not have a name.
     # In the relevant code being tested,
@@ -194,4 +194,4 @@ def test_find_docs_examples(fence, expected_dataset_definition_example):
     result = list(
         test_complete_examples.find_complete_ehrql_examples_in_markdown(example)
     )
-    assert result == expected_dataset_definition_example
+    assert result == expected_example

--- a/tests/docs/test_run_generate_dataset_example.py
+++ b/tests/docs/test_run_generate_dataset_example.py
@@ -191,3 +191,20 @@ def test_run_ehrql_measures_example_gives_unreadable_csv(tmp_path):
         ) as exc_info:
             test_complete_examples.test_ehrql_example(tmp_path, example)
     assert type(exc_info.value) is test_complete_examples.EhrqlExampleTestError
+
+
+def test_run_ehrql_non_matching_example(tmp_path):
+    example = test_complete_examples.EhrqlExample(
+        path="test",
+        fence_number=1,
+        source=textwrap.dedent(
+            """\
+            from ehrql import months
+            """
+        ),
+    )
+    with pytest.raises(
+        test_complete_examples.EhrqlExampleTestError,
+    ) as exc_info:
+        test_complete_examples.test_ehrql_example(tmp_path, example)
+    assert type(exc_info.value) is test_complete_examples.EhrqlExampleTestError

--- a/tests/docs/test_run_generate_dataset_example.py
+++ b/tests/docs/test_run_generate_dataset_example.py
@@ -6,7 +6,7 @@ import pytest
 from . import test_complete_examples
 
 
-def test_run_ehrql_example(tmp_path):
+def test_run_ehrql_dataset_example(tmp_path):
     example = test_complete_examples.EhrqlExample(
         path="test",
         fence_number=1,
@@ -23,7 +23,29 @@ def test_run_ehrql_example(tmp_path):
     test_complete_examples.test_ehrql_example(tmp_path, example)
 
 
-def test_run_ehrql_example_failing(tmp_path):
+def test_run_ehrql_measures_example(tmp_path):
+    example = test_complete_examples.EhrqlExample(
+        path="test",
+        fence_number=1,
+        source=textwrap.dedent(
+            """\
+            from ehrql import create_measures, months
+            from ehrql.tables.tpp import patients
+
+            measures = create_measures()
+            measures.define_measure(
+                name="test",
+                numerator=patients.exists_for_patient(),
+                denominator=patients.exists_for_patient(),
+                intervals=months(12).starting_on("2020-01-01"),
+            )
+            """
+        ),
+    )
+    test_complete_examples.test_ehrql_example(tmp_path, example)
+
+
+def test_run_ehrql_dataset_example_failing(tmp_path):
     example = test_complete_examples.EhrqlExample(
         path="test",
         fence_number=1,
@@ -41,7 +63,31 @@ def test_run_ehrql_example_failing(tmp_path):
     assert type(exc_info.value) is test_complete_examples.EhrqlExampleTestError
 
 
-def test_run_ehrql_example_failing_codelist_from_csv_call(tmp_path):
+def test_run_ehrql_measures_example_failing(tmp_path):
+    example = test_complete_examples.EhrqlExample(
+        path="test",
+        fence_number=1,
+        source=textwrap.dedent(
+            """\
+            from ehrql import create_measures, months
+            from ehrql.tables.tpp import patients
+
+            measures = create_measures()
+            measures.define_measure(
+                name="test",
+                numerator=patients.exists_for_patient(),
+                denominator=not_a_function(),
+                intervals=months(12).starting_on("2020-01-01"),
+            )
+            """
+        ),
+    )
+    with pytest.raises(test_complete_examples.EhrqlExampleTestError) as exc_info:
+        test_complete_examples.test_ehrql_example(tmp_path, example)
+    assert type(exc_info.value) is test_complete_examples.EhrqlExampleTestError
+
+
+def test_run_ehrql_dataset_example_failing_codelist_from_csv_call(tmp_path):
     example = test_complete_examples.EhrqlExample(
         path="test",
         fence_number=1,
@@ -66,7 +112,37 @@ def test_run_ehrql_example_failing_codelist_from_csv_call(tmp_path):
     assert type(exc_info.value) is test_complete_examples.EhrqlExampleTestError
 
 
-def test_run_ehrql_example_gives_unreadable_csv(tmp_path):
+def test_run_ehrql_measures_example_failing_codelist_from_csv_call(tmp_path):
+    example = test_complete_examples.EhrqlExample(
+        path="test",
+        fence_number=1,
+        source=textwrap.dedent(
+            """\
+            from ehrql import create_measures, months
+            from ehrql.tables.tpp import patients
+
+            codes = codelist_from_csv()
+
+            measures = create_measures()
+            measures.define_measure(
+                name="test",
+                numerator=patients.exists_for_patient(),
+                denominator=patients.exists_for_patient(),
+                intervals=months(12).starting_on("2020-01-01"),
+            )
+            """
+        ),
+    )
+
+    with pytest.raises(
+        test_complete_examples.EhrqlExampleTestError,
+        match=r"generate_measures failed for example",
+    ) as exc_info:
+        test_complete_examples.test_ehrql_example(tmp_path, example)
+    assert type(exc_info.value) is test_complete_examples.EhrqlExampleTestError
+
+
+def test_run_ehrql_dataset_example_gives_unreadable_csv(tmp_path):
     example = test_complete_examples.EhrqlExample(
         path="test",
         fence_number=1,
@@ -83,7 +159,35 @@ def test_run_ehrql_example_gives_unreadable_csv(tmp_path):
     with unittest.mock.patch("ehrql.main.generate_dataset", return_value=None):
         with pytest.raises(
             test_complete_examples.EhrqlExampleTestError,
-            match=r"Check of output dataset CSV failed for example",
+            match=r"Check of CSV output failed for example",
+        ) as exc_info:
+            test_complete_examples.test_ehrql_example(tmp_path, example)
+    assert type(exc_info.value) is test_complete_examples.EhrqlExampleTestError
+
+
+def test_run_ehrql_measures_example_gives_unreadable_csv(tmp_path):
+    example = test_complete_examples.EhrqlExample(
+        path="test",
+        fence_number=1,
+        source=textwrap.dedent(
+            """\
+            from ehrql import create_measures, months
+            from ehrql.tables.tpp import patients
+
+            measures = create_measures()
+            measures.define_measure(
+                name="test",
+                numerator=patients.exists_for_patient(),
+                denominator=patients.exists_for_patient(),
+                intervals=months(12).starting_on("2020-01-01"),
+            )
+            """
+        ),
+    )
+    with unittest.mock.patch("ehrql.main.generate_measures", return_value=None):
+        with pytest.raises(
+            test_complete_examples.EhrqlExampleTestError,
+            match=r"Check of CSV output failed for example",
         ) as exc_info:
             test_complete_examples.test_ehrql_example(tmp_path, example)
     assert type(exc_info.value) is test_complete_examples.EhrqlExampleTestError

--- a/tests/docs/test_run_generate_dataset_example.py
+++ b/tests/docs/test_run_generate_dataset_example.py
@@ -6,8 +6,8 @@ import pytest
 from . import test_complete_examples
 
 
-def test_run_generate_dataset_example(tmp_path):
-    example = test_complete_examples.DatasetDefinitionExample(
+def test_run_ehrql_example(tmp_path):
+    example = test_complete_examples.EhrqlExample(
         path="test",
         fence_number=1,
         source=textwrap.dedent(
@@ -20,11 +20,11 @@ def test_run_generate_dataset_example(tmp_path):
             """
         ),
     )
-    test_complete_examples.test_ehrql_generate_dataset_example(tmp_path, example)
+    test_complete_examples.test_ehrql_example(tmp_path, example)
 
 
-def test_run_generate_dataset_example_failing(tmp_path):
-    example = test_complete_examples.DatasetDefinitionExample(
+def test_run_ehrql_example_failing(tmp_path):
+    example = test_complete_examples.EhrqlExample(
         path="test",
         fence_number=1,
         source=textwrap.dedent(
@@ -36,13 +36,13 @@ def test_run_generate_dataset_example_failing(tmp_path):
             """
         ),
     )
-    with pytest.raises(test_complete_examples.DatasetDefinitionTestError) as exc_info:
-        test_complete_examples.test_ehrql_generate_dataset_example(tmp_path, example)
-    assert type(exc_info.value) is test_complete_examples.DatasetDefinitionTestError
+    with pytest.raises(test_complete_examples.EhrqlExampleTestError) as exc_info:
+        test_complete_examples.test_ehrql_example(tmp_path, example)
+    assert type(exc_info.value) is test_complete_examples.EhrqlExampleTestError
 
 
-def test_run_generate_dataset_example_failing_codelist_from_csv_call(tmp_path):
-    example = test_complete_examples.DatasetDefinitionExample(
+def test_run_ehrql_example_failing_codelist_from_csv_call(tmp_path):
+    example = test_complete_examples.EhrqlExample(
         path="test",
         fence_number=1,
         source=textwrap.dedent(
@@ -59,15 +59,15 @@ def test_run_generate_dataset_example_failing_codelist_from_csv_call(tmp_path):
     )
 
     with pytest.raises(
-        test_complete_examples.DatasetDefinitionTestError,
+        test_complete_examples.EhrqlExampleTestError,
         match=r"generate_dataset failed for example",
     ) as exc_info:
-        test_complete_examples.test_ehrql_generate_dataset_example(tmp_path, example)
-    assert type(exc_info.value) is test_complete_examples.DatasetDefinitionTestError
+        test_complete_examples.test_ehrql_example(tmp_path, example)
+    assert type(exc_info.value) is test_complete_examples.EhrqlExampleTestError
 
 
-def test_run_generate_dataset_example_gives_unreadable_csv(tmp_path):
-    example = test_complete_examples.DatasetDefinitionExample(
+def test_run_ehrql_example_gives_unreadable_csv(tmp_path):
+    example = test_complete_examples.EhrqlExample(
         path="test",
         fence_number=1,
         source=textwrap.dedent(
@@ -82,10 +82,8 @@ def test_run_generate_dataset_example_gives_unreadable_csv(tmp_path):
     )
     with unittest.mock.patch("ehrql.main.generate_dataset", return_value=None):
         with pytest.raises(
-            test_complete_examples.DatasetDefinitionTestError,
+            test_complete_examples.EhrqlExampleTestError,
             match=r"Check of output dataset CSV failed for example",
         ) as exc_info:
-            test_complete_examples.test_ehrql_generate_dataset_example(
-                tmp_path, example
-            )
-    assert type(exc_info.value) is test_complete_examples.DatasetDefinitionTestError
+            test_complete_examples.test_ehrql_example(tmp_path, example)
+    assert type(exc_info.value) is test_complete_examples.EhrqlExampleTestError


### PR DESCRIPTION
Fixes #1726.

This PR enables complete examples of measure definitions in the documentation to be tested.

As with dataset definitions, these can be:

* Python files in the documentation source path; these are assumed to be some kind of valid ehrQL definition
* examples in the documentation source Markdown; labelled as `ehrql`

The same caveats around codelist monkeypatching — detailed in #1694 — apply as do for the dataset definition tests.