### PR TITLE
Improve setting up `test_data` for `assure`

### DIFF
--- a/tests/fixtures/good_definition_files/assurance.py
+++ b/tests/fixtures/good_definition_files/assurance.py
@@ -11,7 +11,7 @@ dataset.define_population(patients.date_of_birth.is_on_or_after("2000-01-01"))
 test_data = {
     # Correctly not expected in population
     1: {
-        "patients": [{"date_of_birth": date(1999, 12, 31)}],
+        "patients": {"date_of_birth": date(1999, 12, 31)},
         "expected_in_population": False,
     },
 }

--- a/tests/unit/test_assurance.py
+++ b/tests/unit/test_assurance.py
@@ -33,19 +33,19 @@ dataset.has_matching_event = events.where(
 test_data = {
     # Correctly not expected in population
     1: {
-        "patients": [{"date_of_birth": date(1999, 12, 31)}],
+        "patients": {"date_of_birth": date(1999, 12, 31)},
         "events": [],
         "expected_in_population": False,
     },
     # Incorrectly not expected in population
     2: {
-        "patients": [{"date_of_birth": date(2000, 1, 1)}],
+        "patients": {"date_of_birth": date(2000, 1, 1)},
         "events": [],
         "expected_in_population": False,
     },
     # Incorrectly expected in population
     3: {
-        "patients": [{"date_of_birth": date(1999, 12, 31)}],
+        "patients": {"date_of_birth": date(1999, 12, 31)},
         "events": [{"date": date(2020, 1, 1), "code": "11111111"}],
         "expected_columns": {
             "has_matching_event": True,
@@ -53,7 +53,7 @@ test_data = {
     },
     # Has correct expected_columns
     4: {
-        "patients": [{"date_of_birth": date(2010, 1, 1)}],
+        "patients": {"date_of_birth": date(2010, 1, 1)},
         "events": [{"date": date(2020, 1, 1), "code": "11111111"}],
         "expected_columns": {
             "has_matching_event": True,
@@ -61,7 +61,7 @@ test_data = {
     },
     # Has incorrect expected_columns
     5: {
-        "patients": [{"date_of_birth": date(2010, 1, 1)}],
+        "patients": {"date_of_birth": date(2010, 1, 1)},
         "events": [{"date": date(2020, 1, 1), "code": "22222222"}],
         "expected_columns": {
             "has_matching_event": True,


### PR DESCRIPTION
Before, data for (1) one-row-per-patient and (2) many-rows-per-patient tables was added in the same way – a list of dictionaries. This was confusing because (1) should only be able to take one dictionary (i.e., one row per patient).

Closes #1846