### PR TITLE
Add `test-data-file` parameter to `generate-dataset`

### DIFF
--- a/docs/how-to/test-dataset-definition.md
+++ b/docs/how-to/test-dataset-definition.md
@@ -172,12 +172,35 @@ test_data = {
 
 ## Running the tests
 
-Finally, you can run your assurance tests through the terminal using the command below to verify if your expectations were successful or failed.
-The results of your tests will be displayed in your terminal.
+Finally you can run your assurance tests to verify if your expectations were successful or failed.
+
+### Option 1: Running tests through the terminal
+
+To run your tests through the terminal, use the following command:
 
 ```
 opensafely exec ehrql:v1 assure analysis/test_dataset_definition.py
 ```
+
+### Option 2: Integrating tests into your `generate-dataset` action
+
+You can also run your tests every time you execute a `generate-dataset` action by providing your test file using the `--test-data-file` flag in the `project.yaml` file:
+
+```
+actions:
+  generate_dataset:
+    run: >
+        ehrql:v1 generate-dataset
+        analysis/dataset_definition.py
+        --test-data-file analysis/test_dataset_definition.py
+        --output outputs/dataset.arrow
+    outputs:
+      highly_sensitive:
+        population: outputs/dataset.arrow
+
+```
+
+## Interpreting the results
 
 ### Successful expectations
 
@@ -192,7 +215,7 @@ Validate results: All OK!
 
 #### Failed constraint validations
 
-If the test data you provided does not meet constraints you will see a message with more information.
+If the test data you provided does not meet the constraints you will see a message with more information.
 We recommend that you fix the errors so that the test data meets the constraints and is identical to the production data.
 However, if you are sure that you want to test your ehrQL query with values that do not to the constraints, you can ignore the '*Validate test data*' section of the message.
 

--- a/docs/includes/generated_docs/cli.md
+++ b/docs/includes/generated_docs/cli.md
@@ -57,7 +57,7 @@ Generate dummy tables and write them out as CSV files (one per table).
   <a href="#assure"><tt>assure</tt></a>
 </div>
 <p class="indent">
-Experimental command for running assurance tests.
+Command for running assurance tests.
 </p>
 
 <div class="attr-heading">
@@ -114,8 +114,9 @@ Show the exact version of ehrQL in use and then exit.
 </h2>
 ```
 ehrql generate-dataset DEFINITION_FILE [--help] [--output DATASET_FILE]
-      [--dummy-data-file DUMMY_DATA_FILE] [--dummy-tables DUMMY_TABLES_PATH]
-      [--dsn DSN] [--query-engine QUERY_ENGINE_CLASS] [--backend BACKEND_CLASS]
+      [--test-data-file TEST_DATA_FILE] [--dummy-data-file DUMMY_DATA_FILE]
+      [--dummy-tables DUMMY_TABLES_PATH] [--dsn DSN]
+      [--query-engine QUERY_ENGINE_CLASS] [--backend BACKEND_CLASS]
       [ -- ... PARAMETERS ...]
 ```
 Take a dataset definition file and output a dataset.
@@ -151,6 +152,15 @@ Path of the file where the dataset will be written (console by default).
 
 The file extension determines the file format used. Supported formats are:
 `.arrow`, `.csv`, `.csv.gz`
+
+</div>
+
+<div class="attr-heading" id="generate-dataset.test-data-file">
+  <tt>--test-data-file TEST_DATA_FILE</tt>
+  <a class="headerlink" href="#generate-dataset.test-data-file" title="Permanent link">🔗</a>
+</div>
+<div markdown="block" class="indent">
+Takes a test dataset definition file.
 
 </div>
 
@@ -542,10 +552,7 @@ double-dash ` -- `.
 ```
 ehrql assure TEST_DATA_FILE [--help] [ -- ... PARAMETERS ...]
 ```
-Experimental command for running assurance tests.
-
-Note that **this command is experimental** and not yet intended for widespread
-use.
+Command for running assurance tests.
 
 <div class="attr-heading" id="assure.test_data_file">
   <tt>TEST_DATA_FILE</tt>

--- a/ehrql/__main__.py
+++ b/ehrql/__main__.py
@@ -303,10 +303,7 @@ def add_assure(subparsers, environ, user_args):
         "assure",
         help=strip_indent(
             """
-            Experimental command for running assurance tests.
-
-            Note that **this command is experimental** and not yet intended for widespread
-            use.
+            Command for running assurance tests.
             """
         ),
         formatter_class=RawTextHelpFormatter,

--- a/ehrql/__main__.py
+++ b/ehrql/__main__.py
@@ -168,6 +168,15 @@ def add_generate_dataset(subparsers, environ, user_args):
         type=valid_output_path,
         dest="dataset_file",
     )
+    parser.add_argument(
+        "--test-data-file",
+        help=strip_indent(
+            """
+            Takes a test dataset definition file.
+            """
+        ),
+        type=existing_file,
+    )
     add_dummy_data_file_argument(parser, environ)
     add_dummy_tables_argument(parser, environ)
     add_dataset_definition_file_argument(parser, environ)

--- a/ehrql/main.py
+++ b/ehrql/main.py
@@ -48,6 +48,7 @@ def generate_dataset(
     query_engine_class,
     dummy_tables_path,
     dummy_data_file,
+    test_data_file,
     environ,
     user_args,
 ):
@@ -55,6 +56,10 @@ def generate_dataset(
     variable_definitions, dummy_data_config = load_dataset_definition(
         definition_file, user_args, environ
     )
+
+    if test_data_file:
+        log.info(f"Testing dataset definition with tests in {str(definition_file)}")
+        assure(test_data_file, environ=environ, user_args=user_args)
 
     if dsn:
         generate_dataset_with_dsn(

--- a/tests/docs/test_complete_examples.py
+++ b/tests/docs/test_complete_examples.py
@@ -301,11 +301,11 @@ def test_ehrql_example(tmp_path, example):
 
     match example.definition_type:
         case EhrqlExampleDefinitionType.DATASET:
-            definition_fn = ehrql.main.generate_dataset
+            generate_fn = ehrql.main.generate_dataset
             wrapped_fn = wrapped_load_dataset_definition
             ehrql_fn_name_to_patch = "ehrql.main.load_dataset_definition"
         case EhrqlExampleDefinitionType.MEASURE:
-            definition_fn = ehrql.main.generate_measures
+            generate_fn = ehrql.main.generate_measures
             wrapped_fn = wrapped_load_measure_definitions
             ehrql_fn_name_to_patch = "ehrql.main.load_measure_definitions"
         case _:
@@ -336,16 +336,16 @@ def test_ehrql_example(tmp_path, example):
         args = [tmp_example_path, tmp_output_path]
         kwargs = {
             name: None
-            for name, param in inspect.signature(definition_fn).parameters.items()
+            for name, param in inspect.signature(generate_fn).parameters.items()
             if param.kind == param.KEYWORD_ONLY
         }
         kwargs.update({"environ": {}, "user_args": ()})
         try:
-            definition_fn(*args, **kwargs)
+            generate_fn(*args, **kwargs)
         except Exception as e:
-            definition_fn_name = definition_fn.__name__.rpartition(".")[-1]
+            generate_fn_name = generate_fn.__name__.rpartition(".")[-1]
             raise EhrqlExampleTestError(
-                f"{definition_fn_name} failed for example: {formatted_example}"
+                f"{generate_fn_name} failed for example: {formatted_example}"
             ) from e
 
     try:

--- a/tests/docs/test_complete_examples.py
+++ b/tests/docs/test_complete_examples.py
@@ -333,20 +333,15 @@ def test_ehrql_example(tmp_path, example):
             return_value=None,
         ),
     ):
+        args = [tmp_example_path, tmp_output_path]
+        kwargs = {
+            name: None
+            for name, param in inspect.signature(definition_fn).parameters.items()
+            if param.kind == param.KEYWORD_ONLY
+        }
+        kwargs.update({"environ": {}, "user_args": ()})
         try:
-            # No name needed to store a value:
-            # the output CSV gets written to a temporary file.
-            definition_fn(
-                tmp_example_path,
-                tmp_output_path,
-                dsn=None,
-                backend_class=None,
-                query_engine_class=None,
-                dummy_tables_path=None,
-                dummy_data_file=None,
-                environ={},
-                user_args=(),
-            )
+            definition_fn(*args, **kwargs)
         except Exception as e:
             definition_fn_name = definition_fn.__name__.rpartition(".")[-1]
             raise EhrqlExampleTestError(

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -50,6 +50,7 @@ def test_generate_dataset_dsn_arg(mock_load_and_compile):
             query_engine_class=None,
             dummy_tables_path=None,
             dummy_data_file=None,
+            test_data_file=None,
             environ={},
             user_args=(),
         )
@@ -68,6 +69,7 @@ def test_generate_dataset_dummy_data_file_arg(mock_load_and_compile):
             backend_class=None,
             query_engine_class=None,
             dummy_tables_path=None,
+            test_data_file=None,
             environ={},
             user_args=(),
         )
@@ -85,6 +87,7 @@ def test_generate_dataset_no_data_args(mock_load_and_compile):
             query_engine_class=None,
             dummy_tables_path=None,
             dummy_data_file=None,
+            test_data_file=None,
             environ={},
             user_args=(),
         )

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -94,6 +94,28 @@ def test_generate_dataset_no_data_args(mock_load_and_compile):
         p.assert_called_once()
 
 
+def test_generate_dataset_with_test_data_file(mock_load_and_compile):
+    with (
+        mock.patch("ehrql.main.assure") as p,
+        mock.patch("ehrql.main.generate_dataset_with_dummy_data"),
+    ):
+        generate_dataset(
+            Path("dataset_definition.py"),
+            Path("results.csv"),
+            # Interesting argument
+            test_data_file=Path("test_data.py"),
+            # Defaults
+            dsn=None,
+            backend_class=None,
+            query_engine_class=None,
+            dummy_tables_path=None,
+            dummy_data_file=None,
+            environ={},
+            user_args=(),
+        )
+        p.assert_called_once()
+
+
 def test_get_query_engine_defaults():
     query_engine = get_query_engine(
         dsn=None,


### PR DESCRIPTION
This allows users to test their dataset definition every time they run their `generate-dataset` action by providing a test file through the `--test-data-file` flag. It makes it possible for users to integrate tests into their OpenSAFELY pipeline.

Closes #1851
