### PR TITLE
Expose SystmOne "go live" date and explain when to use it

### DIFF
--- a/ehrql/backends/tpp.py
+++ b/ehrql/backends/tpp.py
@@ -764,7 +764,8 @@ class TPPBackend(SQLBackend):
                 CAST(NULLIF(reg.EndDate, '9999-12-31T00:00:00') AS date) AS end_date,
                 org.Organisation_ID AS practice_pseudo_id,
                 NULLIF(org.STPCode, '') AS practice_stp,
-                NULLIF(org.Region, '') AS practice_nuts1_region_name
+                NULLIF(org.Region, '') AS practice_nuts1_region_name,
+                CAST(org.GoLiveDate AS date) AS practice_systmone_go_live_date
             FROM RegistrationHistory AS reg
             LEFT OUTER JOIN Organisation AS org
             ON reg.Organisation_ID = org.Organisation_ID

--- a/ehrql/tables/tpp.py
+++ b/ehrql/tables/tpp.py
@@ -360,10 +360,32 @@ class appointments(EventFrame):
     Appointments in primary care.
 
     !!! warning
-        When a patient moves practice,
-        their appointment history is deleted.
+        In TPP this data comes from the "Appointment" table. This table has not yet been
+        well characterised, so there are some issues around how to interpret findings
+        from it. The data contains records created when an appointment is made with a GP
+        practice, but may not capture absolutely all GP/patient interactions, for
+        example it's uncertain whether an ad-hoc call to a patient would be included.
+        There are also duplicate events in the table that we need to better understand.
 
-    You can find out more about [the associated database table][appointments_5] in the [short data report][appointments_1].
+        As a consequence, if you try to use the appointment table, you will see warnings
+        when running your code locally, and failures when the GitHub action tests your
+        code. If you need access to the appointments data, please speak to your
+        OpenSAFELY co-pilot. We will be considering projects on a case by case basis
+        until it can enter the normal stable pool of data.
+
+        A **very important** caveat for this data: there are some circumstances where
+        historical appointment records will be incomplete, for example when a patient
+        moves from a practice using a different EHR provider, or when a practice changes
+        EHR provider. If your study could be negatively affected by such missing data,
+        it may be important to use the
+        [`practice_registrations.spanning_with_systmone()`](#practice_registrations.spanning_with_systmone)
+        method to identify patients which have a suitably continuous practice
+        registration during the study period.
+
+    Some further investigation of the appointments data in TPP can be found in [this
+    King's fund report](https://www.kingsfund.org.uk/blog/2016/05/crisis-general-practice).
+
+    And you can find out more about [the associated database table][appointments_5] in the [short data report][appointments_1].
     It shows:
 
     * Date ranges for `booked_date`, `start_date`, and `seen_date`

--- a/ehrql/tables/tpp.py
+++ b/ehrql/tables/tpp.py
@@ -1233,6 +1233,17 @@ class practice_registrations(EventFrame):
             & (self.end_date.is_after(end_date) | self.end_date.is_null())
         )
 
+    def spanning_with_systmone(self, start_date, end_date):
+        """
+        Filter registrations to just those spanning the entire period between
+        `start_date` and `end_date` _and_ where the practice has been using the SystmOne
+        EHR platform throughout that period (see
+        [`systmone_go_live_date`](#practice_registrations.practice_systmone_go_live_date)).
+        """
+        return self.spanning(start_date, end_date).where(
+            self.practice_systmone_go_live_date <= start_date
+        )
+
 
 @table
 class sgss_covid_all_tests(EventFrame):

--- a/ehrql/tables/tpp.py
+++ b/ehrql/tables/tpp.py
@@ -1192,6 +1192,17 @@ class practice_registrations(EventFrame):
             <https://www.ons.gov.uk/methodology/geography/ukgeographies/eurostat>
         """,
     )
+    practice_systmone_go_live_date = Series(
+        datetime.date,
+        description="""
+            Date on which the practice started using the SystmOne EHR platform.
+
+            Most patient records will have been transferred from the previous EHR
+            platform but records which are specific to SystmOne will not exist before
+            this date. In particular, the [appointments](#appointments) table should
+            only be considered accurate for a given practice _after_ this date.
+        """,
+    )
 
     def for_patient_on(self, date):
         """

--- a/tests/integration/backends/test_tpp.py
+++ b/tests/integration/backends/test_tpp.py
@@ -1728,8 +1728,18 @@ def test_patients(select_all_tpp):
 def test_practice_registrations(select_all_tpp):
     results = select_all_tpp(
         Patient(Patient_ID=1),
-        Organisation(Organisation_ID=2, STPCode="abc", Region="def"),
-        Organisation(Organisation_ID=3, STPCode="", Region=""),
+        Organisation(
+            Organisation_ID=2,
+            STPCode="abc",
+            Region="def",
+            GoLiveDate="2005-10-20T15:16:17",
+        ),
+        Organisation(
+            Organisation_ID=3,
+            STPCode="",
+            Region="",
+            GoLiveDate="2021-05-06T04:05:06",
+        ),
         RegistrationHistory(
             Patient_ID=1,
             StartDate=date(2010, 1, 1),
@@ -1751,6 +1761,7 @@ def test_practice_registrations(select_all_tpp):
             "practice_pseudo_id": 2,
             "practice_stp": "abc",
             "practice_nuts1_region_name": "def",
+            "practice_systmone_go_live_date": date(2005, 10, 20),
         },
         {
             "patient_id": 1,
@@ -1759,6 +1770,7 @@ def test_practice_registrations(select_all_tpp):
             "practice_pseudo_id": 3,
             "practice_stp": None,
             "practice_nuts1_region_name": None,
+            "practice_systmone_go_live_date": date(2021, 5, 6),
         },
     ]
 


### PR DESCRIPTION
The new warning text was supplied by Alex and is visible here:
https://evansd-appointments-warning.databuilder.pages.dev/reference/schemas/tpp/#appointments

And you can follow links from there to the new method and new field. 

Closes #1982