### PR TITLE
Ignore "sort by constant" errors from MSSQL

### DIFF
--- a/docs/includes/generated_docs/specs.md
+++ b/docs/includes/generated_docs/specs.md
@@ -464,9 +464,6 @@ e.sort_by(
     p.i1,
     # Literal constant
     0,
-    # Compound expression which we can statically determine to evaluate to a
-    # constant
-    when(e.i1.is_in([])).then(1).otherwise(0),
 )
 .first_for_patient()
 .i1

--- a/ehrql/query_engines/mssql.py
+++ b/ehrql/query_engines/mssql.py
@@ -9,7 +9,7 @@ from ehrql.query_engines.mssql_dialect import (
     ScalarSelectAggregation,
     SelectStarInto,
 )
-from ehrql.query_model.nodes import is_constant
+from ehrql.query_model.nodes import Value
 from ehrql.utils.mssql_log_utils import execute_with_log
 from ehrql.utils.sqlalchemy_exec_utils import (
     execute_with_retry_factory,
@@ -212,9 +212,17 @@ class MSSQLQueryEngine(BaseSQLQueryEngine):
         )
 
     def get_order_clauses(self, sort_conditions, position):
-        # Sorting by a constant is obviously a no-op and causes MSSQL to choke, so we
-        # exclude such clauses
-        sort_conditions = [node for node in sort_conditions if not is_constant(node)]
+        # MSSQL throws an error when attempting to sort by a constant expression. Here
+        # we exclude the simplest form of constant expression while not attempting to
+        # deal with more complex examples constructed using CASE expressions. This means
+        # there are valid query model constructions which we can't execute on MSSQL, but
+        # I think that's OK. None of them are meaningful queries, and handling explicit
+        # constants covers the one plausible use case where a user might want to "no-op
+        # out" a sort condition by replacing it with a constant without having to change
+        # the query structure.
+        sort_conditions = [
+            node for node in sort_conditions if not isinstance(node, Value)
+        ]
         return super().get_order_clauses(sort_conditions, position)
 
 

--- a/ehrql/query_model/nodes.py
+++ b/ehrql/query_model/nodes.py
@@ -41,7 +41,6 @@ __all__ = [
     "get_domain",
     "get_input_nodes",
     "get_root_frame",
-    "is_constant",
 ]
 
 
@@ -683,40 +682,6 @@ def is_sorted_sort(frame):
 @is_sorted.register(Filter)
 def is_sorted_filter(frame):
     return is_sorted(frame.source)
-
-
-# CONSTANTS
-#
-# It's expected that these functions will have some false negatives i.e. nodes that in
-# fact take a constant value although we can't (yet) determine that they do; but they
-# should not have false positives. The impetus for this code is handling some cases
-# where MSSQL refuses to accept a constant value, so we just to need to reliably
-# identify those cases.
-
-
-@singledispatch
-def is_constant(node):
-    return all(is_constant(subnode) for subnode in get_input_nodes(node))
-
-
-@is_constant.register(SelectColumn)
-@is_constant.register(SelectTable)
-@is_constant.register(SelectPatientTable)
-def is_constant_select(_):
-    return False
-
-
-@is_constant.register(Value)
-def is_constant_value(_):
-    return True
-
-
-@is_constant.register(Function.In)
-def is_constant_in(node):
-    # Membership of the empty set is always False
-    if isinstance(node.rhs, Value) and len(node.rhs.value) == 0:
-        return True
-    return is_constant(node.lhs) and is_constant(node.rhs)
 
 
 # TYPE VALIDATION

--- a/tests/generative/ignored_errors.py
+++ b/tests/generative/ignored_errors.py
@@ -20,6 +20,7 @@ class IgnoredError(enum.Enum):
     TOO_COMPLEX = enum.auto()
     ARITHMETIC_OVERFLOW = enum.auto()
     DATE_OVERFLOW = enum.auto()
+    UNSUPPORTED_SQL = enum.auto()
     CONNECTION_ERROR = enum.auto()
 
 
@@ -120,6 +121,17 @@ IGNORED_ERRORS = {
             # Invalid date errors
             sqlalchemy.exc.NotSupportedError,
             re.compile(r".+Could not convert '.+' into the associated python type"),
+        ),
+    ],
+    IgnoredError.UNSUPPORTED_SQL: [
+        # MSSQL can't handle constant expressions (not just literals, any expression
+        # which evaluates as a constant) in ORDER BY clauses. In theory we could
+        # identify these ourselves and exclude them as they're always no-ops, but this
+        # isn't worth the effort right now so we need to stop Hypothesis telling us
+        # about this.
+        (
+            sqlalchemy.exc.OperationalError,
+            re.compile(".*do not support constants as ORDER BY clause expressions"),
         ),
     ],
     IgnoredError.CONNECTION_ERROR: [

--- a/tests/spec/sort_and_pick/test_sort_by_with_constants.py
+++ b/tests/spec/sort_and_pick/test_sort_by_with_constants.py
@@ -1,5 +1,3 @@
-from ehrql import when
-
 from ..tables import e, p
 
 
@@ -29,9 +27,6 @@ def test_sort_by_patient_series(spec_test):
             p.i1,
             # Literal constant
             0,
-            # Compound expression which we can statically determine to evaluate to a
-            # constant
-            when(e.i1.is_in([])).then(1).otherwise(0),
         )
         .first_for_patient()
         .i1,

--- a/tests/unit/query_model/test_nodes.py
+++ b/tests/unit/query_model/test_nodes.py
@@ -28,7 +28,6 @@ from ehrql.query_model.nodes import (
     get_domain,
     get_series_type,
     has_one_row_per_patient,
-    is_constant,
 )
 
 
@@ -495,51 +494,3 @@ def test_can_pick_row_from_sorted_and_filtered_table():
     sorted_by_date = Sort(events, date)
     filtered_by_code = Filter(sorted_by_date, Function.EQ(code, Value("abc123")))
     assert PickOneRowPerPatient(filtered_by_code, Position.FIRST)
-
-
-# TEST IS_CONSTANT
-#
-
-
-@pytest.mark.parametrize(
-    "expected,node",
-    [
-        (
-            True,
-            Function.EQ(
-                Value("a"),
-                Value("b"),
-            ),
-        ),
-        (
-            False,
-            Function.EQ(
-                Value("a"),
-                SelectColumn(SelectTable("events", EVENTS_SCHEMA), "code"),
-            ),
-        ),
-        (
-            True,
-            Function.In(
-                Value("a"),
-                Value(frozenset({"a", "b"})),
-            ),
-        ),
-        (
-            False,
-            Function.In(
-                SelectColumn(SelectTable("events", EVENTS_SCHEMA), "code"),
-                Value(frozenset({"a", "b"})),
-            ),
-        ),
-        (
-            True,
-            Function.In(
-                SelectColumn(SelectTable("events", EVENTS_SCHEMA), "code"),
-                Value(frozenset()),
-            ),
-        ),
-    ],
-)
-def test_is_constant(expected, node):
-    assert is_constant(node) == expected


### PR DESCRIPTION
This is all extremely tedious. The changes added in #1871, which were designed to actually fix the issue which #1869 failed to fix, also failed to fix the issue.

A proper fix here is achievable but not worth the effort, and therefore we tell the gentests to ignore this issue and accept that there are valid query model constructions we can't execute on MSSQL.

In the worst case, a user tries to do something which is in fact a no-op although they don't realise it and then get a runtime error. This seems acceptable for now.