### PR TITLE
Fix awkward line spacing in ehrQL tutorial

### DIFF
--- a/docs/tutorial/writing-a-more-complex-dataset-definition/index.md
+++ b/docs/tutorial/writing-a-more-complex-dataset-definition/index.md
@@ -282,13 +282,7 @@ ethnicity_codelist = codelist_from_csv(
 )
 ```
 
-Notice that because we specified `column` and `category_column`,
-
-```python
-ethnicity_codelist
-```
-
-shows pairs of codes and groups.
+Notice that because we specified `column` and `category_column`, `ethnicity_codelist` shows pairs of codes and groups.
 
 !!! tip "Dictionaries"
     `ethnicity_codelist` is a *dictionary*, or a data structure that maps from unique keys to values.

--- a/docs/tutorial/writing-a-more-complex-dataset-definition/index.md
+++ b/docs/tutorial/writing-a-more-complex-dataset-definition/index.md
@@ -366,13 +366,7 @@ asthma_inhaler_codelist = codelist_from_csv(
 )
 ```
 
-Notice that because we specified only `column`,
-
-```python
-asthma_inhaler_codelist
-```
-
-shows only codes.
+Notice that because we specified only `column`, `asthma_inhaler_codelist` shows only codes.
 
 Next, we import the `medications` table.
 


### PR DESCRIPTION
This section of the tutorial caused some stumbling during a recent run-through. I'm not sure why the reference to the created asthma codelist variable needed a big code block that broke the flow of this sentence. @evansd  also spotted a similarly disjointed layout for the ethnicity codelist variable which has also been fixed.