### PR TITLE
Add `covid_therapeutics_raw` table

### DIFF
--- a/docs/includes/generated_docs/schemas/raw.tpp.md
+++ b/docs/includes/generated_docs/schemas/raw.tpp.md
@@ -14,6 +14,7 @@ and data curation purposes.
 from ehrql.tables.raw.tpp import (
     apcs_cost_historical,
     apcs_historical,
+    covid_therapeutics_raw,
     isaric,
     ons_deaths,
     wl_clockstops,
@@ -161,6 +162,341 @@ It has been exposed to users for data exploration, and may be removed in future.
   </dt>
   <dd markdown="block">
 
+
+  </dd>
+</div>
+
+  </dl>
+</div>
+
+
+<p class="dimension-indicator"><code>many rows per patient</code></p>
+## covid_therapeutics_raw
+
+The COVID Therapeutics dataset contains information on COVID treatments used in inpatient
+and outpatient settings.
+
+**Metadata**
+
+* **Data provider** NHS England
+* **Participation / Coverage** Inpatients and outpatients treated with antivirals/nMABs for COVID-19 in England
+* **Provenance** Data sourced largely from BlueTeq system (forms completed by clinicians)
+* **Update frequency in OpenSAFELY** Approximately weekly
+* **Delay between event occurring and event appearing in OpenSAFELY** Approximately 2-9 days
+* **Collected information** Treatment start date; therapeutic intervention; COVID indication, current status, risk group, region
+
+
+**Overview**
+
+Antivirals and neutralising monoclonal antibodies (nMABs) for COVID-19 can be
+administered in inpatient setting or, for outpatients, in COVID Medicine Delivery
+Units (CMDUs) specifically set up for this purpose. For patients considered for
+these treatments, clinicians submit completed forms to NHS England. Each row
+represents one completed form for one course of treatment. Data received by
+OpenSAFELY currently covers patients who were approved for treatment. The patient
+may or may not have actually received the treatment or completed the course (but we
+assume that they usually do). They may have another form completed for another
+treatment, either because it was decided to give them a different treatment, or for
+some other reason. They may in theory also have another form completed some months
+later for another instance of infection.
+
+Treatment dates may be in the past or future at the point when the form is
+submitted.
+
+Note that this dataset contains some **duplicate** rows – some full duplicates and
+some partial duplicates.
+
+
+**More Information**
+
+* [Treatment guidelines](https://www.nice.org.uk/guidance/ta878)
+* [Draft Data Report](https://docs.google.com/document/d/15o4x9sqHEO-sLm2dTqgm3PyAh72cdgOOmZC4AB3BTNk/) (currently only available to internal staff)
+<div markdown="block" class="definition-list-wrapper">
+  <div class="title">Columns</div>
+  <dl markdown="block">
+<div markdown="block">
+  <dt id="covid_therapeutics_raw.current_status">
+    <strong>current_status</strong>
+    <a class="headerlink" href="#covid_therapeutics_raw.current_status" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+Status of form/application.
+
+ * Possible values: `Approved`, `Treatment Complete`, `Treatment Not Started`, `Treatment Stopped`
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="covid_therapeutics_raw.covid_indication">
+    <strong>covid_indication</strong>
+    <a class="headerlink" href="#covid_therapeutics_raw.covid_indication" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+Treatment setting/indication.
+
+ * Possible values: `non_hospitalised`, `hospitalised_with`, `hospital_onset`
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="covid_therapeutics_raw.diagnosis">
+    <strong>diagnosis</strong>
+    <a class="headerlink" href="#covid_therapeutics_raw.diagnosis" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+Always has the value 'Covid-19'.
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="covid_therapeutics_raw.intervention">
+    <strong>intervention</strong>
+    <a class="headerlink" href="#covid_therapeutics_raw.intervention" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+Intervention or therapeutic name. Expected to be one of:
+
+ * Paxlovid
+ * Sotrovimab
+ * Molnupiravir
+ * Remdesivir
+ * Casirivimab and imdevimab
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="covid_therapeutics_raw.treatment_start_date">
+    <strong>treatment_start_date</strong>
+    <a class="headerlink" href="#covid_therapeutics_raw.treatment_start_date" title="Permanent link">🔗</a>
+    <code>date</code>
+  </dt>
+  <dd markdown="block">
+Entered by the clinician and can represent either a future planned start
+date or a past date at the time of form submission.
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="covid_therapeutics_raw.CASIM05_date_of_symptom_onset">
+    <strong>CASIM05_date_of_symptom_onset</strong>
+    <a class="headerlink" href="#covid_therapeutics_raw.CASIM05_date_of_symptom_onset" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+Date of symptom onset (Casirivimab/imdevimab).
+
+Not in a consistent format and so cannot be converted to a date column.
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="covid_therapeutics_raw.CASIM05_risk_cohort">
+    <strong>CASIM05_risk_cohort</strong>
+    <a class="headerlink" href="#covid_therapeutics_raw.CASIM05_risk_cohort" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+High-risk group to which the patient was considered to belong. Derived from
+tick-boxes. Multiple groups can be selected and will be joined with the word
+` and ` e.g. `liver disease and rare neurological conditions`.
+
+The available groups as at the time of writing are listed below. However
+note that the precise wording used has changed over time and so filtering by
+a specific disease name may not be reliable.
+
+ * `Downs syndrome`
+ * `HIV or AIDS`
+ * `IMID`
+ * `haematologic malignancy`
+ * `Patients with a haematological diseases` (sic)
+ * `immune deficiencies`
+ * `liver disease`
+ * `primary immune deficiencies`
+ * `rare neurological conditions`
+ * `rare neurological diseases`
+ * `renal disease`
+ * `sickle cell disease`
+ * `solid cancer`
+ * `solid organ recipients`
+ * `stem cell transplant recipients`
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="covid_therapeutics_raw.MOL1_onset_of_symptoms">
+    <strong>MOL1_onset_of_symptoms</strong>
+    <a class="headerlink" href="#covid_therapeutics_raw.MOL1_onset_of_symptoms" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+Date of symptom onset (Molnupiravir).
+
+Not in a consistent format and so cannot be converted to a date column.
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="covid_therapeutics_raw.MOL1_high_risk_cohort">
+    <strong>MOL1_high_risk_cohort</strong>
+    <a class="headerlink" href="#covid_therapeutics_raw.MOL1_high_risk_cohort" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+High-risk group to which the patient was considered to belong. Derived from
+tick-boxes. Multiple groups can be selected and will be joined with the word
+` and ` e.g. `liver disease and rare neurological conditions`.
+
+The available groups as at the time of writing are listed below. However
+note that the precise wording used has changed over time and so filtering by
+a specific disease name may not be reliable.
+
+ * `Downs syndrome`
+ * `HIV or AIDS`
+ * `IMID`
+ * `haematologic malignancy`
+ * `Patients with a haematological diseases` (sic)
+ * `immune deficiencies`
+ * `liver disease`
+ * `primary immune deficiencies`
+ * `rare neurological conditions`
+ * `rare neurological diseases`
+ * `renal disease`
+ * `sickle cell disease`
+ * `solid cancer`
+ * `solid organ recipients`
+ * `stem cell transplant recipients`
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="covid_therapeutics_raw.SOT02_onset_of_symptoms">
+    <strong>SOT02_onset_of_symptoms</strong>
+    <a class="headerlink" href="#covid_therapeutics_raw.SOT02_onset_of_symptoms" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+Date of symptom onset (Sotrovimab).
+
+Not in a consistent format and so cannot be converted to a date column.
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="covid_therapeutics_raw.SOT02_risk_cohorts">
+    <strong>SOT02_risk_cohorts</strong>
+    <a class="headerlink" href="#covid_therapeutics_raw.SOT02_risk_cohorts" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+High-risk group to which the patient was considered to belong. Derived from
+tick-boxes. Multiple groups can be selected and will be joined with the word
+` and ` e.g. `liver disease and rare neurological conditions`.
+
+The available groups as at the time of writing are listed below. However
+note that the precise wording used has changed over time and so filtering by
+a specific disease name may not be reliable.
+
+ * `Downs syndrome`
+ * `HIV or AIDS`
+ * `IMID`
+ * `haematologic malignancy`
+ * `Patients with a haematological diseases` (sic)
+ * `immune deficiencies`
+ * `liver disease`
+ * `primary immune deficiencies`
+ * `rare neurological conditions`
+ * `rare neurological diseases`
+ * `renal disease`
+ * `sickle cell disease`
+ * `solid cancer`
+ * `solid organ recipients`
+ * `stem cell transplant recipients`
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="covid_therapeutics_raw.form_name">
+    <strong>form_name</strong>
+    <a class="headerlink" href="#covid_therapeutics_raw.form_name" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+Name and version of the patient registration form used to register the
+treatment.
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="covid_therapeutics_raw.received">
+    <strong>received</strong>
+    <a class="headerlink" href="#covid_therapeutics_raw.received" title="Permanent link">🔗</a>
+    <code>date</code>
+  </dt>
+  <dd markdown="block">
+Date form submitted.
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="covid_therapeutics_raw.count">
+    <strong>count</strong>
+    <a class="headerlink" href="#covid_therapeutics_raw.count" title="Permanent link">🔗</a>
+    <code>integer</code>
+  </dt>
+  <dd markdown="block">
+Number of forms.
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="covid_therapeutics_raw.age_at_received_date">
+    <strong>age_at_received_date</strong>
+    <a class="headerlink" href="#covid_therapeutics_raw.age_at_received_date" title="Permanent link">🔗</a>
+    <code>integer</code>
+  </dt>
+  <dd markdown="block">
+Can occasionally be zero, presumably indicating an unknown or missing value
+as minimum eligibility age is 12.
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="covid_therapeutics_raw.region">
+    <strong>region</strong>
+    <a class="headerlink" href="#covid_therapeutics_raw.region" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+NHS England region in which the CMDU submitting the form is located.
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="covid_therapeutics_raw.load_date">
+    <strong>load_date</strong>
+    <a class="headerlink" href="#covid_therapeutics_raw.load_date" title="Permanent link">🔗</a>
+    <code>date</code>
+  </dt>
+  <dd markdown="block">
+Date on which the current dataset was imported.
 
   </dd>
 </div>

--- a/ehrql/backends/tpp.py
+++ b/ehrql/backends/tpp.py
@@ -293,6 +293,31 @@ class TPPBackend(SQLBackend):
         """
     )
 
+    covid_therapeutics_raw = QueryTable(
+        """
+        SELECT
+            Patient_ID AS patient_id,
+            COVID_indication AS covid_indication,
+            Count AS count,
+            CurrentStatus AS current_status,
+            Diagnosis AS diagnosis,
+            FormName AS form_name,
+            Intervention AS intervention,
+            CASIM05_date_of_symptom_onset,
+            CASIM05_risk_cohort,
+            MOL1_onset_of_symptoms,
+            MOL1_high_risk_cohort,
+            SOT02_onset_of_symptoms,
+            SOT02_risk_cohorts,
+            CAST(Received AS date) AS received,
+            CAST(TreatmentStartDate AS date) AS treatment_start_date,
+            AgeAtReceivedDate AS age_at_received_date,
+            Region AS region,
+            CONVERT(DATE, Der_LoadDate, 23) AS load_date
+        FROM Therapeutics
+        """
+    )
+
     ec = MappedTable(
         source="EC",
         columns={

--- a/ehrql/tables/raw/tpp.py
+++ b/ehrql/tables/raw/tpp.py
@@ -16,6 +16,7 @@ from ehrql.tables import Constraint, EventFrame, Series, table
 __all__ = [
     "apcs_cost_historical",
     "apcs_historical",
+    "covid_therapeutics_raw",
     "isaric",
     "ons_deaths",
     "wl_clockstops",
@@ -508,4 +509,235 @@ class apcs_cost_historical(EventFrame):
     )
     discharge_date = Series(
         datetime.date,
+    )
+
+
+@table
+class covid_therapeutics_raw(EventFrame):
+    """
+    The COVID Therapeutics dataset contains information on COVID treatments used in inpatient
+    and outpatient settings.
+
+    **Metadata**
+
+    * **Data provider** NHS England
+    * **Participation / Coverage** Inpatients and outpatients treated with antivirals/nMABs for COVID-19 in England
+    * **Provenance** Data sourced largely from BlueTeq system (forms completed by clinicians)
+    * **Update frequency in OpenSAFELY** Approximately weekly
+    * **Delay between event occurring and event appearing in OpenSAFELY** Approximately 2-9 days
+    * **Collected information** Treatment start date; therapeutic intervention; COVID indication, current status, risk group, region
+
+
+    **Overview**
+
+    Antivirals and neutralising monoclonal antibodies (nMABs) for COVID-19 can be
+    administered in inpatient setting or, for outpatients, in COVID Medicine Delivery
+    Units (CMDUs) specifically set up for this purpose. For patients considered for
+    these treatments, clinicians submit completed forms to NHS England. Each row
+    represents one completed form for one course of treatment. Data received by
+    OpenSAFELY currently covers patients who were approved for treatment. The patient
+    may or may not have actually received the treatment or completed the course (but we
+    assume that they usually do). They may have another form completed for another
+    treatment, either because it was decided to give them a different treatment, or for
+    some other reason. They may in theory also have another form completed some months
+    later for another instance of infection.
+
+    Treatment dates may be in the past or future at the point when the form is
+    submitted.
+
+    Note that this dataset contains some **duplicate** rows – some full duplicates and
+    some partial duplicates.
+
+
+    **More Information**
+
+    * [Treatment guidelines](https://www.nice.org.uk/guidance/ta878)
+    * [Draft Data Report](https://docs.google.com/document/d/15o4x9sqHEO-sLm2dTqgm3PyAh72cdgOOmZC4AB3BTNk/) (currently only available to internal staff)
+    """
+
+    current_status = Series(
+        str,
+        description="Status of form/application.",
+        constraints=[
+            Constraint.Categorical(
+                [
+                    "Approved",
+                    "Treatment Complete",
+                    "Treatment Not Started",
+                    "Treatment Stopped",
+                ]
+            )
+        ],
+    )
+    covid_indication = Series(
+        str,
+        description="Treatment setting/indication.",
+        constraints=[
+            Constraint.Categorical(
+                ["non_hospitalised", "hospitalised_with", "hospital_onset"]
+            )
+        ],
+    )
+    diagnosis = Series(
+        str,
+        description="Always has the value 'Covid-19'.",
+    )
+    intervention = Series(
+        str,
+        description="""
+            Intervention or therapeutic name. Expected to be one of:
+
+             * Paxlovid
+             * Sotrovimab
+             * Molnupiravir
+             * Remdesivir
+             * Casirivimab and imdevimab
+        """,
+    )
+    treatment_start_date = Series(
+        datetime.date,
+        description="""
+            Entered by the clinician and can represent either a future planned start
+            date or a past date at the time of form submission.
+        """,
+    )
+    CASIM05_date_of_symptom_onset = Series(
+        str,
+        description="""
+            Date of symptom onset (Casirivimab/imdevimab).
+
+            Not in a consistent format and so cannot be converted to a date column.
+        """,
+    )
+    CASIM05_risk_cohort = Series(
+        str,
+        description="""
+            High-risk group to which the patient was considered to belong. Derived from
+            tick-boxes. Multiple groups can be selected and will be joined with the word
+            ` and ` e.g. `liver disease and rare neurological conditions`.
+
+            The available groups as at the time of writing are listed below. However
+            note that the precise wording used has changed over time and so filtering by
+            a specific disease name may not be reliable.
+
+             * `Downs syndrome`
+             * `HIV or AIDS`
+             * `IMID`
+             * `haematologic malignancy`
+             * `Patients with a haematological diseases` (sic)
+             * `immune deficiencies`
+             * `liver disease`
+             * `primary immune deficiencies`
+             * `rare neurological conditions`
+             * `rare neurological diseases`
+             * `renal disease`
+             * `sickle cell disease`
+             * `solid cancer`
+             * `solid organ recipients`
+             * `stem cell transplant recipients`
+        """,
+    )
+    MOL1_onset_of_symptoms = Series(
+        str,
+        description="""
+            Date of symptom onset (Molnupiravir).
+
+            Not in a consistent format and so cannot be converted to a date column.
+        """,
+    )
+    MOL1_high_risk_cohort = Series(
+        str,
+        description="""
+            High-risk group to which the patient was considered to belong. Derived from
+            tick-boxes. Multiple groups can be selected and will be joined with the word
+            ` and ` e.g. `liver disease and rare neurological conditions`.
+
+            The available groups as at the time of writing are listed below. However
+            note that the precise wording used has changed over time and so filtering by
+            a specific disease name may not be reliable.
+
+             * `Downs syndrome`
+             * `HIV or AIDS`
+             * `IMID`
+             * `haematologic malignancy`
+             * `Patients with a haematological diseases` (sic)
+             * `immune deficiencies`
+             * `liver disease`
+             * `primary immune deficiencies`
+             * `rare neurological conditions`
+             * `rare neurological diseases`
+             * `renal disease`
+             * `sickle cell disease`
+             * `solid cancer`
+             * `solid organ recipients`
+             * `stem cell transplant recipients`
+        """,
+    )
+    SOT02_onset_of_symptoms = Series(
+        str,
+        description="""
+            Date of symptom onset (Sotrovimab).
+
+            Not in a consistent format and so cannot be converted to a date column.
+        """,
+    )
+    SOT02_risk_cohorts = Series(
+        str,
+        description="""
+            High-risk group to which the patient was considered to belong. Derived from
+            tick-boxes. Multiple groups can be selected and will be joined with the word
+            ` and ` e.g. `liver disease and rare neurological conditions`.
+
+            The available groups as at the time of writing are listed below. However
+            note that the precise wording used has changed over time and so filtering by
+            a specific disease name may not be reliable.
+
+             * `Downs syndrome`
+             * `HIV or AIDS`
+             * `IMID`
+             * `haematologic malignancy`
+             * `Patients with a haematological diseases` (sic)
+             * `immune deficiencies`
+             * `liver disease`
+             * `primary immune deficiencies`
+             * `rare neurological conditions`
+             * `rare neurological diseases`
+             * `renal disease`
+             * `sickle cell disease`
+             * `solid cancer`
+             * `solid organ recipients`
+             * `stem cell transplant recipients`
+        """,
+    )
+    form_name = Series(
+        str,
+        description="""
+            Name and version of the patient registration form used to register the
+            treatment.
+        """,
+    )
+    received = Series(
+        datetime.date,
+        description="Date form submitted.",
+    )
+    count = Series(
+        int,
+        description="Number of forms.",
+    )
+    age_at_received_date = Series(
+        int,
+        description="""
+            Can occasionally be zero, presumably indicating an unknown or missing value
+            as minimum eligibility age is 12.
+        """,
+    )
+    region = Series(
+        str,
+        description="""
+            NHS England region in which the CMDU submitting the form is located.
+        """,
+    )
+    load_date = Series(
+        datetime.date,
+        description="Date on which the current dataset was imported.",
     )

--- a/tests/integration/backends/test_tpp.py
+++ b/tests/integration/backends/test_tpp.py
@@ -44,6 +44,7 @@ from tests.lib.tpp_schema import (
     RegistrationHistory,
     SGSS_AllTests_Negative,
     SGSS_AllTests_Positive,
+    Therapeutics,
     Vaccination,
     VaccinationReference,
     WL_ClockStops,
@@ -640,6 +641,54 @@ def test_clinical_events_ranges(select_all_tpp):
     ]
 
     assert results == expected
+
+
+@register_test_for(tpp_raw.covid_therapeutics_raw)
+def test_covid_therapeutics_raw(select_all_tpp):
+    results = select_all_tpp(
+        Therapeutics(
+            Patient_ID=1,
+            COVID_indication="a",
+            Count=3,
+            CurrentStatus="b",
+            Diagnosis="c",
+            FormName="d",
+            Intervention="e",
+            CASIM05_date_of_symptom_onset="f",
+            CASIM05_risk_cohort="g",
+            MOL1_onset_of_symptoms="h",
+            MOL1_high_risk_cohort="i",
+            SOT02_onset_of_symptoms="j",
+            SOT02_risk_cohorts="k",
+            Received="2023-10-15T12:13:45",
+            TreatmentStartDate="2023-11-16T13:45:07",
+            AgeAtReceivedDate=60,
+            Region="l",
+            Der_LoadDate="2023-09-14 12:34:56.78000",
+        ),
+    )
+    assert results == [
+        {
+            "patient_id": 1,
+            "covid_indication": "a",
+            "count": 3,
+            "current_status": "b",
+            "diagnosis": "c",
+            "form_name": "d",
+            "intervention": "e",
+            "CASIM05_date_of_symptom_onset": "f",
+            "CASIM05_risk_cohort": "g",
+            "MOL1_onset_of_symptoms": "h",
+            "MOL1_high_risk_cohort": "i",
+            "SOT02_onset_of_symptoms": "j",
+            "SOT02_risk_cohorts": "k",
+            "received": date(2023, 10, 15),
+            "treatment_start_date": date(2023, 11, 16),
+            "age_at_received_date": 60,
+            "region": "l",
+            "load_date": date(2023, 9, 14),
+        },
+    ]
 
 
 @register_test_for(tpp.ec)


### PR DESCRIPTION
This adds a mostly raw (rare?) view on the COVID Therapeutics dataset. Things which could be straightforwardly tidied up (e.g. converting datetimes to dates) but anything more exotic has been left as is.

Values that have been converted have been checked against the real data to confirm that the conversions are valid.

Documentation has been pulled in from the old Cohort Extractor docs: https://docs.opensafely.org/data-sources/therapeutics/

And also from the very useful Short Data Report (linked in the code).

There's a further question as to how we properly tidy this, remove duplicates etc; but I thought it was best to start with this.

Docs visible here:
https://evansd-covid-therapeutics.databuilder.pages.dev/reference/schemas/raw.tpp/#covid_therapeutics_raw


Closes #1896