### PR TITLE
Allow supplying explicit NULLs in `case()`

### DIFF
--- a/docs/includes/generated_docs/specs.md
+++ b/docs/includes/generated_docs/specs.md
@@ -2978,6 +2978,37 @@ returns the following patient series:
 
 
 
+#### 10.1.4 Case with explicit null
+
+This example makes use of a patient-level table named `p` containing the following data:
+
+| patient|i1 |
+| - | - |
+| 1|6 |
+| 2|7 |
+| 3|8 |
+| 4|9 |
+| 5| |
+
+```python
+case(
+    when(p.i1 < 8).then(None),
+    when(p.i1 > 8).then(100),
+    otherwise=200,
+)
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1| |
+| 2| |
+| 3|200 |
+| 4|100 |
+| 5|200 |
+
+
+
 ### 10.2 Case expressions with single condition
 
 

--- a/ehrql/query_engines/base_sql.py
+++ b/ehrql/query_engines/base_sql.py
@@ -541,7 +541,10 @@ class BaseSQLQueryEngine(BaseQueryEngine):
     @get_sql.register(Case)
     def get_sql_case(self, node):
         cases = [
-            (self.get_predicate(condition), self.get_expr(value))
+            (
+                self.get_predicate(condition),
+                self.get_expr(value) if value is not None else None,
+            )
             for (condition, value) in node.cases.items()
         ]
         if node.default is not None:

--- a/ehrql/query_engines/in_memory.py
+++ b/ehrql/query_engines/in_memory.py
@@ -100,6 +100,9 @@ class InMemoryQueryEngine(BaseQueryEngine):
             default=value,
         )
 
+    def visit_NoneType(self, node):
+        return PatientColumn({}, None)
+
     def convert_value(self, value):
         if hasattr(value, "_to_primitive_type"):
             return value._to_primitive_type()
@@ -351,10 +354,7 @@ class InMemoryQueryEngine(BaseQueryEngine):
             (self.visit(condition), self.visit(value))
             for condition, value in node.cases.items()
         ]
-        if node.default is None:
-            default = PatientColumn({}, None)
-        else:
-            default = self.visit(node.default)
+        default = self.visit(node.default)
         # Flatten arguments into a single list for easier handling
         arguments = [default, *[i for pair in cases for i in pair]]
         return apply_function(case_flattened, *arguments)

--- a/ehrql/query_language.py
+++ b/ehrql/query_language.py
@@ -1035,8 +1035,11 @@ def _apply(qm_cls, *args):
 
 
 def _convert(arg):
+    # Pass null values through unchanged
+    if arg is None:
+        return None
     # Unpack tuple arguments
-    if isinstance(arg, tuple):
+    elif isinstance(arg, tuple):
         return tuple(_convert(a) for a in arg)
     # Unpack dictionary arguments
     if isinstance(arg, _DictArg):
@@ -1414,12 +1417,7 @@ def case(*when_thens, otherwise=None):
     ```
     """
     cases = _DictArg((case._condition, case._value) for case in when_thens)
-    # If we don't want an `otherwise` value then we shouldn't supply an argument, or
-    # else it will get converted into `Value(None)` which is not what we want
-    if otherwise is None:
-        return _apply(qm.Case, cases)
-    else:
-        return _apply(qm.Case, cases, otherwise)
+    return _apply(qm.Case, cases, otherwise)
 
 
 # HORIZONTAL AGGREGATION FUNCTIONS

--- a/ehrql/query_model/nodes.py
+++ b/ehrql/query_model/nodes.py
@@ -700,26 +700,8 @@ def validate_types(node):
     typevar_context = {}
     for field in dataclasses.fields(node):
         target_typespec = field.type
-        # Bail out early if there's no type-checking to be done; this allows us to work
-        # with values that `get_typespec` cant' handle in cases where we don't actually
-        # care about the type.
-        if target_typespec is Any:
-            continue
         value = getattr(node, field.name)
-        # This might look a bit backward: instead of checking whether the value is of
-        # the expected type, we convert the value to a type specification and check that
-        # it matches the required specification. We do this because although Series
-        # objects are parameterized with the type of thing they represent (e.g.
-        # Series[int]) they don't actually contain any instances of these values (there
-        # are no ints sitting around to be checked). So the standard, "isinstance()",
-        # approach to type checking doesn't work. There may well be a more elegant
-        # alternative approach here, but this works for now.
-        try:
-            # sets and mappings require that their items are of homogenous types, and
-            # raise a TypeError during the conversion to type specification.
-            typespec = get_typespec(value)
-        except TypeError as e:
-            raise TypeValidationError(str(e)) from e
+        typespec = get_typespec(value)
         if not type_matches(typespec, target_typespec, typevar_context):
             # Try to make errors a bit more helpful by resolving TypeVars if we can.
             # This means that if validation fails because e.g. `T` has been bound to

--- a/ehrql/query_model/nodes.py
+++ b/ehrql/query_model/nodes.py
@@ -426,7 +426,7 @@ class Function:
 
 
 class Case(Series[T]):
-    cases: Mapping[Series[bool], Series[T]]
+    cases: Mapping[Series[bool], Series[T] | None]
     default: Series[T] | None = None
 
     def __hash__(self):
@@ -649,10 +649,8 @@ def get_input_nodes(node):
 # nested inside a dict object
 @get_input_nodes.register(Case)
 def get_input_nodes_for_case(node):
-    inputs = [*node.cases.keys(), *node.cases.values()]
-    if node.default is not None:
-        inputs.append(node.default)
-    return inputs
+    inputs = [*node.cases.keys(), *node.cases.values(), node.default]
+    return [i for i in inputs if i is not None]
 
 
 # Minimum/Maximum of functions contain their inputs inside a tuple

--- a/ehrql/query_model/transforms.py
+++ b/ehrql/query_model/transforms.py
@@ -14,6 +14,7 @@ The transformations applied here are all about efficient execution, and therefor
 want to keep them separate from the core query model classes.
 """
 from collections import defaultdict
+from collections.abc import Set
 from typing import Any
 
 from ehrql.query_model.introspection import all_unique_nodes
@@ -23,6 +24,7 @@ from ehrql.query_model.nodes import (
     Parameter,
     PickOneRowPerPatient,
     SelectColumn,
+    Series,
     Sort,
     Value,
     get_input_nodes,
@@ -34,11 +36,7 @@ from ehrql.query_model.query_graph_rewriter import QueryGraphRewriter
 
 
 class PickOneRowPerPatientWithColumns(PickOneRowPerPatient):
-    # The actual type here is `frozenset[Series]` but our type-checking code can't
-    # currently handle the mixed type sets we get here (e.g. `Series[bool]` and
-    # `Series[int]`). We've decided that, as this is an internal class not part of the
-    # public API, it's not worth complicating the type-checking code for this use case.
-    selected_columns: Any
+    selected_columns: Set[Series[Any]]
 
 
 def apply_transforms(variables):

--- a/ehrql/utils/typing_utils.py
+++ b/ehrql/utils/typing_utils.py
@@ -88,7 +88,14 @@ def type_matches(spec, target_spec, typevar_context):
     target_spec_origin = typing.get_origin(target_spec)
     target_spec_args = typing.get_args(target_spec)
 
-    if target_spec_origin is None:
+    if spec_origin is typing.types.UnionType:
+        # If `spec` is a union type then we consider it to match if all of its members
+        # match
+        return all(
+            type_matches(spec_arg, target_spec, typevar_context)
+            for spec_arg in spec_args
+        )
+    elif target_spec_origin is None:
         # If there's no origin type that means `target_spec` is an ordinary class
         if spec == bool and target_spec == int:
             # This is inconsistent with Python's type hierarchy, but considering bool to be

--- a/tests/spec/case_expressions/test_case.py
+++ b/tests/spec/case_expressions/test_case.py
@@ -78,3 +78,21 @@ def test_case_with_boolean_column(spec_test):
             4: None,
         },
     )
+
+
+def test_case_with_explicit_null(spec_test):
+    spec_test(
+        table_data,
+        case(
+            when(p.i1 < 8).then(None),
+            when(p.i1 > 8).then(100),
+            otherwise=200,
+        ),
+        {
+            1: None,
+            2: None,
+            3: 200,
+            4: 100,
+            5: 200,
+        },
+    )

--- a/tests/unit/query_model/test_nodes.py
+++ b/tests/unit/query_model/test_nodes.py
@@ -58,6 +58,7 @@ def queries():
     q.first_vaccination = PickOneRowPerPatient(Sort(vaccinations, date), Position.FIRST)
     q.vaccination_status = Case(
         {
+            Function.LT(q.vaccination_count, Value(0)): None,
             Function.EQ(q.vaccination_count, Value(1)): Value("partial"),
             Function.EQ(q.vaccination_count, Value(2)): Value("full"),
             Function.GE(q.vaccination_count, Value(3)): Value("boosted"),

--- a/tests/unit/query_model/test_nodes.py
+++ b/tests/unit/query_model/test_nodes.py
@@ -427,32 +427,6 @@ def test_cannot_define_operation_returning_any_type(queries):
         get_series_type(BadOperation(queries.vaccination_count))
 
 
-def test_any_type_acts_as_an_escape_hatch():
-    # In the `query_model_transforms` module we define new node types which are purely
-    # for internal use by the query engines and don't form part of the public query
-    # model API. We sometimes want to use types here without having to add support for
-    # them in the type checking system, which is already "cleverer" than anyone would
-    # like. This test ensures that `Any` can be used as an escape hatch.
-
-    mixed_set = frozenset({1, 2.0, "three"})
-
-    # Confirm that we can't validate heterogeneous sets
-    class SomePublicOperation(Series):
-        value: set[Any]
-
-    with pytest.raises(
-        TypeValidationError, match=r"frozensets must be of homogeneous type"
-    ):
-        SomePublicOperation(value=mixed_set)
-
-    # Confirm that we can nevertheless use such a value as long as we don't care what
-    # type it is
-    class SomeInternalOperation(Series):
-        value: Any
-
-    assert SomeInternalOperation(value=mixed_set)
-
-
 @pytest.mark.parametrize(
     "lhs,cmp,rhs",
     [

--- a/tests/unit/utils/test_typing_utils.py
+++ b/tests/unit/utils/test_typing_utils.py
@@ -51,6 +51,10 @@ def test_get_typespec_errors_on_unhandled_container_type():
     [
         (True, list[str], list[int | str]),
         (True, dict[str, FileNotFoundError], dict[Any, OSError]),
+        (True, int | str, str | int),
+        (True, int | str, int | float | str),
+        (True, FileNotFoundError | FileExistsError, OSError),
+        (True, FileNotFoundError | UnicodeError, OSError | ValueError),
         (False, list[str], list[int]),
         (False, tuple[int], list[int]),
         (False, list[str], list[Numeric]),

--- a/tests/unit/utils/test_typing_utils.py
+++ b/tests/unit/utils/test_typing_utils.py
@@ -5,22 +5,37 @@ import pytest
 from ehrql.utils.typing_utils import get_typespec, get_typevars, type_matches
 
 
-def test_get_typevars():
-    T = TypeVar("T")
-    V = TypeVar("V")
-    assert get_typevars(T) == {T}
-    assert get_typevars(dict[T, list[set[V]]]) == {T, V}
-    assert get_typevars(dict[tuple[T], set[T]]) == {T}
+T = TypeVar("T")
+V = TypeVar("V")
+Numeric = TypeVar("Numeric", int, float)
 
 
-def test_get_typespec():
-    assert get_typespec("hello") == str
-    assert get_typespec({"hello", "there"}) == set[str]
-    assert get_typespec({1: "one", 2: "two"}) == dict[int, str]
-    assert get_typespec({1: {0.1, 0.2}, 2: {0.3, 0.4}}) == dict[int, set[float]]
-    assert get_typespec({}) == dict[Any, Any]
-    assert get_typespec(frozenset()) == frozenset[Any]
-    assert get_typespec(int) == type[int]
+@pytest.mark.parametrize(
+    "typespec,typevars",
+    [
+        (T, {T}),
+        (dict[T, list[set[V]]], {T, V}),
+        (dict[tuple[T], set[T]], {T}),
+    ],
+)
+def test_get_typevars(typespec, typevars):
+    assert get_typevars(typespec) == typevars
+
+
+@pytest.mark.parametrize(
+    "value,typespec",
+    [
+        ("hello", str),
+        ({"hello", "there"}, set[str]),
+        ({1: "one", 2: "two"}, dict[int, str]),
+        ({1: {0.1, 0.2}, 2: {0.3, 0.4}}, dict[int, set[float]]),
+        ({}, dict[Any, Any]),
+        (frozenset(), frozenset[Any]),
+        (int, type[int]),
+    ],
+)
+def test_get_typespec(value, typespec):
+    assert get_typespec(value) == typespec
 
 
 def test_get_typespec_errors():
@@ -38,14 +53,24 @@ def test_get_typespec_errors_on_unhandled_container_type():
         get_typespec([1, 2, 3])
 
 
-def test_type_matches():
-    assert type_matches(list[str], list[int | str], {})
-    assert type_matches(dict[str, FileNotFoundError], dict[Any, OSError], {})
+@pytest.mark.parametrize(
+    "matches,typespec_a,typespec_b",
+    [
+        (True, list[str], list[int | str]),
+        (True, dict[str, FileNotFoundError], dict[Any, OSError]),
+        (False, list[str], list[int]),
+        (False, tuple[int], list[int]),
+        (False, list[str], list[Numeric]),
+        (False, list[float], list[int | str]),
+        (False, list, list[int]),
+        (False, bool, Numeric),
+    ],
+)
+def test_type_matches(matches, typespec_a, typespec_b):
+    assert type_matches(typespec_a, typespec_b, {}) == matches
 
 
 def test_type_matches_and_sets_typevar():
-    T = TypeVar("T")
-    Numeric = TypeVar("Numeric", int, float)
     ctx = {}
     assert type_matches(dict[str, str], dict[T, T], ctx)
     assert type_matches(dict[int, int], dict[Numeric, Numeric], ctx)
@@ -54,44 +79,29 @@ def test_type_matches_and_sets_typevar():
 
 
 def test_type_matches_and_sets_typevar_with_any():
-    T = TypeVar("T")
     ctx = {}
     assert type_matches(list[Any], list[T], ctx)
     assert ctx[T] == Any
 
 
 def test_type_matches_and_sets_typevar_with_class_type():
-    T = TypeVar("T")
     ctx = {}
     assert type_matches(type[int], type[T], ctx)
     assert ctx[T] == int
 
 
 def test_type_matches_and_sets_typevar_with_any_and_concrete_type():
-    T = TypeVar("T")
     ctx = {}
     assert type_matches(dict[Any, int], dict[T, T], ctx)
     assert ctx[T] == int
 
 
 def test_any_matches_bound_type_var():
-    T = TypeVar("T")
     ctx = {T: bool}
     assert type_matches(Any, T, ctx)
 
 
-def test_type_matches_rejects_mismatch():
-    Numeric = TypeVar("Numeric", int, float)
-    assert not type_matches(list[str], list[int], {})
-    assert not type_matches(tuple[int], list[int], {})
-    assert not type_matches(list[str], list[Numeric], {})
-    assert not type_matches(list[float], list[int | str], {})
-    assert not type_matches(list, list[int], {})
-    assert not type_matches(bool, Numeric, {})
-
-
 def test_type_matches_only_with_consistent_typevar():
-    T = TypeVar("T")
     ctx = {}
     assert not type_matches(dict[int, bool], dict[T, T], ctx)
     assert not type_matches(dict[str, str], dict[T, T], ctx)

--- a/tests/unit/utils/test_typing_utils.py
+++ b/tests/unit/utils/test_typing_utils.py
@@ -27,8 +27,10 @@ def test_get_typevars(typespec, typevars):
     [
         ("hello", str),
         ({"hello", "there"}, set[str]),
+        ({"hello", 1}, set[str | int]),
         ({1: "one", 2: "two"}, dict[int, str]),
         ({1: {0.1, 0.2}, 2: {0.3, 0.4}}, dict[int, set[float]]),
+        ({1: "one", "two": 2.0}, dict[int | str, str | float]),
         ({}, dict[Any, Any]),
         (frozenset(), frozenset[Any]),
         (int, type[int]),
@@ -36,15 +38,6 @@ def test_get_typevars(typespec, typevars):
 )
 def test_get_typespec(value, typespec):
     assert get_typespec(value) == typespec
-
-
-def test_get_typespec_errors():
-    with pytest.raises(TypeError, match="homogeneous"):
-        get_typespec({1, "two"})
-    with pytest.raises(TypeError, match="homogeneous"):
-        get_typespec({1: "one", "two": "two"})
-    with pytest.raises(TypeError, match="homogeneous"):
-        get_typespec({1: "one", 2: 2.0})
 
 
 def test_get_typespec_errors_on_unhandled_container_type():


### PR DESCRIPTION
As part of this change we end up making the type system a bit more powerful and can throw away some of the workarounds we previously needed.

Closes #1637