### PR TITLE
Fix date-sensitive test that stated failing today

### DIFF
--- a/ehrql/dummy_data/generator.py
+++ b/ehrql/dummy_data/generator.py
@@ -33,14 +33,19 @@ class DummyDataGenerator:
         batch_size=5000,
         random_seed="BwRV3spP",
         timeout=60,
+        today=None,
     ):
         self.variable_definitions = variable_definitions
         self.population_size = population_size
         self.batch_size = batch_size
         self.random_seed = random_seed
         self.timeout = timeout
+        # TODO: I dislike using today's date as part of the data generation because it
+        # makes the results non-deterministic. However until we're able to infer a
+        # suitable time range by inspecting the query, this will have to do.
+        self.today = today if today is not None else date.today()
         self.patient_generator = DummyPatientGenerator(
-            self.variable_definitions, self.random_seed
+            self.variable_definitions, self.random_seed, self.today
         )
 
     def get_tables(self):
@@ -141,13 +146,10 @@ class DummyDataGenerator:
 
 
 class DummyPatientGenerator:
-    def __init__(self, variable_definitions, random_seed):
-        # TODO: I dislike using today's date as part of the data generation because it
-        # makes the results non-deterministic. However until we're able to infer a
-        # suitable time range by inspecting the query, this will have to do.
-        self.today = date.today()
+    def __init__(self, variable_definitions, random_seed, today):
         self.rnd = random.Random()
         self.random_seed = random_seed
+        self.today = today
 
         self.query_info = QueryInfo.from_variable_definitions(variable_definitions)
         # Create ORM classes for each of the tables used in the dataset definition

--- a/ehrql/main.py
+++ b/ehrql/main.py
@@ -330,9 +330,8 @@ def generate_measures_with_dummy_data(
         query_engine = LocalFileQueryEngine(dummy_tables_path)
         results = get_measure_results(query_engine, measure_definitions)
     else:
-        results = DummyMeasuresDataGenerator(
-            measure_definitions, dummy_data_config
-        ).get_results()
+        generator = DummyMeasuresDataGenerator(measure_definitions, dummy_data_config)
+        results = generator.get_results()
 
     log.info("Calculating measures and writing results")
     if disclosure_control_config.enabled:

--- a/ehrql/measures/dummy_data.py
+++ b/ehrql/measures/dummy_data.py
@@ -14,12 +14,13 @@ from ehrql.query_model.nodes import Function
 
 
 class DummyMeasuresDataGenerator:
-    def __init__(self, measures, dummy_data_config):
+    def __init__(self, measures, dummy_data_config, **kwargs):
         self.measures = measures
         combined = CombinedMeasureComponents.from_measures(measures)
         self.generator = DummyDataGenerator(
             get_dataset_variables(combined),
             population_size=get_population_size(dummy_data_config, combined),
+            **kwargs,
         )
 
     def get_data(self):

--- a/tests/unit/dummy_data/test_generator.py
+++ b/tests/unit/dummy_data/test_generator.py
@@ -272,7 +272,11 @@ def dummy_patient_generator():
     dataset = Dataset()
     dataset.define_population(patients.exists_for_patient())
     variable_definitions = compile(dataset)
-    generator = DummyPatientGenerator(variable_definitions, random_seed="abc")
+    generator = DummyPatientGenerator(
+        variable_definitions,
+        random_seed="abc",
+        today=datetime.date(2024, 1, 1),
+    )
     generator.generate_patient_facts(patient_id=1)
     # Ensure that this patient has a long enough history that we get a sensible
     # distribution of event dates (the fixed random seed above should ensure that the

--- a/tests/unit/measures/test_dummy_data.py
+++ b/tests/unit/measures/test_dummy_data.py
@@ -52,7 +52,9 @@ def test_dummy_measures_data_generator():
         intervals=intervals,
     )
 
-    generator = DummyMeasuresDataGenerator(measures, measures.dummy_data_config)
+    generator = DummyMeasuresDataGenerator(
+        measures, measures.dummy_data_config, today=date(2024, 1, 1)
+    )
     results = list(generator.get_results())
 
     # Check we generated the right number of rows: 2 rows for each breakdown by sex, 3

--- a/tests/unit/measures/test_dummy_data.py
+++ b/tests/unit/measures/test_dummy_data.py
@@ -69,8 +69,8 @@ def test_dummy_measures_data_generator():
     numerators = [row[4] for row in results]
     denominators = [row[5] for row in results]
 
-    assert all(v > 0 for v in numerators)
-    assert all(v > 0 for v in denominators)
+    assert all([v > 0 for v in numerators])
+    assert all([v > 0 for v in denominators])
 
 
 def test_population_is_nonzero_when_no_groups():

--- a/tests/unit/measures/test_dummy_data.py
+++ b/tests/unit/measures/test_dummy_data.py
@@ -52,10 +52,8 @@ def test_dummy_measures_data_generator():
         intervals=intervals,
     )
 
-    results = DummyMeasuresDataGenerator(
-        measures, measures.dummy_data_config
-    ).get_results()
-    results = list(results)
+    generator = DummyMeasuresDataGenerator(measures, measures.dummy_data_config)
+    results = list(generator.get_results())
 
     # Check we generated the right number of rows: 2 rows for each breakdown by sex, 3
     # for each breakdown by region

--- a/tests/unit/measures/test_dummy_data.py
+++ b/tests/unit/measures/test_dummy_data.py
@@ -88,17 +88,12 @@ def test_population_is_nonzero_when_no_groups():
 
 
 def test_configured_population_size():
-    events_in_interval = events.where(events.date.is_during(INTERVAL))
-    had_event = events_in_interval.exists_for_patient()
-    intervals = years(2).starting_on("2020-01-01")
     measures = Measures()
-
     measures.define_measure(
-        "had_event_by_region",
-        numerator=had_event,
+        "had_event",
+        numerator=events.exists_for_patient(),
         denominator=patients.exists_for_patient(),
-        group_by=dict(region=patients.region),
-        intervals=intervals,
+        intervals=years(1).starting_on("2020-01-01"),
     )
 
     measures.configure_dummy_data(population_size=10)


### PR DESCRIPTION
Past-Dave helpfully observed:
> TODO: I dislike using today's date as part of the data generation because it makes the results non-deterministic.

The amusingly manifested itself at midnight last night when the below test started failing:
https://github.com/opensafely-core/ehrql/blob/804c159a99332ef70a89bc82e023bffd6b13e3a4/tests/unit/measures/test_dummy_data.py#L31-L38

This is because the test uses fixed date intervals but the dummy data generator was producing events relative to today's date, meaning that as time went on the proportion of these events falling in the required intervals got smaller. Today it reached zero in one interval and test failed.

We now support supplying the "origin date" as an argument to the dummy data generator.

Amusing side note: this problem manifested itself on 29 February but, almost unbelievably, it is _not_ a leap year bug. Given the particular random seed and exponential distribution we have chosen for dates, the tests fails 1520 days after the measure start date. And it _just so happens_ that 1520 days after 2020-01-01 (a natural choice for start date) is 29 Feb.