### PR TITLE
Add yet another type of ignored MSSQL error

### DIFF
--- a/tests/generative/ignored_errors.py
+++ b/tests/generative/ignored_errors.py
@@ -134,6 +134,12 @@ IGNORED_ERRORS = {
             sqlalchemy.exc.OperationalError,
             re.compile(".*do not support constants as ORDER BY clause expressions"),
         ),
+        (
+            sqlalchemy.exc.OperationalError,
+            re.compile(
+                ".*do not support integer indices as ORDER BY clause expressions"
+            ),
+        ),
     ],
     IgnoredError.CONNECTION_ERROR: [
         # Sometimes we lose connection to the database server in a way that isn't


### PR DESCRIPTION
This is an alternative manifestation of the "sort by constant" problem which we've tackled before (see #1869, #1871 and #1876).

The generative test run which raised it was:
https://github.com/opensafely-core/ehrql/actions/runs/7937960053/job/21676080319