### PR TITLE
Improve error messages

### DIFF
--- a/ehrql/__init__.py
+++ b/ehrql/__init__.py
@@ -4,6 +4,7 @@ from ehrql.codes import codelist_from_csv
 from ehrql.measures import INTERVAL, Measures, create_measures
 from ehrql.query_language import (
     Dataset,
+    Error,
     case,
     create_dataset,
     days,
@@ -25,6 +26,7 @@ __all__ = [
     "INTERVAL",
     "Measures",
     "Dataset",
+    "Error",
     "case",
     "create_dataset",
     "create_measures",

--- a/ehrql/docs/language.py
+++ b/ehrql/docs/language.py
@@ -128,8 +128,6 @@ def is_included_class(cls):
         return False
     if cls.__name__.startswith("_"):
         return False
-    if issubclass(cls, Exception):
-        return False
     if cls in EXCLUDE_FROM_DOCS:
         return False
     return True

--- a/ehrql/docs/language.py
+++ b/ehrql/docs/language.py
@@ -17,6 +17,7 @@ EXCLUDE_FROM_DOCS = {
     ql.WhenThen,
     ql.when,
     ql.DummyDataConfig,
+    ql.Error,
 }
 
 

--- a/ehrql/query_language.py
+++ b/ehrql/query_language.py
@@ -1079,9 +1079,26 @@ def _convert(arg):
     # If it's an ehrQL series then get the wrapped query model node
     elif isinstance(arg, BaseSeries):
         return arg._qm_node
-    # Otherwise it's a static value and needs to be put in a query model Value wrapper
-    else:
+    # If it's a static value then we need to be put in a query model Value wrapper
+    elif isinstance(
+        arg, bool | int | float | datetime.date | str | BaseCode | frozenset
+    ):
         return qm.Value(arg)
+    #
+    # Handle various kinds of user error
+    #
+    elif isinstance(arg, BaseFrame):
+        raise TypeError(
+            f"Expecting a series but got a frame (`{arg.__class__.__name__}`): "
+            f"are you missing a column name?"
+        )
+    elif callable(arg):
+        raise TypeError(
+            f"Function referenced but not called: are you missing parentheses on "
+            f"`{arg.__name__}()`?"
+        )
+    else:
+        raise TypeError(f"Not a valid ehrQL type: {arg!r}")
 
 
 def Parameter(name, type_):

--- a/ehrql/query_language.py
+++ b/ehrql/query_language.py
@@ -30,11 +30,16 @@ VALID_VARIABLE_NAME_RE = re.compile(r"^[A-Za-z]+[A-Za-z0-9_]*$")
 REGISTERED_TYPES = {}
 
 
-class InvalidOperationError(Exception):
+class Error(Exception):
     """
     Used to translate errors from the query model into something more
     ehrQL-appropriate
     """
+
+    # Pretend this exception is defined in the top-level `ehrql` module: this allows us
+    # to avoid leaking the internal `query_language` module into the error messages
+    # without creating circular import problems.
+    __module__ = "ehrql"
 
 
 @dataclasses.dataclass
@@ -1038,7 +1043,7 @@ def _build(qm_cls, *args, **kwargs):
     try:
         return qm_cls(*args, **kwargs)
     except qm.DomainMismatchError:
-        raise InvalidOperationError(
+        raise Error(
             "\n"
             "Cannot combine series which are drawn from different tables and both\n"
             "have more than one value per patient.\n"

--- a/ehrql/query_language.py
+++ b/ehrql/query_language.py
@@ -567,10 +567,14 @@ class FloatEventSeries(FloatFunctions, NumericAggregations, EventSeries):
 
 def parse_date_if_str(value):
     if isinstance(value, str):
+        # By default, `fromisoformat()` accepts the alternative YYYYMMDD format. We only
+        # want to allow the hyphenated version so we pre-validate it.
+        if not re.match(r"^\d{4}-\d{2}-\d{2}$", value):
+            raise ValueError(f"Dates must be in YYYY-MM-DD format: {value!r}")
         try:
             return datetime.date.fromisoformat(value)
         except ValueError as e:
-            raise ValueError(f"{e} in {value!r}")
+            raise ValueError(f"{e} in {value!r}") from None
     else:
         return value
 

--- a/ehrql/query_language.py
+++ b/ehrql/query_language.py
@@ -141,13 +141,14 @@ class Dataset:
                 f"alphanumeric characters and underscores (you defined a "
                 f"variable '{name}')"
             )
+        _raise_helpful_error_if_possible(value)
         if not isinstance(value, BaseSeries):
             raise TypeError(
-                f"Invalid variable '{name}'. Dataset variables must be values not whole rows"
+                f"Expecting an ehrQL series, got type '{type(value).__qualname__}'"
             )
-        if not qm.has_one_row_per_patient(value._qm_node):
+        if not isinstance(value, PatientSeries):
             raise TypeError(
-                f"Invalid variable '{name}'. Dataset variables must return one row per patient"
+                "Expecting a series with only one value per patient",
             )
         self.variables[name] = value
 

--- a/ehrql/query_language.py
+++ b/ehrql/query_language.py
@@ -93,7 +93,10 @@ class Dataset:
                 f"Expecting a boolean series but got series of type "
                 f"'{population_condition._type.__qualname__}'"
             )
-        validate_population_definition(population_condition._qm_node)
+        try:
+            validate_population_definition(population_condition._qm_node)
+        except qm.ValidationError as exc:
+            raise Error(str(exc)) from None
         self.variables["population"] = population_condition
 
     def add_column(self, column_name: str, ehrql_query):

--- a/ehrql/query_language.py
+++ b/ehrql/query_language.py
@@ -1261,10 +1261,6 @@ def get_all_series_from_class(cls):
 #
 
 
-class SchemaError(Exception):
-    ...
-
-
 # A class decorator which replaces the class definition with an appropriately configured
 # instance of the class. Obviously this is a _bit_ odd, but I think worth it overall.
 # Using classes to define tables is (as far as I can tell) the only way to get nice
@@ -1279,9 +1275,7 @@ def table(cls):
             (EventFrame,): qm.SelectTable,
         }[cls.__bases__]
     except KeyError:
-        raise SchemaError(
-            "Schema class must subclass either `PatientFrame` or `EventFrame`"
-        )
+        raise Error("Schema class must subclass either `PatientFrame` or `EventFrame`")
 
     qm_node = qm_class(
         name=cls.__name__,
@@ -1307,7 +1301,7 @@ def get_table_schema_from_class(cls):
 def table_from_rows(rows):
     def decorator(cls):
         if cls.__bases__ != (PatientFrame,):
-            raise SchemaError("`@table_from_rows` can only be used with `PatientFrame`")
+            raise Error("`@table_from_rows` can only be used with `PatientFrame`")
         qm_node = qm.InlinePatientTable(
             rows=tuple(rows),
             schema=get_table_schema_from_class(cls),
@@ -1327,7 +1321,7 @@ def table_from_file(path):
 
     def decorator(cls):
         if cls.__bases__ != (PatientFrame,):
-            raise SchemaError("`@table_from_file` can only be used with `PatientFrame`")
+            raise Error("`@table_from_file` can only be used with `PatientFrame`")
 
         schema = get_table_schema_from_class(cls)
         column_specs = get_column_specs_from_schema(schema)

--- a/ehrql/query_language.py
+++ b/ehrql/query_language.py
@@ -1053,6 +1053,22 @@ def _build(qm_cls, *args, **kwargs):
             "row for each patient from the table using `first_for_patient()`."
             # Use `from None` to hide the chained exception
         ) from None
+    except qm.TypeValidationError as exc:
+        # We deliberately omit information about the query model operation and field
+        # name here because these often don't match what's used in ehrQL and are liable
+        # to cause confusion
+        raise TypeError(
+            f"Expected type '{_format_typespec(exc.expected)}' "
+            f"but got '{_format_typespec(exc.received)}'"
+            # Use `from None` to hide the chained exception
+        ) from None
+
+
+def _format_typespec(typespec):
+    # At present we don't do anything beyond formatting as a string and then removing
+    # the module name prefix from "Series". It might be nice to remove mention of
+    # "Series" entirely here, but that's a task for another day.
+    return str(typespec).replace(f"{qm.__name__}.{qm.Series.__qualname__}", "Series")
 
 
 def _apply(qm_cls, *args):

--- a/tests/unit/query_model/test_nodes.py
+++ b/tests/unit/query_model/test_nodes.py
@@ -483,7 +483,13 @@ def test_value_nodes_reject_unhandled_container_types():
 
 def test_cannot_pick_row_from_unsorted_table():
     events = SelectTable("events", EVENTS_SCHEMA)
-    with pytest.raises(TypeValidationError):
+    with pytest.raises(
+        TypeValidationError,
+        match=(
+            "PickOneRowPerPatient.source requires 'SortedFrame' "
+            "but received 'UnsortedFrame'"
+        ),
+    ):
         PickOneRowPerPatient(events, Position.FIRST)
 
 

--- a/tests/unit/test_query_language.py
+++ b/tests/unit/test_query_language.py
@@ -17,12 +17,12 @@ from ehrql.query_language import (
     DateEventSeries,
     DateFunctions,
     DatePatientSeries,
+    Error,
     EventFrame,
     FloatEventSeries,
     FloatPatientSeries,
     IntEventSeries,
     IntPatientSeries,
-    InvalidOperationError,
     Parameter,
     PatientFrame,
     SchemaError,
@@ -795,7 +795,7 @@ def test_domain_mismatch_errors_are_wrapped():
         f = Series(float)
 
     with pytest.raises(
-        InvalidOperationError,
+        Error,
         match="Cannot combine series which are drawn from different tables",
     ) as exc:
         events.f + other_events.f

--- a/tests/unit/test_query_language.py
+++ b/tests/unit/test_query_language.py
@@ -25,7 +25,6 @@ from ehrql.query_language import (
     IntPatientSeries,
     Parameter,
     PatientFrame,
-    SchemaError,
     Series,
     StrEventSeries,
     StrPatientSeries,
@@ -327,7 +326,7 @@ def test_construct_constructs_event_frame():
 
 
 def test_construct_enforces_correct_base_class():
-    with pytest.raises(SchemaError, match="Schema class must subclass"):
+    with pytest.raises(Error, match="Schema class must subclass"):
 
         @table
         class some_table(Dataset):
@@ -335,7 +334,7 @@ def test_construct_enforces_correct_base_class():
 
 
 def test_construct_enforces_exactly_one_base_class():
-    with pytest.raises(SchemaError, match="Schema class must subclass"):
+    with pytest.raises(Error, match="Schema class must subclass"):
 
         @table
         class some_table(PatientFrame, Dataset):
@@ -353,7 +352,7 @@ def test_table_from_rows():
 
 def test_table_from_rows_only_accepts_patient_frame():
     with pytest.raises(
-        SchemaError, match="`@table_from_rows` can only be used with `PatientFrame`"
+        Error, match="`@table_from_rows` can only be used with `PatientFrame`"
     ):
 
         @table_from_rows([])
@@ -395,7 +394,7 @@ def test_table_from_file(file_extension, tmp_path):
 
 def test_table_from_file_only_accepts_patient_frame():
     with pytest.raises(
-        SchemaError,
+        Error,
         match="`@table_from_file` can only be used with `PatientFrame`",
     ):
 

--- a/tests/unit/test_query_language.py
+++ b/tests/unit/test_query_language.py
@@ -825,3 +825,12 @@ def test_domain_mismatch_errors_are_wrapped():
 def test_type_errors(value, error):
     with pytest.raises(TypeError, match=re.escape(error)):
         when(patients.exists_for_patient()).then(value).otherwise(None)
+
+
+def test_query_model_type_errors():
+    with pytest.raises(
+        TypeError,
+        match=re.escape("Expected type 'Series[int] | None' but got 'Series[str]'"),
+    ) as exc:
+        patients.i.when_null_then("empty")
+    assert_not_chained_exception(exc)

--- a/tests/unit/test_query_language.py
+++ b/tests/unit/test_query_language.py
@@ -74,6 +74,17 @@ class events(EventFrame):
 events_schema = TableSchema(event_date=Column(date), f=Column(float))
 
 
+def assert_not_chained_exception(excinfo):
+    # Including chained exception details in the traceback is the default Python
+    # behaviour but we often want to hide internal details from the user where these are
+    # not helpful
+    traceback_str = "\n".join(traceback.format_exception(excinfo.value))
+    assert (
+        "During handling of the above exception, another exception occurred"
+        not in traceback_str
+    )
+
+
 def test_create_dataset():
     assert isinstance(create_dataset(), Dataset)
 
@@ -784,6 +795,4 @@ def test_domain_mismatch_errors_are_wrapped():
         match="Cannot combine series which are drawn from different tables",
     ) as exc:
         events.f + other_events.f
-    # Check original error is excluded from traceback
-    traceback_str = "\n".join(traceback.format_exception(exc.value))
-    assert "DomainMismatchError" not in traceback_str
+    assert_not_chained_exception(exc)

--- a/tests/unit/test_query_language.py
+++ b/tests/unit/test_query_language.py
@@ -683,13 +683,17 @@ def test_parse_date_if_str(value, expected):
 @pytest.mark.parametrize(
     "value,error",
     [
-        ("1st March 2020", "Invalid isoformat string: '1st March 2020'"),
+        ("1st March 2020", "Dates must be in YYYY-MM-DD format: '1st March 2020'"),
+        ("20201231", "Dates must be in YYYY-MM-DD format: '20201231'"),
         ("2021-02-29", "day is out of range for month in '2021-02-29'"),
+        ("2020-01-01  ", "Dates must be in YYYY-MM-DD format: '2020-01-01  '"),
+        ("2021-14-01", "month must be in 1..12 in '2021-14-01'"),
     ],
 )
 def test_parse_date_if_str_errors(value, error):
-    with pytest.raises(ValueError, match=error):
+    with pytest.raises(ValueError, match=error) as exc:
         parse_date_if_str(value)
+    assert_not_chained_exception(exc)
 
 
 def test_parameter():

--- a/tests/unit/test_query_language.py
+++ b/tests/unit/test_query_language.py
@@ -204,6 +204,15 @@ def test_define_population_rejects_invalid_arguments(population, error):
         Dataset().define_population(population)
 
 
+def test_define_population_rejects_invalid_population():
+    with pytest.raises(
+        Error,
+        match="population definition must not evaluate as True for NULL inputs",
+    ) as exc:
+        Dataset().define_population(~events.exists_for_patient())
+    assert_not_chained_exception(exc)
+
+
 def test_cannot_reassign_dataset_variable():
     dataset = Dataset()
     dataset.foo = patients.date_of_birth.year

--- a/tests/unit/test_query_language.py
+++ b/tests/unit/test_query_language.py
@@ -172,6 +172,38 @@ def test_cannot_define_population_more_than_once():
         dataset.define_population(patients.exists_for_patient())
 
 
+@pytest.mark.parametrize(
+    "population,error",
+    [
+        (
+            False,
+            "Expecting an ehrQL series, got type 'bool'",
+        ),
+        (
+            patients,
+            "Expecting a series but got a frame (`patients`): "
+            "are you missing a column name?",
+        ),
+        (
+            patients.exists_for_patient,
+            "Function referenced but not called: "
+            "are you missing parentheses on `exists_for_patient()`?",
+        ),
+        (
+            events.event_date.is_not_null(),
+            "Expecting a series with only one value per patient",
+        ),
+        (
+            patients.date_of_birth,
+            "Expecting a boolean series but got series of type 'date'",
+        ),
+    ],
+)
+def test_define_population_rejects_invalid_arguments(population, error):
+    with pytest.raises(TypeError, match=re.escape(error)):
+        Dataset().define_population(population)
+
+
 def test_cannot_reassign_dataset_variable():
     dataset = Dataset()
     dataset.foo = patients.date_of_birth.year


### PR DESCRIPTION
This is a follow on from #1873 and attempts to address many of the issues noted in #505.

As part of this work I discovered that there's an alternative ISO date format (`YYYYMMDD` without hyphens) and so I've updated the parser to only accept the hyphenated version to avoid any possibility of confusion.

