### PR TITLE
Extend gentests' ignored error list

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -110,7 +110,7 @@ black *args=".": devenv
     $BIN/black --check {{ args }}
 
 ruff *args=".": devenv
-    $BIN/ruff {{ args }}
+    $BIN/ruff check {{ args }}
 
 # runs the various dev checks but does not change any files
 check *args: devenv black ruff
@@ -120,7 +120,7 @@ check *args: devenv black ruff
 # runs the format (black) and other code linting (ruff) checks and fixes the files
 fix: devenv
     $BIN/black .
-    $BIN/ruff --fix .
+    $BIN/ruff check --fix .
 
 
 # build the ehrql docker image

--- a/tests/generative/ignored_errors.py
+++ b/tests/generative/ignored_errors.py
@@ -88,6 +88,11 @@ IGNORED_ERRORS = {
             sqlalchemy.exc.OperationalError,
             re.compile(".+Arithmetic overflow error for type int.+"),
         ),
+        # Trino
+        (
+            sqlalchemy.exc.DBAPIError,
+            re.compile(r".+TrinoQueryError.+Value \w+ exceeds MAX_INT.+"),
+        ),
     ],
     IgnoredError.DATE_OVERFLOW: [
         # The variable strategy will sometimes result in date operations that construct


### PR DESCRIPTION
The previous night's run uncovered a new sort of arithmetic overflow error from Trino which is not an interesting sort of failure.