### PR TITLE
Expose `consultation_id` on TPP `medications` table

### DIFF
--- a/docs/includes/generated_docs/schemas/core.md
+++ b/docs/includes/generated_docs/schemas/core.md
@@ -69,7 +69,7 @@ As such, codelists should include all relevant inactive codes.
 <p class="dimension-indicator"><code>many rows per patient</code></p>
 ## medications
 
-The medication table provides data about prescribed medications in primary care.
+The medications table provides data about prescribed medications in primary care.
 
 Prescribing data, including the contents of the medications table are standardised
 across clinical information systems such as SystmOne (TPP). This is a requirement

--- a/docs/includes/generated_docs/schemas/emis.md
+++ b/docs/includes/generated_docs/schemas/emis.md
@@ -70,7 +70,7 @@ As such, codelists should include all relevant inactive codes.
 <p class="dimension-indicator"><code>many rows per patient</code></p>
 ## medications
 
-The medication table provides data about prescribed medications in primary care.
+The medications table provides data about prescribed medications in primary care.
 
 Prescribing data, including the contents of the medications table are standardised
 across clinical information systems such as SystmOne (TPP). This is a requirement

--- a/docs/includes/generated_docs/schemas/tpp.md
+++ b/docs/includes/generated_docs/schemas/tpp.md
@@ -723,6 +723,18 @@ referrals are recorded in the clinical events table but this data will be incomp
   </dd>
 </div>
 
+<div markdown="block">
+  <dt id="clinical_events.consultation_id">
+    <strong>consultation_id</strong>
+    <a class="headerlink" href="#clinical_events.consultation_id" title="Permanent link">🔗</a>
+    <code>integer</code>
+  </dt>
+  <dd markdown="block">
+ID of the consultation associated with this event
+
+  </dd>
+</div>
+
   </dl>
 </div>
 
@@ -801,7 +813,8 @@ These additional fields are:
     <code>float</code>
   </dt>
   <dd markdown="block">
-The lower bound of the reference range associated with an event's numeric_value
+The lower bound of the reference range associated with an event's
+numeric_value
 
   </dd>
 </div>
@@ -813,7 +826,8 @@ The lower bound of the reference range associated with an event's numeric_value
     <code>float</code>
   </dt>
   <dd markdown="block">
-The upper bound of the reference range associated with an event's numeric_value
+The upper bound of the reference range associated with an event's
+numeric_value
 
   </dd>
 </div>
@@ -825,9 +839,22 @@ The upper bound of the reference range associated with an event's numeric_value
     <code>string</code>
   </dt>
   <dd markdown="block">
-If an event's numeric_value is returned with a comparator, e.g. as '<9.5', then this column contains that comparator
+If an event's numeric_value is returned with a comparator, e.g. as '<9.5',
+then this column contains that comparator
 
  * Possible values: `~`, `=`, `>=`, `>`, `<`, `<=`
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="clinical_events_ranges.consultation_id">
+    <strong>consultation_id</strong>
+    <a class="headerlink" href="#clinical_events_ranges.consultation_id" title="Permanent link">🔗</a>
+    <code>integer</code>
+  </dt>
+  <dd markdown="block">
+ID of the consultation associated with this event
+
   </dd>
 </div>
 
@@ -1400,7 +1427,7 @@ undocumented algorithm.
 <p class="dimension-indicator"><code>many rows per patient</code></p>
 ## medications
 
-The medication table provides data about prescribed medications in primary care.
+The medications table provides data about prescribed medications in primary care.
 
 Prescribing data, including the contents of the medications table are standardised
 across clinical information systems such as SystmOne (TPP). This is a requirement
@@ -1453,6 +1480,18 @@ on how to
   </dt>
   <dd markdown="block">
 
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="medications.consultation_id">
+    <strong>consultation_id</strong>
+    <a class="headerlink" href="#medications.consultation_id" title="Permanent link">🔗</a>
+    <code>integer</code>
+  </dt>
+  <dd markdown="block">
+ID of the consultation associated with this event
 
   </dd>
 </div>

--- a/ehrql/backends/tpp.py
+++ b/ehrql/backends/tpp.py
@@ -260,6 +260,7 @@ class TPPBackend(SQLBackend):
                 NULL AS snomedct_code,
                 CTV3Code AS ctv3_code,
                 NumericValue AS numeric_value,
+                Consultation_ID AS consultation_id,
                 CodedEvent_ID
             FROM CodedEvent
             UNION ALL
@@ -269,6 +270,7 @@ class TPPBackend(SQLBackend):
                 ConceptId AS snomedct_code,
                 NULL AS ctv3_code,
                 NumericValue AS numeric_value,
+                Consultation_ID AS consultation_id,
                 CodedEvent_ID
             FROM CodedEvent_SNOMED
         """
@@ -574,7 +576,8 @@ class TPPBackend(SQLBackend):
             SELECT
                 meds.Patient_ID AS patient_id,
                 CAST(meds.ConsultationDate AS date) AS date,
-                dict.DMD_ID AS dmd_code
+                dict.DMD_ID AS dmd_code,
+                Consultation_ID AS consultation_id
             FROM MedicationIssue AS meds
             LEFT JOIN ({medication_dictionary_query}) AS dict
             ON meds.MultilexDrug_ID = dict.MultilexDrug_ID

--- a/ehrql/query_language.py
+++ b/ehrql/query_language.py
@@ -1370,6 +1370,7 @@ class Series:
     def __init__(
         self,
         type_,
+        *,
         description="",
         constraints=(),
         required=True,

--- a/ehrql/query_language.py
+++ b/ehrql/query_language.py
@@ -1294,12 +1294,11 @@ def get_all_series_from_class(cls):
 # the classes, and having the classes themselves in the module namespaces only makes
 # autocomplete more confusing and error prone.
 def table(cls):
-    try:
-        qm_class = {
-            (PatientFrame,): qm.SelectPatientTable,
-            (EventFrame,): qm.SelectTable,
-        }[cls.__bases__]
-    except KeyError:
+    if PatientFrame in cls.__mro__:
+        qm_class = qm.SelectPatientTable
+    elif EventFrame in cls.__mro__:
+        qm_class = qm.SelectTable
+    else:
         raise Error("Schema class must subclass either `PatientFrame` or `EventFrame`")
 
     qm_node = qm_class(

--- a/ehrql/tables/core.py
+++ b/ehrql/tables/core.py
@@ -218,7 +218,7 @@ class clinical_events(EventFrame):
 @table
 class medications(EventFrame):
     """
-    The medication table provides data about prescribed medications in primary care.
+    The medications table provides data about prescribed medications in primary care.
 
     Prescribing data, including the contents of the medications table are standardised
     across clinical information systems such as SystmOne (TPP). This is a requirement

--- a/ehrql/tables/tpp.py
+++ b/ehrql/tables/tpp.py
@@ -6,8 +6,9 @@ OpenSAFELY-TPP backend. For more information about this backend, see
 
 import datetime
 
+import ehrql.tables.core
 from ehrql import case, when
-from ehrql.codes import CTV3Code, DMDCode, ICD10Code, OPCS4Code, SNOMEDCTCode
+from ehrql.codes import CTV3Code, ICD10Code, OPCS4Code, SNOMEDCTCode
 from ehrql.tables import Constraint, EventFrame, PatientFrame, Series, table
 from ehrql.tables.core import patients
 
@@ -672,7 +673,7 @@ class household_memberships_2020(PatientFrame):
 
 
 @table
-class medications(EventFrame):
+class medications(ehrql.tables.core.medications.__class__):
     """
     The medications table provides data about prescribed medications in primary care.
 
@@ -706,8 +707,6 @@ class medications(EventFrame):
     [use ehrQL to answer specific questions](../../how-to/examples.md#excluding-medications-for-patients-who-have-transferred-between-practices).
     """
 
-    date = Series(datetime.date)
-    dmd_code = Series(DMDCode)
     consultation_id = Series(
         int, description="ID of the consultation associated with this event"
     )

--- a/ehrql/tables/tpp.py
+++ b/ehrql/tables/tpp.py
@@ -7,9 +7,9 @@ OpenSAFELY-TPP backend. For more information about this backend, see
 import datetime
 
 from ehrql import case, when
-from ehrql.codes import CTV3Code, ICD10Code, OPCS4Code, SNOMEDCTCode
+from ehrql.codes import CTV3Code, DMDCode, ICD10Code, OPCS4Code, SNOMEDCTCode
 from ehrql.tables import Constraint, EventFrame, PatientFrame, Series, table
-from ehrql.tables.core import medications, patients
+from ehrql.tables.core import patients
 
 
 __all__ = [
@@ -463,6 +463,9 @@ class clinical_events(EventFrame):
     snomedct_code = Series(SNOMEDCTCode)
     ctv3_code = Series(CTV3Code)
     numeric_value = Series(float)
+    consultation_id = Series(
+        int, description="ID of the consultation associated with this event"
+    )
 
 
 @table
@@ -520,6 +523,9 @@ class clinical_events_ranges(EventFrame):
                 ]
             )
         ],
+    )
+    consultation_id = Series(
+        int, description="ID of the consultation associated with this event"
     )
 
 
@@ -663,6 +669,48 @@ class household_memberships_2020(PatientFrame):
 
     household_pseudo_id = Series(int)
     household_size = Series(int)
+
+
+@table
+class medications(EventFrame):
+    """
+    The medications table provides data about prescribed medications in primary care.
+
+    Prescribing data, including the contents of the medications table are standardised
+    across clinical information systems such as SystmOne (TPP). This is a requirement
+    for data transfer through the
+    [Electronic Prescription Service](https://digital.nhs.uk/services/electronic-prescription-service/)
+    in which data passes from the prescriber to the pharmacy for dispensing.
+
+    Medications are coded using
+    [dm+d codes](https://www.bennett.ox.ac.uk/blog/2019/08/what-is-the-dm-d-the-nhs-dictionary-of-medicines-and-devices/).
+    The medications table is structured similarly to the [clinical_events](#clinical_events)
+    table, and each row in the table is made up of a patient identifier, an event (dm+d)
+    code, and an event date. For this table, the event refers to the issue of a medication
+    (coded as a dm+d code), and the event date, the date the prescription was issued.
+
+    ### Factors to consider when using medications data
+
+    Depending on the specific area of research, you may wish to exclude medications
+    in particular periods. For example, in order to ensure medication data is stable
+    following a change of practice, you may want to exclude patients for a period after
+    the start of their practice registration . You may also want to
+    exclude medications for patients for a period prior to their leaving a practice.
+    Alternatively, for research looking at a specific period of
+    interest, you may simply want to ensure that all included patients were registered
+    at a single practice for a minimum time prior to the study period, and were
+    registered at the same practice for the duration of the study period.
+
+    Examples of using ehrQL to calculation such periods can be found in the documentation
+    on how to
+    [use ehrQL to answer specific questions](../../how-to/examples.md#excluding-medications-for-patients-who-have-transferred-between-practices).
+    """
+
+    date = Series(datetime.date)
+    dmd_code = Series(DMDCode)
+    consultation_id = Series(
+        int, description="ID of the consultation associated with this event"
+    )
 
 
 @table

--- a/ehrql/tables/tpp.py
+++ b/ehrql/tables/tpp.py
@@ -490,18 +490,24 @@ class clinical_events_ranges(EventFrame):
     numeric_value = Series(float)
     lower_bound = Series(
         float,
-        "The lower bound of the reference range associated with an event's numeric_value",
+        description="""
+            The lower bound of the reference range associated with an event's
+            numeric_value
+        """,
     )
     upper_bound = Series(
         float,
-        "The upper bound of the reference range associated with an event's numeric_value",
+        description="""
+            The upper bound of the reference range associated with an event's
+            numeric_value
+        """,
     )
     comparator = Series(
         str,
-        description=(
-            "If an event's numeric_value is returned with a comparator, "
-            "e.g. as '<9.5', then this column contains that comparator"
-        ),
+        description="""
+            If an event's numeric_value is returned with a comparator, e.g. as '<9.5',
+            then this column contains that comparator
+        """,
         constraints=[
             Constraint.Categorical(
                 [

--- a/tests/integration/backends/test_tpp.py
+++ b/tests/integration/backends/test_tpp.py
@@ -451,18 +451,21 @@ def test_clinical_events(select_all_tpp):
             ConsultationDate="2020-10-20T14:30:05",
             CTV3Code="xyz",
             NumericValue=0.5,
+            Consultation_ID=1234,
         ),
         CodedEvent_SNOMED(
             Patient_ID=1,
             ConsultationDate="2020-11-21T09:30:00",
             ConceptId="ijk",
             NumericValue=1.5,
+            Consultation_ID=1234,
         ),
         CodedEvent_SNOMED(
             Patient_ID=1,
             ConsultationDate="9999-12-31T00:00:00",
             ConceptId="lmn",
             NumericValue=None,
+            Consultation_ID=5678,
         ),
     )
     assert results == [
@@ -472,6 +475,7 @@ def test_clinical_events(select_all_tpp):
             "snomedct_code": None,
             "ctv3_code": "xyz",
             "numeric_value": 0.5,
+            "consultation_id": 1234,
         },
         {
             "patient_id": 1,
@@ -479,6 +483,7 @@ def test_clinical_events(select_all_tpp):
             "snomedct_code": "ijk",
             "ctv3_code": None,
             "numeric_value": 1.5,
+            "consultation_id": 1234,
         },
         {
             "patient_id": 1,
@@ -486,6 +491,7 @@ def test_clinical_events(select_all_tpp):
             "snomedct_code": "lmn",
             "ctv3_code": None,
             "numeric_value": None,
+            "consultation_id": 5678,
         },
     ]
 
@@ -500,6 +506,7 @@ def test_clinical_events_ranges(select_all_tpp):
             ConsultationDate="2020-10-20T14:30:05",
             CTV3Code="xyz",
             NumericValue=None,
+            Consultation_ID=1234,
         ),
         CodedEvent_SNOMED(
             Patient_ID=1,
@@ -507,6 +514,7 @@ def test_clinical_events_ranges(select_all_tpp):
             ConsultationDate="2020-11-21T09:30:00",
             ConceptId="ijk",
             NumericValue=1.5,
+            Consultation_ID=1234,
         ),
         CodedEvent(
             Patient_ID=1,
@@ -514,6 +522,7 @@ def test_clinical_events_ranges(select_all_tpp):
             ConsultationDate="2020-12-20T14:30:05",
             CTV3Code="xyz",
             NumericValue=None,
+            Consultation_ID=1234,
         ),
         CodedEvent_SNOMED(
             Patient_ID=1,
@@ -521,6 +530,7 @@ def test_clinical_events_ranges(select_all_tpp):
             ConsultationDate="2021-01-21T09:30:00",
             ConceptId="ijk",
             NumericValue=1.5,
+            Consultation_ID=1234,
         ),
         CodedEvent(
             Patient_ID=1,
@@ -528,6 +538,7 @@ def test_clinical_events_ranges(select_all_tpp):
             ConsultationDate="2021-02-20T14:30:05",
             CTV3Code="xyz",
             NumericValue=None,
+            Consultation_ID=1234,
         ),
         CodedEvent_SNOMED(
             Patient_ID=1,
@@ -535,6 +546,7 @@ def test_clinical_events_ranges(select_all_tpp):
             ConsultationDate="2021-03-21T09:30:00",
             ConceptId="ijk",
             NumericValue=1.5,
+            Consultation_ID=1234,
         ),
         CodedEventRange(
             Patient_ID=1,
@@ -589,6 +601,7 @@ def test_clinical_events_ranges(select_all_tpp):
             "comparator": "~",
             "lower_bound": 1.0,
             "upper_bound": 2.0,
+            "consultation_id": 1234,
         },
         {
             "patient_id": 1,
@@ -599,6 +612,7 @@ def test_clinical_events_ranges(select_all_tpp):
             "comparator": ">=",
             "lower_bound": 3.0,
             "upper_bound": 4.0,
+            "consultation_id": 1234,
         },
         {
             "patient_id": 1,
@@ -609,6 +623,7 @@ def test_clinical_events_ranges(select_all_tpp):
             "comparator": "<",
             "lower_bound": 5.0,
             "upper_bound": 6.0,
+            "consultation_id": 1234,
         },
         {
             "patient_id": 1,
@@ -619,6 +634,7 @@ def test_clinical_events_ranges(select_all_tpp):
             "comparator": "=",
             "lower_bound": 2.0,
             "upper_bound": 3.0,
+            "consultation_id": 1234,
         },
         {
             "patient_id": 1,
@@ -629,6 +645,7 @@ def test_clinical_events_ranges(select_all_tpp):
             "comparator": ">",
             "lower_bound": 4.0,
             "upper_bound": 5.0,
+            "consultation_id": 1234,
         },
         {
             "patient_id": 1,
@@ -639,6 +656,7 @@ def test_clinical_events_ranges(select_all_tpp):
             "comparator": "<=",
             "lower_bound": 6.0,
             "upper_bound": 7.0,
+            "consultation_id": 1234,
         },
     ]
 
@@ -1267,6 +1285,7 @@ def test_medications(select_all_tpp):
         MedicationIssue(
             Patient_ID=1,
             ConsultationDate="2020-05-15T10:10:10",
+            Consultation_ID=1234,
             MultilexDrug_ID="0;0;0",
         ),
         # MedicationIssue.MultilexDrug_ID found in CustomMedicationDictionary only
@@ -1274,6 +1293,7 @@ def test_medications(select_all_tpp):
         MedicationIssue(
             Patient_ID=1,
             ConsultationDate="2020-05-16T10:10:10",
+            Consultation_ID=1234,
             MultilexDrug_ID="2;0;0",
         ),
         # MedicationIssue.MultilexDrug_ID found in both; MedicationDictionary
@@ -1283,6 +1303,7 @@ def test_medications(select_all_tpp):
         MedicationIssue(
             Patient_ID=1,
             ConsultationDate="2020-05-17T10:10:10",
+            Consultation_ID=1234,
             MultilexDrug_ID="3;0;0",
         ),
         # MedicationIssue.MultilexDrug_ID found in both, but MedicationDictionary.DMD_ID
@@ -1292,6 +1313,7 @@ def test_medications(select_all_tpp):
         MedicationIssue(
             Patient_ID=1,
             ConsultationDate="2020-05-18T10:10:10",
+            Consultation_ID=1234,
             MultilexDrug_ID="5;0;0",
         ),
         # MedicationIssue.MultilexDrug_ID found in MedicationDictionary but DMD_ID
@@ -1300,6 +1322,7 @@ def test_medications(select_all_tpp):
         MedicationIssue(
             Patient_ID=1,
             ConsultationDate="2020-05-19T10:10:10",
+            Consultation_ID=1234,
             MultilexDrug_ID="6;0;0",
         ),
         # MedicationIssue.MultilexDrug_ID found in both, but MedicationDictionary.DMD_ID
@@ -1309,6 +1332,7 @@ def test_medications(select_all_tpp):
         MedicationIssue(
             Patient_ID=1,
             ConsultationDate="2020-05-20T10:10:10",
+            Consultation_ID=1234,
             MultilexDrug_ID="7;0;0",
         ),
     )
@@ -1317,31 +1341,37 @@ def test_medications(select_all_tpp):
             "patient_id": 1,
             "date": date(2020, 5, 15),
             "dmd_code": "100000",
+            "consultation_id": 1234,
         },
         {
             "patient_id": 1,
             "date": date(2020, 5, 16),
             "dmd_code": "200000",
+            "consultation_id": 1234,
         },
         {
             "patient_id": 1,
             "date": date(2020, 5, 17),
             "dmd_code": "300000",
+            "consultation_id": 1234,
         },
         {
             "patient_id": 1,
             "date": date(2020, 5, 18),
             "dmd_code": "500000",
+            "consultation_id": 1234,
         },
         {
             "patient_id": 1,
             "date": date(2020, 5, 19),
             "dmd_code": None,
+            "consultation_id": 1234,
         },
         {
             "patient_id": 1,
             "date": date(2020, 5, 20),
             "dmd_code": "700000",
+            "consultation_id": 1234,
         },
     ]
 

--- a/tests/unit/docs/test_schemas.py
+++ b/tests/unit/docs/test_schemas.py
@@ -1,0 +1,41 @@
+import pytest
+
+from ehrql.docs.schemas import get_table_docstring
+from ehrql.tables import EventFrame, Series, table
+
+
+def test_get_table_docstring():
+    @table
+    class parent_table(EventFrame):
+        "I have a docstring"
+        col_a = Series(str)
+
+    @table
+    class child_table(parent_table.__class__):
+        """
+        I have a docstring
+
+        With some extra stuff
+        """
+
+        col_b = Series(str)
+
+    assert (
+        get_table_docstring(child_table.__class__)
+        == "I have a docstring\n\nWith some extra stuff"
+    )
+
+
+def test_get_table_docstring_with_mismatch():
+    @table
+    class parent_table(EventFrame):
+        "I have a docstring"
+        col_a = Series(str)
+
+    @table
+    class child_table(parent_table.__class__):
+        "I have a different docstring"
+        col_b = Series(str)
+
+    with pytest.raises(ValueError):
+        get_table_docstring(child_table.__class__)

--- a/tests/unit/test_query_language.py
+++ b/tests/unit/test_query_language.py
@@ -396,12 +396,19 @@ def test_construct_enforces_correct_base_class():
             some_int = Series(int)
 
 
-def test_construct_enforces_exactly_one_base_class():
-    with pytest.raises(Error, match="Schema class must subclass"):
+def test_construct_supports_inheritance():
+    @table
+    class some_table(PatientFrame):
+        some_int = Series(int)
 
-        @table
-        class some_table(PatientFrame, Dataset):
-            some_int = Series(int)
+    @table
+    class child_table(some_table.__class__):
+        some_str = Series(str)
+
+    assert isinstance(child_table, PatientFrame)
+    assert child_table._qm_node.name == "child_table"
+    assert isinstance(child_table.some_int, IntPatientSeries)
+    assert isinstance(child_table.some_str, StrPatientSeries)
 
 
 def test_table_from_rows():


### PR DESCRIPTION
This requires us to create a TPP specialisation of existing core table. Obviously we can just do this by copy/pasting but I worry that this risks drift in the documentation. (Drift in the table structure itself is less of a worry as the backends will naturally enforce consistency for tables sharing the same name.) So I've made a slight tweak to the `@table` decorator to support table inheritance and added a mechanism to enforce docstring consistency.

Closes #1983