### PR TITLE
Make `update-pledge` command depend on `devenv`

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -288,12 +288,12 @@ docs-check-generated-docs-are-current: generate-docs
       exit 1
     fi
 
-update-pledge:
+update-pledge: devenv
     #!/usr/bin/env bash
     set -euo pipefail
     URL_RECORD_FILE="bin/cosmopolitan-release-url.txt"
     ZIP_URL="$(
-      python -c \
+      $BIN/python -c \
         'import requests; print([
             i["browser_download_url"]
             for i in requests.get("https://api.github.com/repos/jart/cosmopolitan/releases/latest").json()["assets"]


### PR DESCRIPTION
Otherwise it fails when run as a scheduled workflow because `requests` isn't installed. Installing the full dev environment is obviously a bit heavyweight given that all we need is `requests` but it keeps things simple and consistent.