### PR TITLE
Use batched inserts for `InsertMany`

### DIFF
--- a/tests/integration/utils/test_sqlalchemy_query_utils.py
+++ b/tests/integration/utils/test_sqlalchemy_query_utils.py
@@ -16,15 +16,15 @@ def test_insert_many(engine):
     if engine.name == "in_memory":
         pytest.skip("SQL tests do not apply to in-memory engine")
 
-    rows = [
-        (1, "a"),
-        (2, "b"),
-        (3, "c"),
-    ]
+    # We need enough rows that we exercise SQLAlchemy's internal batching logic, but not
+    # so many that we significantly slow down the test
+    rows = [(i, f"a{i}") for i in range(5000)]
+
     insert_many = InsertMany(
         table,
         # Test that we can handle an iterator rather than just a list
         iter(rows),
+        batch_size=2000,
     )
 
     with engine.sqlalchemy_engine().connect() as connection:

--- a/tests/integration/utils/test_sqlalchemy_query_utils.py
+++ b/tests/integration/utils/test_sqlalchemy_query_utils.py
@@ -29,10 +29,12 @@ def test_insert_many(engine):
 
     with engine.sqlalchemy_engine().connect() as connection:
         connection.execute(sqlalchemy.schema.CreateTable(table))
-        connection.execute(insert_many)
-        response = connection.execute(sqlalchemy.select(table))
-        results = list(response)
-        # Explicitly drop the table as it persists in the Trino engine
-        connection.execute(sqlalchemy.schema.DropTable(table))
+        try:
+            connection.execute(insert_many)
+            response = connection.execute(sqlalchemy.select(table))
+            results = list(response)
+        finally:
+            # Explicitly drop the table as it persists in the Trino engine
+            connection.execute(sqlalchemy.schema.DropTable(table))
 
     assert sorted(results) == rows


### PR DESCRIPTION
The `InsertMany` construct is most frequently used for codelists, which are small enough that it's not worth optimising. However it is also used for the `@table_from_file` feature where the row counts are much higher – and I have seen such inserts take 2 hours 40 minutes.

Using SQLAlchemy's batched inserts is about 10x faster on MSSQL, and about another order of magnitude faster again on Trino.

Closes #1934