### PR TITLE
Expose `MedicationStatus` column in `medications` raw tables

### DIFF
--- a/docs/includes/generated_docs/schemas/raw.core.md
+++ b/docs/includes/generated_docs/schemas/raw.core.md
@@ -12,9 +12,114 @@ and data curation purposes.
 
 ``` {.python .copy title='To use this schema in an ehrQL file:'}
 from ehrql.tables.raw.core import (
+    medications,
     ons_deaths,
 )
 ```
+
+<p class="dimension-indicator"><code>many rows per patient</code></p>
+## medications
+
+The raw medication table provides data about prescribed medications in primary care together with the medication status.
+
+Prescribing data, including the contents of the medications table are standardised
+across clinical information systems such as SystmOne (TPP). This is a requirement
+for data transfer through the
+[Electronic Prescription Service](https://digital.nhs.uk/services/electronic-prescription-service/)
+in which data passes from the prescriber to the pharmacy for dispensing.
+
+Medications are coded using
+[dm+d codes](https://www.bennett.ox.ac.uk/blog/2019/08/what-is-the-dm-d-the-nhs-dictionary-of-medicines-and-devices/).
+The medications table is structured similarly to the [clinical_events](#clinical_events)
+table, and each row in the table is made up of a patient identifier, an event (dm+d)
+code, and an event date. For this table, the event refers to the issue of a medication
+(coded as a dm+d code), and the event date, the date the prescription was issued.
+
+### Factors to consider when using medications data
+
+Depending on the specific area of research, you may wish to exclude medications
+in particular periods. For example, in order to ensure medication data is stable
+following a change of practice, you may want to exclude patients for a period after
+the start of their practice registration . You may also want to
+exclude medications for patients for a period prior to their leaving a practice.
+Alternatively, for research looking at a specific period of
+interest, you may simply want to ensure that all included patients were registered
+at a single practice for a minimum time prior to the study period, and were
+registered at the same practice for the duration of the study period.
+
+Examples of using ehrQL to calculation such periods can be found in the documentation
+on how to
+[use ehrQL to answer specific questions](../../how-to/examples.md#excluding-medications-for-patients-who-have-transferred-between-practices).
+<div markdown="block" class="definition-list-wrapper">
+  <div class="title">Columns</div>
+  <dl markdown="block">
+<div markdown="block">
+  <dt id="medications.date">
+    <strong>date</strong>
+    <a class="headerlink" href="#medications.date" title="Permanent link">🔗</a>
+    <code>date</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="medications.dmd_code">
+    <strong>dmd_code</strong>
+    <a class="headerlink" href="#medications.dmd_code" title="Permanent link">🔗</a>
+    <code>dm+d code</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="medications.medication_status">
+    <strong>medication_status</strong>
+    <a class="headerlink" href="#medications.medication_status" title="Permanent link">🔗</a>
+    <code>integer</code>
+  </dt>
+  <dd markdown="block">
+Medication status. The values might map to the descriptions below from the data dictionary.
+Note that this still needs to be confirmed.
+
+* 0 - Normal
+* 4 - Historical
+* 5 - Blue script
+* 6 - Private
+* 7 - Not in possession
+* 8 - Repeat dispensed
+* 9 - In possession
+* 10 - Dental
+* 11 - Hospital
+* 12 - Problem substance
+* 13 - From patient group direction
+* 14 - To take out
+* 15 - On admission
+* 16 - Regular medication
+* 17 - As required medication
+* 18 - Variable dose medication
+* 19 - Rate-controlled single regular
+* 20 - Only once
+* 21 - Outpatient
+* 22 - Rate-controlled multiple regular
+* 23 - Rate-controlled multiple only once
+* 24 - Rate-controlled single only once
+* 25 - Placeholder
+* 26 - Unconfirmed
+* 27 - Infusion
+* 28 - Reducing dose blue script
+
+  </dd>
+</div>
+
+  </dl>
+</div>
+
 
 <p class="dimension-indicator"><code>many rows per patient</code></p>
 ## ons_deaths

--- a/docs/includes/generated_docs/schemas/raw.emis.md
+++ b/docs/includes/generated_docs/schemas/raw.emis.md
@@ -12,9 +12,114 @@ and data curation purposes.
 
 ``` {.python .copy title='To use this schema in an ehrQL file:'}
 from ehrql.tables.raw.emis import (
+    medications,
     ons_deaths,
 )
 ```
+
+<p class="dimension-indicator"><code>many rows per patient</code></p>
+## medications
+
+The raw medication table provides data about prescribed medications in primary care together with the medication status.
+
+Prescribing data, including the contents of the medications table are standardised
+across clinical information systems such as SystmOne (TPP). This is a requirement
+for data transfer through the
+[Electronic Prescription Service](https://digital.nhs.uk/services/electronic-prescription-service/)
+in which data passes from the prescriber to the pharmacy for dispensing.
+
+Medications are coded using
+[dm+d codes](https://www.bennett.ox.ac.uk/blog/2019/08/what-is-the-dm-d-the-nhs-dictionary-of-medicines-and-devices/).
+The medications table is structured similarly to the [clinical_events](#clinical_events)
+table, and each row in the table is made up of a patient identifier, an event (dm+d)
+code, and an event date. For this table, the event refers to the issue of a medication
+(coded as a dm+d code), and the event date, the date the prescription was issued.
+
+### Factors to consider when using medications data
+
+Depending on the specific area of research, you may wish to exclude medications
+in particular periods. For example, in order to ensure medication data is stable
+following a change of practice, you may want to exclude patients for a period after
+the start of their practice registration . You may also want to
+exclude medications for patients for a period prior to their leaving a practice.
+Alternatively, for research looking at a specific period of
+interest, you may simply want to ensure that all included patients were registered
+at a single practice for a minimum time prior to the study period, and were
+registered at the same practice for the duration of the study period.
+
+Examples of using ehrQL to calculation such periods can be found in the documentation
+on how to
+[use ehrQL to answer specific questions](../../how-to/examples.md#excluding-medications-for-patients-who-have-transferred-between-practices).
+<div markdown="block" class="definition-list-wrapper">
+  <div class="title">Columns</div>
+  <dl markdown="block">
+<div markdown="block">
+  <dt id="medications.date">
+    <strong>date</strong>
+    <a class="headerlink" href="#medications.date" title="Permanent link">🔗</a>
+    <code>date</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="medications.dmd_code">
+    <strong>dmd_code</strong>
+    <a class="headerlink" href="#medications.dmd_code" title="Permanent link">🔗</a>
+    <code>dm+d code</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="medications.medication_status">
+    <strong>medication_status</strong>
+    <a class="headerlink" href="#medications.medication_status" title="Permanent link">🔗</a>
+    <code>integer</code>
+  </dt>
+  <dd markdown="block">
+Medication status. The values might map to the descriptions below from the data dictionary.
+Note that this still needs to be confirmed.
+
+* 0 - Normal
+* 4 - Historical
+* 5 - Blue script
+* 6 - Private
+* 7 - Not in possession
+* 8 - Repeat dispensed
+* 9 - In possession
+* 10 - Dental
+* 11 - Hospital
+* 12 - Problem substance
+* 13 - From patient group direction
+* 14 - To take out
+* 15 - On admission
+* 16 - Regular medication
+* 17 - As required medication
+* 18 - Variable dose medication
+* 19 - Rate-controlled single regular
+* 20 - Only once
+* 21 - Outpatient
+* 22 - Rate-controlled multiple regular
+* 23 - Rate-controlled multiple only once
+* 24 - Rate-controlled single only once
+* 25 - Placeholder
+* 26 - Unconfirmed
+* 27 - Infusion
+* 28 - Reducing dose blue script
+
+  </dd>
+</div>
+
+  </dl>
+</div>
+
 
 <p class="dimension-indicator"><code>many rows per patient</code></p>
 ## ons_deaths

--- a/docs/includes/generated_docs/schemas/raw.tpp.md
+++ b/docs/includes/generated_docs/schemas/raw.tpp.md
@@ -16,6 +16,7 @@ from ehrql.tables.raw.tpp import (
     apcs_historical,
     covid_therapeutics_raw,
     isaric,
+    medications,
     ons_deaths,
     wl_clockstops,
     wl_openpathways,
@@ -1137,6 +1138,110 @@ Date of enrolment.
   </dt>
   <dd markdown="block">
 Outcome date.
+
+  </dd>
+</div>
+
+  </dl>
+</div>
+
+
+<p class="dimension-indicator"><code>many rows per patient</code></p>
+## medications
+
+The raw medication table provides data about prescribed medications in primary care together with the medication status.
+
+Prescribing data, including the contents of the medications table are standardised
+across clinical information systems such as SystmOne (TPP). This is a requirement
+for data transfer through the
+[Electronic Prescription Service](https://digital.nhs.uk/services/electronic-prescription-service/)
+in which data passes from the prescriber to the pharmacy for dispensing.
+
+Medications are coded using
+[dm+d codes](https://www.bennett.ox.ac.uk/blog/2019/08/what-is-the-dm-d-the-nhs-dictionary-of-medicines-and-devices/).
+The medications table is structured similarly to the [clinical_events](#clinical_events)
+table, and each row in the table is made up of a patient identifier, an event (dm+d)
+code, and an event date. For this table, the event refers to the issue of a medication
+(coded as a dm+d code), and the event date, the date the prescription was issued.
+
+### Factors to consider when using medications data
+
+Depending on the specific area of research, you may wish to exclude medications
+in particular periods. For example, in order to ensure medication data is stable
+following a change of practice, you may want to exclude patients for a period after
+the start of their practice registration . You may also want to
+exclude medications for patients for a period prior to their leaving a practice.
+Alternatively, for research looking at a specific period of
+interest, you may simply want to ensure that all included patients were registered
+at a single practice for a minimum time prior to the study period, and were
+registered at the same practice for the duration of the study period.
+
+Examples of using ehrQL to calculation such periods can be found in the documentation
+on how to
+[use ehrQL to answer specific questions](../../how-to/examples.md#excluding-medications-for-patients-who-have-transferred-between-practices).
+<div markdown="block" class="definition-list-wrapper">
+  <div class="title">Columns</div>
+  <dl markdown="block">
+<div markdown="block">
+  <dt id="medications.date">
+    <strong>date</strong>
+    <a class="headerlink" href="#medications.date" title="Permanent link">🔗</a>
+    <code>date</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="medications.dmd_code">
+    <strong>dmd_code</strong>
+    <a class="headerlink" href="#medications.dmd_code" title="Permanent link">🔗</a>
+    <code>dm+d code</code>
+  </dt>
+  <dd markdown="block">
+
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="medications.medication_status">
+    <strong>medication_status</strong>
+    <a class="headerlink" href="#medications.medication_status" title="Permanent link">🔗</a>
+    <code>integer</code>
+  </dt>
+  <dd markdown="block">
+Medication status. The values might map to the descriptions below from the data dictionary.
+Note that this still needs to be confirmed.
+
+* 0 - Normal
+* 4 - Historical
+* 5 - Blue script
+* 6 - Private
+* 7 - Not in possession
+* 8 - Repeat dispensed
+* 9 - In possession
+* 10 - Dental
+* 11 - Hospital
+* 12 - Problem substance
+* 13 - From patient group direction
+* 14 - To take out
+* 15 - On admission
+* 16 - Regular medication
+* 17 - As required medication
+* 18 - Variable dose medication
+* 19 - Rate-controlled single regular
+* 20 - Only once
+* 21 - Outpatient
+* 22 - Rate-controlled multiple regular
+* 23 - Rate-controlled multiple only once
+* 24 - Rate-controlled single only once
+* 25 - Placeholder
+* 26 - Unconfirmed
+* 27 - Infusion
+* 28 - Reducing dose blue script
 
   </dd>
 </div>

--- a/ehrql/backends/emis.py
+++ b/ehrql/backends/emis.py
@@ -113,6 +113,17 @@ class EMISBackend(SQLBackend):
         """
     )
 
+    medications_raw = QueryTable(
+        """
+        SELECT
+            registration_id AS patient_id,
+            CAST(effective_date AS date) as date,
+            CAST(snomed_concept_id AS varchar) AS dmd_code,
+            medication_status AS medication_status
+        FROM medication_all_orgs_v2
+        """
+    )
+
     medications = QueryTable(
         """
         SELECT

--- a/ehrql/tables/raw/core.py
+++ b/ehrql/tables/raw/core.py
@@ -10,11 +10,12 @@ and data curation purposes.
 
 import datetime
 
-from ehrql.codes import ICD10Code
+from ehrql.codes import DMDCode, ICD10Code
 from ehrql.tables import EventFrame, Series, table
 
 
 __all__ = [
+    "medications",
     "ons_deaths",
 ]
 
@@ -118,3 +119,78 @@ class ons_deaths_raw(EventFrame):
 
 
 ons_deaths = table(ons_deaths_raw)
+
+
+class medications_raw(EventFrame):
+    """
+    The raw medication table provides data about prescribed medications in primary care together with the medication status.
+
+    Prescribing data, including the contents of the medications table are standardised
+    across clinical information systems such as SystmOne (TPP). This is a requirement
+    for data transfer through the
+    [Electronic Prescription Service](https://digital.nhs.uk/services/electronic-prescription-service/)
+    in which data passes from the prescriber to the pharmacy for dispensing.
+
+    Medications are coded using
+    [dm+d codes](https://www.bennett.ox.ac.uk/blog/2019/08/what-is-the-dm-d-the-nhs-dictionary-of-medicines-and-devices/).
+    The medications table is structured similarly to the [clinical_events](#clinical_events)
+    table, and each row in the table is made up of a patient identifier, an event (dm+d)
+    code, and an event date. For this table, the event refers to the issue of a medication
+    (coded as a dm+d code), and the event date, the date the prescription was issued.
+
+    ### Factors to consider when using medications data
+
+    Depending on the specific area of research, you may wish to exclude medications
+    in particular periods. For example, in order to ensure medication data is stable
+    following a change of practice, you may want to exclude patients for a period after
+    the start of their practice registration . You may also want to
+    exclude medications for patients for a period prior to their leaving a practice.
+    Alternatively, for research looking at a specific period of
+    interest, you may simply want to ensure that all included patients were registered
+    at a single practice for a minimum time prior to the study period, and were
+    registered at the same practice for the duration of the study period.
+
+    Examples of using ehrQL to calculation such periods can be found in the documentation
+    on how to
+    [use ehrQL to answer specific questions](../../how-to/examples.md#excluding-medications-for-patients-who-have-transferred-between-practices).
+    """
+
+    date = Series(datetime.date)
+    dmd_code = Series(DMDCode)
+    medication_status = Series(
+        int,
+        description="""
+            Medication status. The values might map to the descriptions below from the data dictionary.
+            Note that this still needs to be confirmed.
+
+            * 0 - Normal
+            * 4 - Historical
+            * 5 - Blue script
+            * 6 - Private
+            * 7 - Not in possession
+            * 8 - Repeat dispensed
+            * 9 - In possession
+            * 10 - Dental
+            * 11 - Hospital
+            * 12 - Problem substance
+            * 13 - From patient group direction
+            * 14 - To take out
+            * 15 - On admission
+            * 16 - Regular medication
+            * 17 - As required medication
+            * 18 - Variable dose medication
+            * 19 - Rate-controlled single regular
+            * 20 - Only once
+            * 21 - Outpatient
+            * 22 - Rate-controlled multiple regular
+            * 23 - Rate-controlled multiple only once
+            * 24 - Rate-controlled single only once
+            * 25 - Placeholder
+            * 26 - Unconfirmed
+            * 27 - Infusion
+            * 28 - Reducing dose blue script
+        """,
+    )
+
+
+medications = table(medications_raw)

--- a/ehrql/tables/raw/emis.py
+++ b/ehrql/tables/raw/emis.py
@@ -8,9 +8,10 @@ data provided by the underlying database tables. They are provided for data deve
 and data curation purposes.
 """
 
-from ehrql.tables.raw.core import ons_deaths
+from ehrql.tables.raw.core import medications, ons_deaths
 
 
 __all__ = [
+    "medications",
     "ons_deaths",
 ]

--- a/ehrql/tables/raw/tpp.py
+++ b/ehrql/tables/raw/tpp.py
@@ -10,7 +10,7 @@ and data curation purposes.
 
 import datetime
 
-from ehrql.codes import ICD10Code
+from ehrql.codes import DMDCode, ICD10Code
 from ehrql.tables import Constraint, EventFrame, Series, table
 
 
@@ -19,6 +19,7 @@ __all__ = [
     "apcs_historical",
     "covid_therapeutics_raw",
     "isaric",
+    "medications",
     "ons_deaths",
     "wl_clockstops",
     "wl_openpathways",
@@ -742,3 +743,78 @@ class covid_therapeutics_raw(EventFrame):
         datetime.date,
         description="Date on which the current dataset was imported.",
     )
+
+
+class medications_raw(EventFrame):
+    """
+    The raw medication table provides data about prescribed medications in primary care together with the medication status.
+
+    Prescribing data, including the contents of the medications table are standardised
+    across clinical information systems such as SystmOne (TPP). This is a requirement
+    for data transfer through the
+    [Electronic Prescription Service](https://digital.nhs.uk/services/electronic-prescription-service/)
+    in which data passes from the prescriber to the pharmacy for dispensing.
+
+    Medications are coded using
+    [dm+d codes](https://www.bennett.ox.ac.uk/blog/2019/08/what-is-the-dm-d-the-nhs-dictionary-of-medicines-and-devices/).
+    The medications table is structured similarly to the [clinical_events](#clinical_events)
+    table, and each row in the table is made up of a patient identifier, an event (dm+d)
+    code, and an event date. For this table, the event refers to the issue of a medication
+    (coded as a dm+d code), and the event date, the date the prescription was issued.
+
+    ### Factors to consider when using medications data
+
+    Depending on the specific area of research, you may wish to exclude medications
+    in particular periods. For example, in order to ensure medication data is stable
+    following a change of practice, you may want to exclude patients for a period after
+    the start of their practice registration . You may also want to
+    exclude medications for patients for a period prior to their leaving a practice.
+    Alternatively, for research looking at a specific period of
+    interest, you may simply want to ensure that all included patients were registered
+    at a single practice for a minimum time prior to the study period, and were
+    registered at the same practice for the duration of the study period.
+
+    Examples of using ehrQL to calculation such periods can be found in the documentation
+    on how to
+    [use ehrQL to answer specific questions](../../how-to/examples.md#excluding-medications-for-patients-who-have-transferred-between-practices).
+    """
+
+    date = Series(datetime.date)
+    dmd_code = Series(DMDCode)
+    medication_status = Series(
+        int,
+        description="""
+            Medication status. The values might map to the descriptions below from the data dictionary.
+            Note that this still needs to be confirmed.
+
+            * 0 - Normal
+            * 4 - Historical
+            * 5 - Blue script
+            * 6 - Private
+            * 7 - Not in possession
+            * 8 - Repeat dispensed
+            * 9 - In possession
+            * 10 - Dental
+            * 11 - Hospital
+            * 12 - Problem substance
+            * 13 - From patient group direction
+            * 14 - To take out
+            * 15 - On admission
+            * 16 - Regular medication
+            * 17 - As required medication
+            * 18 - Variable dose medication
+            * 19 - Rate-controlled single regular
+            * 20 - Only once
+            * 21 - Outpatient
+            * 22 - Rate-controlled multiple regular
+            * 23 - Rate-controlled multiple only once
+            * 24 - Rate-controlled single only once
+            * 25 - Placeholder
+            * 26 - Unconfirmed
+            * 27 - Infusion
+            * 28 - Reducing dose blue script
+        """,
+    )
+
+
+medications = table(medications_raw)

--- a/tests/integration/backends/test_emis.py
+++ b/tests/integration/backends/test_emis.py
@@ -142,6 +142,39 @@ def test_medications(select_all_emis):
     ]
 
 
+@register_test_for(emis_raw.medications)
+def test_medications_raw(select_all_emis):
+    results = select_all_emis(
+        PatientAllOrgsV2(registration_id="1"),
+        PatientAllOrgsV2(registration_id="2"),
+        MedicationAllOrgsV2(
+            registration_id="1",
+            effective_date=datetime(2020, 10, 20, 14, 30, 5),
+            snomed_concept_id=123,
+            medication_status=1,
+        ),
+        MedicationAllOrgsV2(
+            registration_id="2",
+            effective_date=datetime(2022, 1, 15, 12, 30, 5),
+            snomed_concept_id=567,
+        ),
+    )
+    assert results == [
+        {
+            "patient_id": "1",
+            "date": date(2020, 10, 20),
+            "dmd_code": "123",
+            "medication_status": 1,
+        },
+        {
+            "patient_id": "2",
+            "date": date(2022, 1, 15),
+            "dmd_code": "567",
+            "medication_status": None,
+        },
+    ]
+
+
 @register_test_for(emis.ons_deaths)
 def test_ons_deaths(select_all_emis):
     results = select_all_emis(

--- a/tests/integration/backends/test_tpp.py
+++ b/tests/integration/backends/test_tpp.py
@@ -1258,6 +1258,43 @@ def test_isaric_raw_clinical_variables(select_all_tpp):
     ]
 
 
+@register_test_for(tpp_raw.medications)
+def test_medications_raw(select_all_tpp):
+    results = select_all_tpp(
+        Patient(Patient_ID=1),
+        # MedicationIssue.MultilexDrug_ID found in MedicationDictionary only
+        MedicationDictionary(MultilexDrug_ID="0;0;0", DMD_ID="100000"),
+        MedicationIssue(
+            Patient_ID=1,
+            ConsultationDate="2020-05-15T10:10:10",
+            MultilexDrug_ID="0;0;0",
+            MedicationStatus=1,
+        ),
+        # MedicationIssue.MultilexDrug_ID found in CustomMedicationDictionary only
+        CustomMedicationDictionary(MultilexDrug_ID="2;0;0", DMD_ID="200000"),
+        MedicationIssue(
+            Patient_ID=1,
+            ConsultationDate="2020-05-16T10:10:10",
+            MultilexDrug_ID="2;0;0",
+            MedicationStatus=None,
+        ),
+    )
+    assert results == [
+        {
+            "patient_id": 1,
+            "date": date(2020, 5, 15),
+            "dmd_code": "100000",
+            "medication_status": 1,
+        },
+        {
+            "patient_id": 1,
+            "date": date(2020, 5, 16),
+            "dmd_code": "200000",
+            "medication_status": None,
+        },
+    ]
+
+
 @register_test_for(tpp.medications)
 def test_medications(select_all_tpp):
     results = select_all_tpp(

--- a/tests/lib/emis_schema.py
+++ b/tests/lib/emis_schema.py
@@ -50,6 +50,7 @@ class MedicationAllOrgsV2(Base):
     registration_id = mapped_column(t.VARCHAR(128))
     snomed_concept_id = mapped_column(t.BigInteger)
     effective_date = mapped_column(t.DateTime)
+    medication_status = mapped_column(t.Integer)
 
 
 class OnsView(Base):


### PR DESCRIPTION
This adds raw `medications` tables for all backends and exposes the `MedicationStatus` field. I decided not to map the values to the descriptions from the data dictionary (see https://github.com/opensafely-core/ehrql/issues/1991#issuecomment-2076828972) yet as I think we should explore this more thoroughly first, but have added this to the description of the column.

Initially, I think we only need this in TPP and I'm not even sure if EMIS provides identical information. However, because this is a core table I just added this this to EMIS schema and pretend it exises. I assume this is not the best approach but couldn't find a better way to stop the tests failing. Also, I dont know what our current approach is for updating EMIS when we make changes to core tables?  

Closes #1991