### PR TITLE
Stop pre-commit passing filenames to `just check`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,6 +12,7 @@ repos:
       language: system
       types: [python]
       require_serial: true
+      pass_filenames: false
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.3.0


### PR DESCRIPTION
This does mean that pre-commit will fail on ill-formatted files which aren't part of your commit. But if you regularly have such files in your repo and you also like using pre-commit then you've just made two bad life choices.

Closes #2017