### PR TITLE
Ignore out of range integers in generative tests

### DIFF
--- a/tests/generative/ignored_errors.py
+++ b/tests/generative/ignored_errors.py
@@ -99,6 +99,10 @@ IGNORED_ERRORS = {
             sqlalchemy.exc.DBAPIError,
             re.compile(r".+TrinoQueryError.+Value \w+ exceeds MAX_INT.+"),
         ),
+        (
+            sqlalchemy.exc.ProgrammingError,
+            re.compile(".+TrinoUserError.+Out of range for integer.+"),
+        ),
     ],
     IgnoredError.DATE_OVERFLOW: [
         # The variable strategy will sometimes result in date operations that construct


### PR DESCRIPTION
* example error:

```
FAILED tests/generative/test_query_model.py::test_query_model - sqlalchemy.exc.ProgrammingError: (trino.exceptions.TrinoUserError) TrinoUserError(type=USER_ERROR, name=NUMERIC_VALUE_OUT_OF_RANGE, message="Out of range for integer: 1.8429909189388E13", query_id=20240514_010919_13401_gcpd9)
```