### PR TITLE
Bump Trino version

### DIFF
--- a/tests/lib/databases.py
+++ b/tests/lib/databases.py
@@ -313,7 +313,7 @@ def run_trino(container_name, containers, trino_port):  # pragma: no cover
         # This is the version which happened to be current at the time of writing and is
         # pinned for reproduciblity's sake rather than because there's anything
         # significant about it
-        image="trinodb/trino:425",
+        image="trinodb/trino:440",
         volumes={
             TRINO_SETUP_DIR: {"bind": "/trino", "mode": "ro"},
             f"{TRINO_SETUP_DIR}/etc": {"bind": "/etc/trino", "mode": "ro"},


### PR DESCRIPTION
The previously specified version was chosen arbitrarily: it was just the most recent version at the point when development started on the Trino query engine.

However, this version contains the bug identified in #1715 and Hypothesis keeps rediscovering this bug which devalues the generative tests.

Eventually we wil need to resolve the question of exactly what EMIS are running in production and ensure we're testing against that. But for now there's no benefit to not using the latest version.