### PR TITLE
Support sorting by patient series

### DIFF
--- a/docs/includes/generated_docs/specs.md
+++ b/docs/includes/generated_docs/specs.md
@@ -441,6 +441,44 @@ returns the following patient series:
 
 
 
+### 2.5 Pointless sort operations that we should nevertheless handle without error
+
+
+#### 2.5.1 Sort by patient series
+
+This example makes use of an event-level table named `e` and a patient-level table named `p` containing the following data:
+
+| patient|i1 |
+| - | - |
+| 1|101 |
+| 2|201 |
+
+| patient|i1 |
+| - | - |
+| 1|10 |
+| 2|20 |
+
+```python
+e.sort_by(
+    # Patient series
+    p.i1,
+    # Literal constant
+    0,
+    # Compound expression which evaluates to a constant
+    when(True).then(1).otherwise(0),
+)
+.first_for_patient()
+.i1
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1|101 |
+| 2|201 |
+
+
+
 ## 3 Aggregating event and patient frames
 
 

--- a/ehrql/query_engines/in_memory.py
+++ b/ehrql/query_engines/in_memory.py
@@ -120,8 +120,13 @@ class InMemoryQueryEngine(BaseQueryEngine):
 
     def visit_Sort(self, node):
         source = self.visit(node.source)
-        sort_index = self.visit(node.sort_by).sort_index()
-        return source.sort(sort_index)
+        sort_column = self.visit(node.sort_by)
+        if isinstance(sort_column, PatientColumn):
+            # Sorting by a PatientColumn is a no-op, but we need to support it for the
+            # sake of completeness
+            return source
+        else:
+            return source.sort(sort_column.sort_index())
 
     def visit_PickOneRowPerPatient(self, node):
         ix = {

--- a/ehrql/query_engines/trino.py
+++ b/ehrql/query_engines/trino.py
@@ -18,10 +18,11 @@ log = structlog.getLogger()
 class TrinoQueryEngine(BaseSQLQueryEngine):
     sqlalchemy_dialect = TrinoDialect
 
-    def apply_order_clauses_modifications(self, node, order_clauses):
+    def get_order_clauses(self, sort_conditions, position):
+        order_clauses = super().get_order_clauses(sort_conditions, position)
         # Trino always sorts with nulls last by default. We need ascending sorts to
         # sort with nulls first
-        if node.position == Position.FIRST:
+        if position == Position.FIRST:
             order_clauses = [sqlalchemy.nullsfirst(c) for c in order_clauses]
         return order_clauses
 

--- a/ehrql/query_model/transforms.py
+++ b/ehrql/query_model/transforms.py
@@ -28,6 +28,7 @@ from ehrql.query_model.nodes import (
     get_input_nodes,
     get_series_type,
     get_sorts,
+    has_one_row_per_patient,
 )
 from ehrql.query_model.query_graph_rewriter import QueryGraphRewriter
 
@@ -157,7 +158,12 @@ def add_extra_sorts(rewriter, node, selected_column_names):
 def calculate_sorts_to_add(all_sorts, selected_column_names):
     # Don't duplicate existing direct sorts
     direct_sorts = [
-        sort for sort in all_sorts if isinstance(sort.sort_by, SelectColumn)
+        sort
+        for sort in all_sorts
+        if isinstance(sort.sort_by, SelectColumn)
+        # SelectColumn operations only count as direct sorts if they're selected from
+        # the frame we're sorting, not from some other patient frame
+        and not has_one_row_per_patient(sort.sort_by.source)
     ]
     existing_sorted_column_names = {sort.sort_by.name for sort in direct_sorts}
     sorts_to_add = selected_column_names - existing_sorted_column_names

--- a/tests/spec/sort_and_pick/test_sort_by_with_constants.py
+++ b/tests/spec/sort_and_pick/test_sort_by_with_constants.py
@@ -1,0 +1,41 @@
+from ehrql import when
+
+from ..tables import e, p
+
+
+title = "Pointless sort operations that we should nevertheless handle without error"
+
+table_data = {
+    e: """
+          |  i1
+        --+----
+        1 | 101
+        2 | 201
+        """,
+    p: """
+          |  i1
+        --+----
+        1 | 10
+        2 | 20
+        """,
+}
+
+
+def test_sort_by_patient_series(spec_test):
+    spec_test(
+        table_data,
+        e.sort_by(
+            # Patient series
+            p.i1,
+            # Literal constant
+            0,
+            # Compound expression which evaluates to a constant
+            when(True).then(1).otherwise(0),
+        )
+        .first_for_patient()
+        .i1,
+        {
+            1: 101,
+            2: 201,
+        },
+    )

--- a/tests/spec/toc.py
+++ b/tests/spec/toc.py
@@ -10,6 +10,7 @@ contents = {
         "test_sort_by_multiple_columns_and_pick",
         "test_sort_by_column_with_nulls_and_pick",
         "test_sort_by_interleaved_with_where",
+        "test_sort_by_with_constants",
     ],
     "aggregate_frame": [
         "test_exists_for_patient",

--- a/tests/unit/test_docs.py
+++ b/tests/unit/test_docs.py
@@ -40,7 +40,6 @@ def test_generate_docs():
                     assert len(line.strip()) == len(line)
                 else:
                     leading_whitespace_count = len(line) - len(line.strip())
-                    assert leading_whitespace_count > 0
                     assert leading_whitespace_count % 4 == 0
 
 


### PR DESCRIPTION
Doing so is always a pointless no-op, but given that it's not disallowed by the query model we ought to handle it gracefully.

The SQLite and Trino engines handle this out of the box, but MSSQL and the in-memory engine need some help.

Closes #1864