### PR TITLE
Add checks for column constraints in test data for `assure`

### DIFF
--- a/ehrql/assurance.py
+++ b/ehrql/assurance.py
@@ -4,50 +4,30 @@ from ehrql.query_model.introspection import get_table_nodes
 from ehrql.utils.orm_utils import orm_classes_from_tables, table_has_one_row_per_patient
 
 
+UNEXPECTED_TEST_VALUE = "unexpected-test-value"
 UNEXPECTED_IN_POPULATION = "unexpected-in-population"
 UNEXPECTED_NOT_IN_POPULATION = "unexpected-not-in-population"
-UNEXPECTED_VALUE = "unexpected-value"
+UNEXPECTED_OUTPUT_VALUE = "unexpected-output-value"
 
 
 def validate(variable_definitions, test_data):
-    """Given some input data, validates that the given variables produce the given
-    expected output.
+    """Validates that the given test data
+    (1) meet the constraints in the tables and
+    (2) produce the given expected output.
 
-    test_data contains two parts: data for each patient to be inserted into the
-    database, and the expected values in the dataset for each patient.
+    Returns two dictionaries mapping IDs of patients with details of
+    (1) test data that did not meet the constraints of the tables and
+    (2) unexpected data in the output dataset.
 
-    For instance:
-
-        test_data = {
-            1: {
-                "patients": {"date_of_birth": date(1999, 12, 31)},
-                "events": [],
-                "expected_in_population": False,
-            },
-            2: {
-                "patients": {"date_of_birth": date(2010, 1, 1)},
-                "events": [{"date": date(2020, 1, 1), "code": "11111111"}],
-                "expected_columns": {
-                    "has_matching_event": True,
-                },
-            },
-        }
-
-    This indicates that two rows should be inserted into the patients table (one for
-    each patient), and one row should be inserted into the events table (for patient 2).
-
-    This also indicates that patient 1 should not be in the dataset, and that patient 2
-    should be, with True in the "has_matching_event" column.
-
-    Returns a dict mapping IDs of patients with unexpected data in the dataset, to
-    details of the unexpected data.
-
-    See tests/unit/test_assurance.py for more examples.
+    For more see docs/how-to/test-dataset-definition.md
     """
 
     # Create objects to insert into database
     table_nodes = get_table_nodes(*variable_definitions.values())
     orm_classes = orm_classes_from_tables(table_nodes)
+    nodes_by_table_name = {node.name: node for node in table_nodes}
+
+    constraint_validation_errors = {}
     input_data = []
     for patient_id, patient in test_data.items():
         for orm_class in orm_classes.values():
@@ -55,6 +35,13 @@ def validate(variable_definitions, test_data):
                 records = [patient[orm_class.__tablename__]]
             else:
                 records = patient[orm_class.__tablename__]
+            table = nodes_by_table_name[orm_class.__tablename__]
+            constraints_error = validate_constraints(records, table)
+            if constraints_error:
+                constraint_validation_errors[patient_id] = {
+                    "type": UNEXPECTED_TEST_VALUE,
+                    "details": constraints_error,
+                }
             input_data.extend([orm_class(patient_id=patient_id, **r) for r in records])
 
     # Insert test objects into database
@@ -69,11 +56,33 @@ def validate(variable_definitions, test_data):
     }
 
     # Validate results of query
-    return {
+    test_validation_errors = {
         patient_id: validation_result
         for patient_id, patient in test_data.items()
         if (validation_result := validate_patient(patient_id, patient, query_results))
     }
+    return {
+        "constraint_validation_errors": constraint_validation_errors,
+        "test_validation_errors": test_validation_errors,
+    }
+
+
+def validate_constraints(records, table):
+    unexpected_test_values = []
+    for record in records:
+        for column, value in record.items():
+            constraints = table.schema.schema[column].constraints
+            for constraint in constraints:
+                is_valid = constraint.validate(value)
+                if not is_valid:
+                    unexpected_test_values.append(
+                        {
+                            "column": column,
+                            "constraint": f"{constraint}",
+                            "value": f"{value}",
+                        }
+                    )
+    return unexpected_test_values
 
 
 def validate_patient(patient_id, patient, results):
@@ -82,22 +91,46 @@ def validate_patient(patient_id, patient, results):
             return {"type": UNEXPECTED_NOT_IN_POPULATION}
         expected = patient["expected_columns"]
         actual = results[patient_id]
-        unexpected_values = [
+        unexpected_output_values = [
             {"column": k, "expected": expected[k], "actual": actual[k]}
             for k, v in expected.items()
             if expected[k] != actual[k]
         ]
-        if unexpected_values:
-            return {"type": UNEXPECTED_VALUE, "details": unexpected_values}
+        if unexpected_output_values:
+            return {
+                "type": UNEXPECTED_OUTPUT_VALUE,
+                "details": unexpected_output_values,
+            }
     else:
         if patient_id in results:
             return {"type": UNEXPECTED_IN_POPULATION}
 
 
 def present(validation_results):
-    if validation_results:
-        lines = [f"Found errors with {len(validation_results)} patient(s)"]
-        for patient_id, result in validation_results.items():
+    def present_constraints(constraint_validation_errors):
+        lines = []
+        lines.append(
+            f"Validate test data: Found errors with {len(constraint_validation_errors)} patient(s)"
+        )
+        for patient_id, result in constraint_validation_errors.items():
+            if result["type"] == UNEXPECTED_TEST_VALUE:
+                lines.append(
+                    f" * Patient {patient_id} had {len(result['details'])} test data value(s) that did not meet the constraint(s)"
+                )
+                for detail in result["details"]:
+                    lines.append(
+                        f"   * for column '{detail['column']}' with '{detail['constraint']}', got '{detail['value']}'"
+                    )
+            else:
+                assert False, result["type"]
+        return "\n".join(lines)
+
+    def present_results(test_validation_errors):
+        lines = []
+        lines.append(
+            f"Validate results: Found errors with {len(test_validation_errors)} patient(s)"
+        )
+        for patient_id, result in test_validation_errors.items():
             if result["type"] == UNEXPECTED_IN_POPULATION:
                 lines.append(
                     f" * Patient {patient_id} was unexpectedly in the population"
@@ -106,15 +139,25 @@ def present(validation_results):
                 lines.append(
                     f" * Patient {patient_id} was unexpectedly not in the population"
                 )
-            elif result["type"] == UNEXPECTED_VALUE:
-                lines.append(f" * Patient {patient_id} had unexpected value(s)")
+            elif result["type"] == UNEXPECTED_OUTPUT_VALUE:
+                lines.append(f" * Patient {patient_id} had unexpected output value(s)")
                 for detail in result["details"]:
                     lines.append(
-                        f"   * for column {detail['column']}, expected {detail['expected']}, got {detail['actual']}"
+                        f"   * for column '{detail['column']}', expected '{detail['expected']}', got '{detail['actual']}'"
                     )
             else:
                 assert False, result["type"]
-
         return "\n".join(lines)
+
+    if validation_results["constraint_validation_errors"]:
+        lines_constraints = present_constraints(
+            validation_results["constraint_validation_errors"]
+        )
     else:
-        return "All OK!"
+        lines_constraints = "Validate test data: All OK!"
+    if validation_results["test_validation_errors"]:
+        lines_results = present_results(validation_results["test_validation_errors"])
+    else:
+        lines_results = "Validate results: All OK!"
+
+    return lines_constraints + "\n" + lines_results

--- a/tests/fixtures/good_definition_files/assurance.py
+++ b/tests/fixtures/good_definition_files/assurance.py
@@ -11,7 +11,7 @@ dataset.define_population(patients.date_of_birth.is_on_or_after("2000-01-01"))
 test_data = {
     # Correctly not expected in population
     1: {
-        "patients": {"date_of_birth": date(1999, 12, 31)},
+        "patients": {"date_of_birth": date(1999, 12, 1)},
         "expected_in_population": False,
     },
 }

--- a/tests/unit/query_model/test_constraints.py
+++ b/tests/unit/query_model/test_constraints.py
@@ -1,0 +1,45 @@
+from datetime import date
+
+from ehrql.tables import Constraint
+
+
+def test_categorical_validation():
+    c = Constraint.Categorical((1, "a"))
+    assert c.validate("a")
+    assert c.validate(None)
+    assert not c.validate("")
+    assert not c.validate("b")
+
+
+def test_not_null_validation():
+    c = Constraint.NotNull()
+    assert c.validate(1)
+    assert not c.validate(None)
+
+
+def test_unique_validation():
+    c = Constraint.Unique()
+    assert c.validate(1)
+
+
+def test_first_of_month_validation():
+    c = Constraint.FirstOfMonth()
+    assert c.validate(date(2024, 1, 1))
+    assert c.validate(None)
+    assert not c.validate(date(2024, 1, 2))
+
+
+def test_regex_validation():
+    c = Constraint.Regex("E020[0-9]{5}")
+    assert c.validate("E02012345")
+    assert c.validate(None)
+    assert not c.validate("")
+    assert not c.validate("E020")
+
+
+def test_closed_range_validation():
+    c = Constraint.ClosedRange(1, 3)
+    assert c.validate(2)
+    assert c.validate(None)
+    assert not c.validate(0)
+    assert not c.validate(4)

--- a/tests/unit/test_assurance.py
+++ b/tests/unit/test_assurance.py
@@ -4,18 +4,29 @@ from ehrql import Dataset
 from ehrql.assurance import (
     UNEXPECTED_IN_POPULATION,
     UNEXPECTED_NOT_IN_POPULATION,
-    UNEXPECTED_VALUE,
+    UNEXPECTED_OUTPUT_VALUE,
+    UNEXPECTED_TEST_VALUE,
     present,
     validate,
 )
 from ehrql.codes import SNOMEDCTCode
 from ehrql.query_language import compile
-from ehrql.tables import EventFrame, PatientFrame, Series, table
+from ehrql.tables import Constraint, EventFrame, PatientFrame, Series, table
 
 
 @table
 class patients(PatientFrame):
-    date_of_birth = Series(date)
+    date_of_birth = Series(
+        date,
+        constraints=[Constraint.FirstOfMonth(), Constraint.NotNull()],
+    )
+    sex = Series(
+        str,
+        constraints=[
+            Constraint.Categorical(["female", "male", "intersex", "unknown"]),
+            Constraint.NotNull(),
+        ],
+    )
 
 
 @table
@@ -30,10 +41,10 @@ dataset.has_matching_event = events.where(
     events.code == SNOMEDCTCode("11111111")
 ).exists_for_patient()
 
-test_data = {
+valid_test_data = {
     # Correctly not expected in population
     1: {
-        "patients": {"date_of_birth": date(1999, 12, 31)},
+        "patients": {"date_of_birth": date(1999, 12, 1)},
         "events": [],
         "expected_in_population": False,
     },
@@ -45,7 +56,7 @@ test_data = {
     },
     # Incorrectly expected in population
     3: {
-        "patients": {"date_of_birth": date(1999, 12, 31)},
+        "patients": {"date_of_birth": date(1999, 12, 1)},
         "events": [{"date": date(2020, 1, 1), "code": "11111111"}],
         "expected_columns": {
             "has_matching_event": True,
@@ -69,38 +80,176 @@ test_data = {
     },
 }
 
-expected_validation_results = {
-    2: {"type": UNEXPECTED_IN_POPULATION},
-    3: {"type": UNEXPECTED_NOT_IN_POPULATION},
-    5: {
-        "type": UNEXPECTED_VALUE,
-        "details": [
-            {
-                "column": "has_matching_event",
-                "expected": True,
-                "actual": False,
-            }
-        ],
+invalid_test_data = {
+    # Has date_of_birth value that does not meet NotNull constraint
+    1: {
+        "patients": {"date_of_birth": None, "sex": "not-known"},
+        "events": [],
+        "expected_in_population": False,
+    },
+    # Has date_of_birth value that does not meet FirstOfMonth constraint
+    2: {
+        "patients": {"date_of_birth": date(1990, 1, 2)},
+        "events": [],
+        "expected_in_population": False,
+    },
+}
+
+valid_and_invalid_test_data = {
+    # Incorrectly not expected in population
+    1: {
+        "patients": {"date_of_birth": date(2000, 1, 1)},
+        "events": [],
+        "expected_in_population": False,
+    },
+    # Has date_of_birth value that does not meet FirstOfMonth constraint
+    2: {
+        "patients": {"date_of_birth": date(1990, 1, 2)},
+        "events": [],
+        "expected_in_population": False,
+    },
+}
+
+expected_valid_data_validation_results = {
+    "constraint_validation_errors": {},
+    "test_validation_errors": {
+        2: {"type": UNEXPECTED_IN_POPULATION},
+        3: {"type": UNEXPECTED_NOT_IN_POPULATION},
+        5: {
+            "type": UNEXPECTED_OUTPUT_VALUE,
+            "details": [
+                {
+                    "column": "has_matching_event",
+                    "expected": True,
+                    "actual": False,
+                }
+            ],
+        },
     },
 }
 
 
-def test_validate():
-    assert validate(compile(dataset), test_data) == expected_validation_results
+expected_invalid_data_validation_results = {
+    "constraint_validation_errors": {
+        1: {
+            "type": UNEXPECTED_TEST_VALUE,
+            "details": [
+                {
+                    "column": "date_of_birth",
+                    "constraint": "Constraint.NotNull()",
+                    "value": "None",
+                },
+                {
+                    "column": "sex",
+                    "constraint": "Constraint.Categorical(values=('female', 'male', 'intersex', 'unknown'))",
+                    "value": "not-known",
+                },
+            ],
+        },
+        2: {
+            "type": UNEXPECTED_TEST_VALUE,
+            "details": [
+                {
+                    "column": "date_of_birth",
+                    "constraint": "Constraint.FirstOfMonth()",
+                    "value": "1990-01-02",
+                }
+            ],
+        },
+    },
+    "test_validation_errors": {},
+}
+
+expected_valid_and_invalid_data_validation_results = {
+    "constraint_validation_errors": {
+        2: {
+            "type": UNEXPECTED_TEST_VALUE,
+            "details": [
+                {
+                    "column": "date_of_birth",
+                    "constraint": "Constraint.FirstOfMonth()",
+                    "value": "1990-01-02",
+                }
+            ],
+        },
+    },
+    "test_validation_errors": {
+        1: {"type": UNEXPECTED_IN_POPULATION},
+    },
+}
 
 
-def test_present_with_errors():
+def test_valid_data_validate():
     assert (
-        present(expected_validation_results).strip()
+        validate(compile(dataset), valid_test_data)
+        == expected_valid_data_validation_results
+    )
+
+
+def test_valid_data_present_with_errors():
+    assert (
+        present(expected_valid_data_validation_results).strip()
         == """
-Found errors with 3 patient(s)
+Validate test data: All OK!
+Validate results: Found errors with 3 patient(s)
  * Patient 2 was unexpectedly in the population
  * Patient 3 was unexpectedly not in the population
- * Patient 5 had unexpected value(s)
-   * for column has_matching_event, expected True, got False
+ * Patient 5 had unexpected output value(s)
+   * for column 'has_matching_event', expected 'True', got 'False'
+    """.strip()
+    )
+
+
+def test_invalid_data_validate():
+    assert (
+        validate(compile(dataset), invalid_test_data)
+        == expected_invalid_data_validation_results
+    )
+
+
+def test_invalid_data_present_with_errors():
+    assert (
+        present(expected_invalid_data_validation_results).strip()
+        == """
+Validate test data: Found errors with 2 patient(s)
+ * Patient 1 had 2 test data value(s) that did not meet the constraint(s)
+   * for column 'date_of_birth' with 'Constraint.NotNull()', got 'None'
+   * for column 'sex' with 'Constraint.Categorical(values=('female', 'male', 'intersex', 'unknown'))', got 'not-known'
+ * Patient 2 had 1 test data value(s) that did not meet the constraint(s)
+   * for column 'date_of_birth' with 'Constraint.FirstOfMonth()', got '1990-01-02'
+Validate results: All OK!
+    """.strip()
+    )
+
+
+def test_valid_and_invalid_data_validate():
+    assert (
+        validate(compile(dataset), valid_and_invalid_test_data)
+        == expected_valid_and_invalid_data_validation_results
+    )
+
+
+def test_valid_and_invalid_data_present_with_errors():
+    assert (
+        present(expected_valid_and_invalid_data_validation_results).strip()
+        == """
+Validate test data: Found errors with 1 patient(s)
+ * Patient 2 had 1 test data value(s) that did not meet the constraint(s)
+   * for column 'date_of_birth' with 'Constraint.FirstOfMonth()', got '1990-01-02'
+Validate results: Found errors with 1 patient(s)
+ * Patient 1 was unexpectedly in the population
     """.strip()
     )
 
 
 def test_present_with_no_errors():
-    assert present({}) == "All OK!"
+    validation_results_with_no_errors = {
+        "constraint_validation_errors": {},
+        "test_validation_errors": {},
+    }
+    assert (
+        present(validation_results_with_no_errors).strip()
+        == """
+Validate test data: All OK!
+Validate results: All OK!""".strip()
+    )


### PR DESCRIPTION
This builds on the existing structure that tests the output of ehrQL queries and now also checks if the provided test data meets the constraints. We return details about test data that does not meet the constraints along with the results of testing the ehrQL query instead of returning an error. This makes it possible for users to specify test data that does not meet the constraints. 

Closes #1858 