### PR TITLE
Improve error messages from `measures`

### DIFF
--- a/ehrql/measures/measures.py
+++ b/ehrql/measures/measures.py
@@ -11,6 +11,8 @@ from ehrql.query_language import (
     IntPatientSeries,
     Parameter,
     PatientSeries,
+    validate_patient_series,
+    validate_patient_series_type,
 )
 from ehrql.query_model.nodes import Series
 
@@ -233,15 +235,7 @@ class Measures:
     def _validate_num_denom(self, value, name):
         if value is None:
             return
-        if not isinstance(value, PatientSeries):
-            raise Error(
-                f"`{name}` must be a one row per patient series,"
-                f" got '{type(value)}': {value!r}"
-            )
-        if value._type not in (bool, int):
-            raise Error(
-                f"`{name}` must be a boolean or integer series, got '{value._type}'"
-            )
+        validate_patient_series_type(value, types=(bool, int), context=name)
 
     def _validate_intervals(self, intervals):
         if intervals is None:
@@ -287,11 +281,7 @@ class Measures:
                     f"`group_by` names must start with a letter and contain only"
                     f" alphanumeric characters and underscores, got: {key!r}"
                 )
-            if not isinstance(value, PatientSeries):
-                raise Error(
-                    f"`group_by` values must be one row per patient series,"
-                    f"  at '{key}' got '{type(value)}': {value!r}"
-                )
+            validate_patient_series(value, context=f"`group_by` value for '{key}'")
         disallowed = self.RESERVED_NAMES.intersection(group_by)
         if disallowed:
             raise Error(f"disallowed `group_by` column name: {', '.join(disallowed)}")

--- a/ehrql/measures/measures.py
+++ b/ehrql/measures/measures.py
@@ -7,15 +7,12 @@ from ehrql.query_language import (
     BoolPatientSeries,
     DummyDataConfig,
     Duration,
+    Error,
     IntPatientSeries,
     Parameter,
     PatientSeries,
 )
 from ehrql.query_model.nodes import Series
-
-
-class ValidationError(Exception):
-    pass
 
 
 # Parameters to be used in place of date values when constructing the ehrQL queries
@@ -165,19 +162,17 @@ class Measures:
         # Ensure all required arguments are provided (either directly or by defaults)
         for key, value in kwargs.items():
             if value is None:
-                raise ValidationError(
-                    f"No value supplied for '{key}' and no default defined"
-                )
+                raise Error(f"No value supplied for '{key}' and no default defined")
 
         # Ensure measure names are valid
         if not VALID_VARIABLE_NAME_RE.match(name):
-            raise ValidationError(
+            raise Error(
                 f"Measure names must start with a letter and contain only"
                 f" alphanumeric characters and underscores, got: {name!r}"
             )
         # Ensure measure names are unique
         if name in self._measures:
-            raise ValidationError(f"Measure already defined with name: {name}")
+            raise Error(f"Measure already defined with name: {name}")
 
         # Ensure group_by column definitions are consistent across measures
         for group_name, definition in get_all_group_by_columns(
@@ -186,7 +181,7 @@ class Measures:
             if group_name not in kwargs["group_by"]:
                 continue
             if kwargs["group_by"][group_name]._qm_node != definition:
-                raise ValidationError(
+                raise Error(
                     f"Inconsistent definition for `group_by` column: {group_name}"
                 )
 
@@ -223,7 +218,7 @@ class Measures:
             "intervals": intervals,
         }
         if self._defaults:
-            raise ValidationError(
+            raise Error(
                 "Defaults already set; cannot call `define_defaults()` more than once"
             )
         self._validate_kwargs(kwargs)
@@ -239,12 +234,12 @@ class Measures:
         if value is None:
             return
         if not isinstance(value, PatientSeries):
-            raise ValidationError(
+            raise Error(
                 f"`{name}` must be a one row per patient series,"
                 f" got '{type(value)}': {value!r}"
             )
         if value._type not in (bool, int):
-            raise ValidationError(
+            raise Error(
                 f"`{name}` must be a boolean or integer series, got '{value._type}'"
             )
 
@@ -252,12 +247,12 @@ class Measures:
         if intervals is None:
             return
         if isinstance(intervals, Duration):
-            raise ValidationError(
+            raise Error(
                 f"You must supply a date using `{intervals!r}.starting_on('<DATE>')`"
                 f" or `{intervals!r}.ending_on('<DATE>')`"
             )
         if not isinstance(intervals, list):
-            raise ValidationError(
+            raise Error(
                 f"`intervals` must be a list, got '{type(intervals)}': {intervals!r}"
             )
         for interval in intervals:
@@ -269,11 +264,9 @@ class Measures:
             or len(interval) != 2
             or not all(isinstance(i, datetime.date) for i in interval)
         ):
-            raise ValidationError(
-                f"`intervals` must contain pairs of dates, got: {interval!r}"
-            )
+            raise Error(f"`intervals` must contain pairs of dates, got: {interval!r}")
         if interval[0] > interval[1]:
-            raise ValidationError(
+            raise Error(
                 f"Interval start date must be before end date, got: {interval!r}"
             )
 
@@ -281,29 +274,27 @@ class Measures:
         if group_by is None:
             return
         if not isinstance(group_by, dict):
-            raise ValidationError(
+            raise Error(
                 f"`group_by` must be a dictionary, got '{type(group_by)}': {group_by!r}"
             )
         for key, value in group_by.items():
             if not isinstance(key, str):
-                raise ValidationError(
+                raise Error(
                     f"`group_by` names must be strings, got '{type(key)}': {key!r}"
                 )
             if not VALID_VARIABLE_NAME_RE.match(key):
-                raise ValidationError(
+                raise Error(
                     f"`group_by` names must start with a letter and contain only"
                     f" alphanumeric characters and underscores, got: {key!r}"
                 )
             if not isinstance(value, PatientSeries):
-                raise ValidationError(
+                raise Error(
                     f"`group_by` values must be one row per patient series,"
                     f"  at '{key}' got '{type(value)}': {value!r}"
                 )
         disallowed = self.RESERVED_NAMES.intersection(group_by)
         if disallowed:
-            raise ValidationError(
-                f"disallowed `group_by` column name: {', '.join(disallowed)}"
-            )
+            raise Error(f"disallowed `group_by` column name: {', '.join(disallowed)}")
 
     def configure_dummy_data(self, *, population_size):
         """

--- a/tests/unit/measures/test_measures.py
+++ b/tests/unit/measures/test_measures.py
@@ -3,8 +3,8 @@ from datetime import date
 
 import pytest
 
-from ehrql import Measures, months
-from ehrql.measures.measures import Measure, ValidationError, create_measures
+from ehrql import Error, Measures, months
+from ehrql.measures.measures import Measure, create_measures
 from ehrql.tables import PatientFrame, Series, table
 
 
@@ -122,7 +122,7 @@ def test_define_measures_with_default_group_by():
 def test_cannot_redefine_defaults():
     measures = Measures()
     measures.define_defaults(numerator=patients.score)
-    with pytest.raises(ValidationError, match="Defaults already set"):
+    with pytest.raises(Error, match="Defaults already set"):
         measures.define_defaults(numerator=patients.is_interesting)
 
 
@@ -130,7 +130,7 @@ def test_must_define_all_attributes():
     measures = Measures()
     measures.define_defaults(numerator=patients.score)
     with pytest.raises(
-        ValidationError,
+        Error,
         match="No value supplied for 'intervals' and no default defined",
     ):
         measures.define_measure(
@@ -149,9 +149,7 @@ def test_names_must_be_unique():
     )
 
     measures.define_measure(name="test", numerator=patients.score)
-    with pytest.raises(
-        ValidationError, match="Measure already defined with name: test"
-    ):
+    with pytest.raises(Error, match="Measure already defined with name: test"):
         measures.define_measure(name="test", numerator=patients.is_interesting)
 
 
@@ -166,7 +164,7 @@ def test_names_must_be_unique():
 def test_names_must_be_valid(name):
     measures = Measures()
     with pytest.raises(
-        ValidationError,
+        Error,
         match=(
             "must start with a letter and contain only alphanumeric characters"
             " and underscores"
@@ -198,7 +196,7 @@ def test_group_by_columns_must_be_consistent():
         },
     )
     with pytest.raises(
-        ValidationError, match="Inconsistent definition for `group_by` column: category"
+        Error, match="Inconsistent definition for `group_by` column: category"
     ):
         measures.define_measure(
             name="test_2",
@@ -212,9 +210,7 @@ def test_group_by_columns_must_be_consistent():
 def test_numerator_must_be_patient_series():
     measures = Measures()
 
-    with pytest.raises(
-        ValidationError, match="`numerator` must be a one row per patient series"
-    ):
+    with pytest.raises(Error, match="`numerator` must be a one row per patient series"):
         measures.define_measure(
             name="test",
             numerator=object(),
@@ -228,7 +224,7 @@ def test_denominator_must_be_int_or_bool_series():
     measures = Measures()
 
     with pytest.raises(
-        ValidationError, match="`denominator` must be a boolean or integer series"
+        Error, match="`denominator` must be a boolean or integer series"
     ):
         measures.define_measure(
             name="test",
@@ -252,7 +248,7 @@ def test_denominator_must_be_int_or_bool_series():
 def test_invalid_group_by_is_rejected(group_by, error):
     measures = Measures()
 
-    with pytest.raises(ValidationError, match=error):
+    with pytest.raises(Error, match=error):
         measures.define_measure(
             name="test",
             numerator=patients.score,
@@ -281,7 +277,7 @@ def test_invalid_group_by_is_rejected(group_by, error):
 def test_invalid_intervals_are_rejected(intervals, error):
     measures = Measures()
 
-    with pytest.raises(ValidationError, match=error):
+    with pytest.raises(Error, match=error):
         measures.define_measure(
             name="test",
             numerator=patients.score,

--- a/tests/unit/measures/test_measures.py
+++ b/tests/unit/measures/test_measures.py
@@ -210,7 +210,10 @@ def test_group_by_columns_must_be_consistent():
 def test_numerator_must_be_patient_series():
     measures = Measures()
 
-    with pytest.raises(Error, match="`numerator` must be a one row per patient series"):
+    with pytest.raises(
+        TypeError,
+        match="invalid numerator:\nExpecting an ehrQL series, got type 'object'",
+    ):
         measures.define_measure(
             name="test",
             numerator=object(),
@@ -224,7 +227,11 @@ def test_denominator_must_be_int_or_bool_series():
     measures = Measures()
 
     with pytest.raises(
-        Error, match="`denominator` must be a boolean or integer series"
+        TypeError,
+        match=(
+            "invalid denominator:\n"
+            "Expecting a boolean or integer series, got series of type 'str'"
+        ),
     ):
         measures.define_measure(
             name="test",
@@ -241,14 +248,18 @@ def test_denominator_must_be_int_or_bool_series():
         (1234, "`group_by` must be a dictionary"),
         ({1234: patients.category}, "group_by` names must be strings"),
         ({"My Group": patients.category}, "alphanumeric characters and underscores"),
-        ({"my_group": 1234}, "group_by` values must be one row per patient series"),
         ({"measure": patients.category}, "disallowed `group_by` column name: measure"),
+        (
+            {"my_group": 1234},
+            "invalid `group_by` value for 'my_group':\n"
+            "Expecting an ehrQL series, got type 'int'",
+        ),
     ],
 )
 def test_invalid_group_by_is_rejected(group_by, error):
     measures = Measures()
 
-    with pytest.raises(Error, match=error):
+    with pytest.raises((TypeError, Error), match=error):
         measures.define_measure(
             name="test",
             numerator=patients.score,


### PR DESCRIPTION
This refactors some of the validation code in `ehrql.query_language` so that we can re-use it in measures and benefit from the more helpful error messages.