### PR TITLE
Check ignored test rate in CI not in overnight tests

### DIFF
--- a/.github/workflows/generative-tests.yml
+++ b/.github/workflows/generative-tests.yml
@@ -30,8 +30,7 @@ jobs:
             GENTEST_EXAMPLES=150 \
             GENTEST_RANDOMIZE=t \
             GENTEST_MAX_DEPTH=25 \
-            GENTEST_DEBUG=t \
-            GENTEST_CHECK_IGNORED_ERRORS=t
+            GENTEST_DEBUG=t
 
           # We get a maximum of 6 hours runtime with Github Actions so breaking
           # the loop after 4 hours feels like a reasonably balance of getting a

--- a/Justfile
+++ b/Justfile
@@ -218,9 +218,10 @@ test-generative *ARGS: devenv
     #!/usr/bin/env bash
     set -euo pipefail
 
-    examples=${GENTEST_EXAMPLES:-100}
     [[ -v CI ]] && echo "::group::Run tests (click to view)" || echo "Run tests"
-    GENTEST_EXAMPLES=$examples $BIN/python -m pytest \
+    GENTEST_EXAMPLES=${GENTEST_EXAMPLES:-100} \
+    GENTEST_CHECK_IGNORED_ERRORS=t \
+      $BIN/python -m pytest \
         --cov=ehrql \
         --cov=tests \
         --cov-report=html \


### PR DESCRIPTION
The purpose of this check is to make sure that we don't muck up the "ignore broken examples" mechanism such that we end up not actually executing any generative tests, although we think we are.

This is best done in CI, where things are deterministic and where we can catch before merging, rather than in the overnight tests. We run so many batches of examples in the overnight tests that just by chance we can end up hitting a lot of ignored examples every now and then.