### PR TITLE
Wrap `DomainMismatchError` to be less scary

### DIFF
--- a/docs/explanation/running-ehrql.md
+++ b/docs/explanation/running-ehrql.md
@@ -301,7 +301,7 @@ This is one example:
 ```
 $ opensafely exec ehrql:v1 generate-dataset dataset_definition.py --dummy-tables example-data --output output/dataset.csv
 2023-04-21 17:53:42 [info     ] Compiling dataset definition from dataset_definition.py [ehrql.main]
-Failed to import 'dataset_definition.py':
+Error loading file 'dataset_definition.py':
 ```
 ```pycon
 Traceback (most recent call last):

--- a/docs/how-to/errors.md
+++ b/docs/how-to/errors.md
@@ -130,7 +130,7 @@ opensafely exec ehrql:v1 generate-dataset analysis/dataset_definition.py
 #### Error
 
 ```pytb
-Failed to import 'analysis/dataset_definition.py':
+Error loading file 'analysis/dataset_definition.py':
 
   File "/workspace/analysis/dataset_definition.py", line 6
     dataset.define_population(dataset.age > 16)
@@ -174,7 +174,7 @@ opensafely exec ehrql:v1 generate-dataset analysis/dataset_definition.py
 #### Error
 
 ```pytb
-Failed to import 'analysis/dataset_definition.py':
+Error loading file 'analysis/dataset_definition.py':
 
   File "/workspace/analysis/dataset_definition.py", line 5
     dataset.age! = patients.age_on("2023-01-01") # age! is an invalid feature name.

--- a/ehrql/loaders.py
+++ b/ehrql/loaders.py
@@ -308,7 +308,7 @@ def load_module(module_path, user_args=()):
         return module
     except Exception as exc:
         traceback = get_trimmed_traceback(exc, module.__file__)
-        raise DefinitionError(f"Failed to import '{module_path}':\n\n{traceback}")
+        raise DefinitionError(f"Error loading file '{module_path}':\n\n{traceback}")
     finally:
         sys.path = original_sys_path
         sys.argv = original_sys_argv

--- a/tests/integration/utils/test_traceback_utils.py
+++ b/tests/integration/utils/test_traceback_utils.py
@@ -47,7 +47,7 @@ def test_traceback_filtering_handles_syntax_errors():
     filename = FIXTURES / "bad_syntax.py"
     message = (
         r"^"
-        f"Failed to import '{filename}':"
+        f"Error loading file '{filename}':"
         r"\s+"
         f'File "{filename}", line 1'
         r"\s+"


### PR DESCRIPTION
This isn't the easiest error to explain but I've done my best and am very open to bikeshedding on the text here:
```
Error loading file 'example_dataset.py':

Traceback (most recent call last):
  File "/home/dave/projects/ebmdatalab/ehrql/example_dataset.py", line 6, in <module>
    dataset.v = medications.date > clinical_events.date
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ehrql.query_language.InvalidOperationError: 
Cannot combine series which are drawn from different tables and both
have more than one value per patient.

Hint: try reducing one series to have only one value per patient by
using an aggregation like `maximum_for_patient()` or pick a single
row from the table using `first_for_patient()`.
```

I would have been possibly to implement this by just changing the error raised in the query model, but I think it's important that we have a mechanism in place for translating query model errors into ehrQL errors.