### PR TITLE
fix: Fix MSSQL sort-by-constant bug

### DIFF
--- a/docs/includes/generated_docs/specs.md
+++ b/docs/includes/generated_docs/specs.md
@@ -464,8 +464,9 @@ e.sort_by(
     p.i1,
     # Literal constant
     0,
-    # Compound expression which evaluates to a constant
-    when(True).then(1).otherwise(0),
+    # Compound expression which we can statically determine to evaluate to a
+    # constant
+    when(e.i1.is_in([])).then(1).otherwise(0),
 )
 .first_for_patient()
 .i1

--- a/ehrql/query_engines/mssql.py
+++ b/ehrql/query_engines/mssql.py
@@ -9,7 +9,7 @@ from ehrql.query_engines.mssql_dialect import (
     ScalarSelectAggregation,
     SelectStarInto,
 )
-from ehrql.query_model.nodes import has_one_row_per_patient
+from ehrql.query_model.nodes import is_constant
 from ehrql.utils.mssql_log_utils import execute_with_log
 from ehrql.utils.sqlalchemy_exec_utils import (
     execute_with_retry_factory,
@@ -212,11 +212,9 @@ class MSSQLQueryEngine(BaseSQLQueryEngine):
         )
 
     def get_order_clauses(self, sort_conditions, position):
-        # Sorting by a one-row-per-patient series is a no-op and can result in SQL which
-        # causes MSSQL to choke
-        sort_conditions = [
-            node for node in sort_conditions if not has_one_row_per_patient(node)
-        ]
+        # Sorting by a constant is obviously a no-op and causes MSSQL to choke, so we
+        # exclude such clauses
+        sort_conditions = [node for node in sort_conditions if not is_constant(node)]
         return super().get_order_clauses(sort_conditions, position)
 
 

--- a/tests/spec/sort_and_pick/test_sort_by_with_constants.py
+++ b/tests/spec/sort_and_pick/test_sort_by_with_constants.py
@@ -29,8 +29,9 @@ def test_sort_by_patient_series(spec_test):
             p.i1,
             # Literal constant
             0,
-            # Compound expression which evaluates to a constant
-            when(True).then(1).otherwise(0),
+            # Compound expression which we can statically determine to evaluate to a
+            # constant
+            when(e.i1.is_in([])).then(1).otherwise(0),
         )
         .first_for_patient()
         .i1,


### PR DESCRIPTION
This is a follow-up to the attempted fix in #1869. I had naively assumed that the set of all constant expressions was a subset of all patient-level expressions and therefore, as both are no-ops when used as sort conditions, we could just exclude all patient-level expressions – which we already have code to identify.

However, as Hypothesis helpfully [pointed out][1], there are event-level expressions which evaluate as constant e.g. `event_series.is_in([])`, which is always false.

We now add a mechanism for explicitly identifying constant expressions.

Hopefully actually closes #1864

[1]: https://github.com/opensafely-core/ehrql/issues/1864#issuecomment-1876693379