### PR TITLE
Fix categories for waiting list data

### DIFF
--- a/docs/includes/generated_docs/schemas/tpp.md
+++ b/docs/includes/generated_docs/schemas/tpp.md
@@ -2700,7 +2700,12 @@ The treatment function
     <code>string</code>
   </dt>
   <dd markdown="block">
-The priority type
+The priority type.
+
+Note that a small number of rows contain values which are not in the list
+below. These are converted to NULL in this representation of the data. If
+you need to access the original values, please see the corresponding [raw
+table](../raw.tpp/#wl_clockstops).
 
  * Possible values: `routine`, `urgent`, `two week wait`
   </dd>
@@ -2797,9 +2802,14 @@ Clock start for the completed pathway
     <code>string</code>
   </dt>
   <dd markdown="block">
-The waiting list type on completion of the pathway
+The waiting list type on completion of the pathway.
 
- * Possible values: `ORTT`, `IRTT`
+Note that a small number of rows contain values which are not in the list
+below. These are converted to NULL in this representation of the data. If
+you need to access the original values, please see the corresponding [raw
+table](../raw.tpp/#wl_clockstops).
+
+ * Possible values: `ORTT`, `IRTT`, `PTLO`, `PTLI`, `RTTO`, `RTTI`
   </dd>
 </div>
 
@@ -2877,7 +2887,12 @@ Latest clock start for this pathway period
     <code>string</code>
   </dt>
   <dd markdown="block">
-The priority type
+The priority type.
+
+Note that a small number of rows contain values which are not in the list
+below. These are converted to NULL in this representation of the data. If
+you need to access the original values, please see the corresponding [raw
+table](../raw.tpp/#wl_openpathways).
 
  * Possible values: `routine`, `urgent`, `two week wait`
   </dd>
@@ -2975,9 +2990,14 @@ National referral source code for the referral that created the original pathway
     <code>string</code>
   </dt>
   <dd markdown="block">
+The waiting list type.
 
+Note that a small number of rows contain values which are not in the list
+below. These are converted to NULL in this representation of the data. If
+you need to access the original values, please see the corresponding [raw
+table](../raw.tpp/#wl_openpathways).
 
- * Possible values: `ORTT`, `IRTT`, `ONON`, `INON`
+ * Possible values: `ORTT`, `IRTT`, `ONON`, `INON`, `PTLO`, `PTLI`, `RTTO`, `RTTI`
   </dd>
 </div>
 

--- a/ehrql/backends/tpp.py
+++ b/ehrql/backends/tpp.py
@@ -850,7 +850,7 @@ class TPPBackend(SQLBackend):
     )
 
     wl_clockstops = QueryTable(
-        """
+        f"""
             SELECT
                 Patient_ID AS patient_id,
                 ACTIVITY_TREATMENT_FUNCTION_CODE AS activity_treatment_function_code,
@@ -878,7 +878,9 @@ class TPPBackend(SQLBackend):
                 CONVERT(DATE, REFERRAL_TO_TREATMENT_PERIOD_END_DATE, 23) AS referral_to_treatment_period_end_date,
                 CONVERT(DATE, REFERRAL_TO_TREATMENT_PERIOD_START_DATE, 23) AS referral_to_treatment_period_start_date,
                 SOURCE_OF_REFERRAL_FOR_OUTPATIENTS AS source_of_referral_for_outpatients,
-                NULLIF(Waiting_List_Type, 'NULL') AS waiting_list_type,
+                CASE WHEN Waiting_List_Type IN
+                    {ehrql.tables.tpp.wl_clockstops._qm_node.schema.get_column_categories("waiting_list_type")}
+                    THEN Waiting_List_Type END AS waiting_list_type,
                 CONVERT(DATE, Week_Ending_Date, 23) AS week_ending_date
             FROM WL_ClockStops
         """
@@ -918,7 +920,7 @@ class TPPBackend(SQLBackend):
     )
 
     wl_openpathways = QueryTable(
-        """
+        f"""
             SELECT
                 Patient_ID AS patient_id,
                 ACTIVITY_TREATMENT_FUNCTION_CODE AS activity_treatment_function_code,
@@ -951,7 +953,9 @@ class TPPBackend(SQLBackend):
                 ) AS referral_to_treatment_period_end_date,
                 CONVERT(DATE, REFERRAL_TO_TREATMENT_PERIOD_START_DATE, 23) AS referral_to_treatment_period_start_date,
                 SOURCE_OF_REFERRAL AS source_of_referral,
-                NULLIF(Waiting_List_Type, 'NULL') AS waiting_list_type,
+                CASE WHEN Waiting_List_Type IN
+                    {ehrql.tables.tpp.wl_openpathways._qm_node.schema.get_column_categories("waiting_list_type")}
+                    THEN Waiting_List_Type END AS waiting_list_type,
                 CONVERT(DATE, Week_Ending_Date, 23) AS week_ending_date
             FROM WL_OpenPathways
         """

--- a/ehrql/tables/tpp.py
+++ b/ehrql/tables/tpp.py
@@ -1312,7 +1312,11 @@ class wl_clockstops(EventFrame):
     waiting_list_type = Series(
         str,
         description="The waiting list type on completion of the pathway",
-        constraints=[Constraint.Categorical(["ORTT", "IRTT"])],
+        constraints=[
+            Constraint.Categorical(
+                ["ORTT", "IRTT", "PTLO", "PTLI", "RTTO", "RTTI"],
+            )
+        ],
     )
     week_ending_date = Series(
         datetime.date,
@@ -1390,7 +1394,11 @@ class wl_openpathways(EventFrame):
     )
     waiting_list_type = Series(
         str,
-        constraints=[Constraint.Categorical(["ORTT", "IRTT", "ONON", "INON"])],
+        constraints=[
+            Constraint.Categorical(
+                ["ORTT", "IRTT", "ONON", "INON", "PTLO", "PTLI", "RTTO", "RTTI"]
+            )
+        ],
     )
     week_ending_date = Series(
         datetime.date,

--- a/ehrql/tables/tpp.py
+++ b/ehrql/tables/tpp.py
@@ -1287,7 +1287,14 @@ class wl_clockstops(EventFrame):
     )
     priority_type_code = Series(
         str,
-        description="The priority type",
+        description="""
+            The priority type.
+
+            Note that a small number of rows contain values which are not in the list
+            below. These are converted to NULL in this representation of the data. If
+            you need to access the original values, please see the corresponding [raw
+            table](../raw.tpp/#wl_clockstops).
+        """,
         constraints=[Constraint.Categorical(["routine", "urgent", "two week wait"])],
     )
     pseudo_organisation_code_patient_pathway_identifier_issuer = Series(str)
@@ -1311,7 +1318,14 @@ class wl_clockstops(EventFrame):
     source_of_referral_for_outpatients = Series(str)
     waiting_list_type = Series(
         str,
-        description="The waiting list type on completion of the pathway",
+        description="""
+            The waiting list type on completion of the pathway.
+
+            Note that a small number of rows contain values which are not in the list
+            below. These are converted to NULL in this representation of the data. If
+            you need to access the original values, please see the corresponding [raw
+            table](../raw.tpp/#wl_clockstops).
+        """,
         constraints=[
             Constraint.Categorical(
                 ["ORTT", "IRTT", "PTLO", "PTLI", "RTTO", "RTTI"],
@@ -1360,7 +1374,14 @@ class wl_openpathways(EventFrame):
     )
     priority_type_code = Series(
         str,
-        description="The priority type",
+        description="""
+            The priority type.
+
+            Note that a small number of rows contain values which are not in the list
+            below. These are converted to NULL in this representation of the data. If
+            you need to access the original values, please see the corresponding [raw
+            table](../raw.tpp/#wl_openpathways).
+        """,
         constraints=[Constraint.Categorical(["routine", "urgent", "two week wait"])],
     )
     pseudo_organisation_code_patient_pathway_identifier_issuer = Series(str)
@@ -1394,6 +1415,14 @@ class wl_openpathways(EventFrame):
     )
     waiting_list_type = Series(
         str,
+        description="""
+            The waiting list type.
+
+            Note that a small number of rows contain values which are not in the list
+            below. These are converted to NULL in this representation of the data. If
+            you need to access the original values, please see the corresponding [raw
+            table](../raw.tpp/#wl_openpathways).
+        """,
         constraints=[
             Constraint.Categorical(
                 ["ORTT", "IRTT", "ONON", "INON", "PTLO", "PTLI", "RTTO", "RTTI"]

--- a/tests/integration/backends/test_tpp.py
+++ b/tests/integration/backends/test_tpp.py
@@ -1907,6 +1907,14 @@ def test_wl_clockstops(select_all_tpp):
             Waiting_List_Type="ORTT",
             Week_Ending_Date="2024-03-03",
         ),
+        # Test that unrecognised priority type codes and waiting list types are treated
+        # as NULL
+        WL_ClockStops(
+            Patient_ID=1,
+            PRIORITY_TYPE_CODE="10",
+            Referral_Request_Received_Date="2024-02-01",
+            Waiting_List_Type="Unrecognised",
+        ),
     )
     assert results == [
         {
@@ -1924,7 +1932,21 @@ def test_wl_clockstops(select_all_tpp):
             "source_of_referral_for_outpatients": "",
             "waiting_list_type": "ORTT",
             "week_ending_date": date(2024, 3, 3),
-        }
+        },
+        {
+            "patient_id": 1,
+            "activity_treatment_function_code": None,
+            "priority_type_code": None,
+            "pseudo_organisation_code_patient_pathway_identifier_issuer": None,
+            "pseudo_patient_pathway_identifier": None,
+            "pseudo_referral_identifier": None,
+            "referral_request_received_date": date(2024, 2, 1),
+            "referral_to_treatment_period_end_date": None,
+            "referral_to_treatment_period_start_date": None,
+            "source_of_referral_for_outpatients": None,
+            "waiting_list_type": None,
+            "week_ending_date": None,
+        },
     ]
 
 
@@ -1985,8 +2007,16 @@ def test_wl_openpathways(select_all_tpp):
             REFERRAL_TO_TREATMENT_PERIOD_END_DATE="9999-12-31",
             REFERRAL_TO_TREATMENT_PERIOD_START_DATE="2024-03-02",
             SOURCE_OF_REFERRAL="",
-            Waiting_List_Type="IRTT",
+            Waiting_List_Type="ONON",
             Week_Ending_Date="2024-03-03",
+        ),
+        # Test that unrecognised priority type codes and waiting list types are treated
+        # as NULL
+        WL_OpenPathways(
+            Patient_ID=1,
+            PRIORITY_TYPE_CODE="10",
+            REFERRAL_REQUEST_RECEIVED_DATE="2024-02-01",
+            Waiting_List_Type="Unrecognised",
         ),
     )
     assert results == [
@@ -2004,9 +2034,24 @@ def test_wl_openpathways(select_all_tpp):
             "referral_to_treatment_period_end_date": None,
             "referral_to_treatment_period_start_date": date(2024, 3, 2),
             "source_of_referral": "",
-            "waiting_list_type": "IRTT",
+            "waiting_list_type": "ONON",
             "week_ending_date": date(2024, 3, 3),
-        }
+        },
+        {
+            "patient_id": 1,
+            "activity_treatment_function_code": None,
+            "current_pathway_period_start_date": None,
+            "priority_type_code": None,
+            "pseudo_organisation_code_patient_pathway_identifier_issuer": None,
+            "pseudo_patient_pathway_identifier": None,
+            "pseudo_referral_identifier": None,
+            "referral_request_received_date": date(2024, 2, 1),
+            "referral_to_treatment_period_end_date": None,
+            "referral_to_treatment_period_start_date": None,
+            "source_of_referral": None,
+            "waiting_list_type": None,
+            "week_ending_date": None,
+        },
     ]
 
 


### PR DESCRIPTION
Some of the columns we have specified as categorical have a small number of unexpected values. We need to treat these as NULL in order to ensure that our results are valid as specified. (In particular, the Arrow writer will choke if we give it an unexpected categorical value.)