### PR TITLE
Rename `patient_data` to `test_data`

### DIFF
--- a/docs/how-to/test-dataset-definition.md
+++ b/docs/how-to/test-dataset-definition.md
@@ -45,7 +45,7 @@ dataset.latest_asthma_med_date = latest_asthma_med.date
 ## Specifying data and expectations
 
 Next, you need to provide (1) data for test patients and (2) specify the data that you expect to see in the dataset for each patient after applying your ehrQL queries.
-Test data and expectations are defined in a nested dictionary called `patient_data`.
+Test data and expectations are defined in a nested dictionary called `test_data`.
 The key in the outermost dictionary specifies the patient id.
 
 ### Data for test patients
@@ -62,7 +62,7 @@ The `medications` list contains two dictionaries (one for each row we add to the
 Note that you have to specify a list for each table you use in your dataset definition, but this could also be an empty list.
 
 ```py
-patient_data = {
+test_data = {
     1: {
         "patients": [{
             "date_of_birth": date(2020, 1, 1),

--- a/ehrql/loaders.py
+++ b/ehrql/loaders.py
@@ -235,7 +235,7 @@ def load_dataset_definition_unsafe(definition_file, user_args):
 def load_test_definition_unsafe(definition_file, user_args):
     module = load_module(definition_file, user_args)
     variable_definitions = get_variable_definitions_from_module(module)
-    return variable_definitions, module.patient_data
+    return variable_definitions, module.test_data
 
 
 def get_variable_definitions_from_module(module):

--- a/tests/fixtures/good_definition_files/assurance.py
+++ b/tests/fixtures/good_definition_files/assurance.py
@@ -8,7 +8,7 @@ from ehrql.tables.core import patients
 dataset = Dataset()
 dataset.define_population(patients.date_of_birth.is_on_or_after("2000-01-01"))
 
-patient_data = {
+test_data = {
     # Correctly not expected in population
     1: {
         "patients": [{"date_of_birth": date(1999, 12, 31)}],


### PR DESCRIPTION
This is a better name because we define (1) patient test data as well as (2) expectations in this dict.

Closes #1844 