### PR TITLE
Raise more helpful errors from Arrow

### DIFF
--- a/ehrql/file_formats/arrow.py
+++ b/ehrql/file_formats/arrow.py
@@ -87,15 +87,19 @@ def get_field_and_convertor(name, spec):
             index_type, value_type, spec.categories
         )
     else:
-        column_to_pyarrow = make_column_to_pyarrow(type_)
+        column_to_pyarrow = make_column_to_pyarrow(name, type_)
 
     field = pyarrow.field(name, type_, nullable=spec.nullable)
     return field, column_to_pyarrow
 
 
-def make_column_to_pyarrow(type_):
+def make_column_to_pyarrow(name, type_):
     def column_to_pyarrow(column):
-        return pyarrow.array(column, type=type_, size=len(column))
+        try:
+            return pyarrow.array(column, type=type_, size=len(column))
+        except Exception as exc:
+            exc.add_note(f"Error when writing column '{name}'")
+            raise exc
 
     return column_to_pyarrow
 

--- a/tests/integration/file_formats/test_arrow.py
+++ b/tests/integration/file_formats/test_arrow.py
@@ -1,4 +1,5 @@
 import pyarrow.feather
+import pytest
 
 from ehrql.file_formats import write_dataset
 from ehrql.query_model.column_specs import ColumnSpec
@@ -34,3 +35,14 @@ def test_write_dataset_arrow(tmp_path):
     # This column has categories, but it's not a string so we shouldn't encode it as a
     # dictionary
     assert not pyarrow.types.is_dictionary(table.column("risk_score").type)
+
+
+def test_write_dataset_arrow_annotates_errors_with_column(tmp_path):
+    filename = tmp_path / "file.arrow"
+    column_specs = {
+        "value": ColumnSpec(int, min_value=0, max_value=100),
+    }
+    results = [(-1,)]
+    with pytest.raises(OverflowError) as exc:
+        write_dataset(filename, results, column_specs)
+    assert "Error when writing column 'value'" in exc.value.__notes__

--- a/tests/integration/file_formats/test_arrow.py
+++ b/tests/integration/file_formats/test_arrow.py
@@ -46,3 +46,16 @@ def test_write_dataset_arrow_annotates_errors_with_column(tmp_path):
     with pytest.raises(OverflowError) as exc:
         write_dataset(filename, results, column_specs)
     assert "Error when writing column 'value'" in exc.value.__notes__
+
+
+def test_write_dataset_arrow_raises_helpful_dictionary_errors(tmp_path):
+    filename = tmp_path / "file.arrow"
+    column_specs = {
+        "category": ColumnSpec(str, categories=("A", "B", "C")),
+    }
+    results = [("D",)]
+    with pytest.raises(
+        ValueError,
+        match="Invalid value 'D' for column 'category'\nAllowed are: 'A', 'B', 'C'",
+    ):
+        write_dataset(filename, results, column_specs)


### PR DESCRIPTION
For all errors we now annotate them with the name of the column they occurred in to make debugging a bit easier.

For unexpected values in categorical columns we now show the column name, value, and the list of allowed values.