### PR TITLE
Better error messages for `case()`, `when()`, `then()` misuse

### DIFF
--- a/ehrql/docs/language.py
+++ b/ehrql/docs/language.py
@@ -126,8 +126,6 @@ def is_included_class(cls):
         return False
     if not cls.__module__.startswith("ehrql."):
         return False
-    if cls.__name__.startswith("_"):
-        return False
     if cls in EXCLUDE_FROM_DOCS:
         return False
     return True

--- a/ehrql/query_language.py
+++ b/ehrql/query_language.py
@@ -1504,6 +1504,8 @@ def case(*when_thens, otherwise=None):
             )
         else:
             cases[case._condition] = case._value
+    if not cases:
+        raise TypeError("`case()` expression requires at least one case")
     return _wrap(qm.Case, cases, default=_convert(otherwise))
 
 

--- a/ehrql/query_language.py
+++ b/ehrql/query_language.py
@@ -1475,6 +1475,10 @@ def case(*when_thens, otherwise=None):
     category = when(size < 15).then("small").otherwise("large")
     ```
     """
+    if any(isinstance(case, when) for case in when_thens):
+        raise TypeError(
+            "`when(...)` clause missing a `.then(...)` value in `case()` expression"
+        )
     cases = _DictArg((case._condition, case._value) for case in when_thens)
     return _apply(qm.Case, cases, otherwise)
 
@@ -1521,6 +1525,15 @@ def raise_helpful_error_if_possible(arg):
         raise TypeError(
             f"Function referenced but not called: are you missing parentheses on "
             f"`{arg.__name__}()`?"
+        )
+    if isinstance(arg, when):
+        raise TypeError(
+            "Missing `.then(...).otherwise(...)` conditions on a `when(...)` expression"
+        )
+    if isinstance(arg, WhenThen):
+        raise TypeError(
+            "Missing `.otherwise(...)` condition on a `when(...).then(...)` expression\n"
+            "Note: you can use `.otherwise(None)` to get NULL values"
         )
 
 

--- a/ehrql/query_language.py
+++ b/ehrql/query_language.py
@@ -265,7 +265,15 @@ class BaseSeries:
                 "you supplied a PatientSeries with only one value per patient"
             )
         else:
-            raise TypeError(f"Invalid argument type: {type(other)}")
+            # If the argument is not a supported ehrQL type then we'll get an error here
+            # (including hopefully helpful errors for common mistakes)
+            _convert(other)
+            # Otherwise it _is_ a supported type, but probably not of the right
+            # cardinality
+            raise TypeError(
+                f"Invalid type: {type(other).__qualname__}\n"
+                f"Note `is_in()` usually expects a list of values rather than a single value"
+            )
 
     def is_not_in(self, other):
         """

--- a/ehrql/query_language.py
+++ b/ehrql/query_language.py
@@ -1469,11 +1469,34 @@ def case(*when_thens, otherwise=None):
     category = when(size < 15).then("small").otherwise("large")
     ```
     """
-    if any(isinstance(case, when) for case in when_thens):
-        raise TypeError(
-            "`when(...)` clause missing a `.then(...)` value in `case()` expression"
-        )
-    cases = {case._condition: case._value for case in when_thens}
+    cases = {}
+    for case in when_thens:
+        if isinstance(case, when):
+            raise TypeError(
+                "`when(...)` clause missing a `.then(...)` value in `case()` expression"
+            )
+        elif (
+            isinstance(case, BaseSeries)
+            and isinstance(case._qm_node, qm.Case)
+            and len(case._qm_node.cases) == 1
+        ):
+            raise TypeError(
+                "invalid syntax for `otherwise` in `case()` expression, instead of:\n"
+                "\n"
+                "    case(\n"
+                "        when(...).then(...).otherwise(...)\n"
+                "    )\n"
+                "\n"
+                "You should write:\n"
+                "\n"
+                "    case(\n"
+                "        when(...).then(...),\n"
+                "        otherwise=...\n"
+                "    )\n"
+                "\n"
+            )
+        else:
+            cases[case._condition] = case._value
     return _wrap(qm.Case, cases, default=_convert(otherwise))
 
 

--- a/ehrql/query_language.py
+++ b/ehrql/query_language.py
@@ -1502,6 +1502,8 @@ def case(*when_thens, otherwise=None):
                 "    when(<CONDITION>).then(<VALUE>)\n"
                 "\n"
             )
+        elif case._condition in cases:
+            raise TypeError("duplicated condition in `case()` expression")
         else:
             cases[case._condition] = case._value
     if not cases:

--- a/ehrql/query_language.py
+++ b/ehrql/query_language.py
@@ -1407,7 +1407,15 @@ def get_tables_from_namespace(namespace):
 
 class when:
     def __init__(self, condition):
-        self._condition = _convert(condition)
+        condition_qm = _convert(condition)
+        type_ = get_series_type(condition_qm)
+        if type_ is not bool:
+            raise TypeError(
+                f"invalid case condition:\n"
+                f"Expecting a boolean series, got series of type"
+                f" '{type_.__qualname__}'",
+            )
+        self._condition = condition_qm
 
     def then(self, value):
         return WhenThen(self._condition, _convert(value))

--- a/ehrql/query_language.py
+++ b/ehrql/query_language.py
@@ -1495,6 +1495,13 @@ def case(*when_thens, otherwise=None):
                 "    )\n"
                 "\n"
             )
+        elif not isinstance(case, WhenThen):
+            raise TypeError(
+                "cases must be specified in the form:\n"
+                "\n"
+                "    when(<CONDITION>).then(<VALUE>)\n"
+                "\n"
+            )
         else:
             cases[case._condition] = case._value
     return _wrap(qm.Case, cases, default=_convert(otherwise))

--- a/ehrql/query_language.py
+++ b/ehrql/query_language.py
@@ -1506,6 +1506,8 @@ def case(*when_thens, otherwise=None):
             cases[case._condition] = case._value
     if not cases:
         raise TypeError("`case()` expression requires at least one case")
+    if otherwise is None and all(value is None for value in cases.values()):
+        raise TypeError("`case()` expression cannot have all `None` values")
     return _wrap(qm.Case, cases, default=_convert(otherwise))
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ import threading
 from pathlib import Path
 
 import pytest
+from hypothesis.internal.reflection import extract_lambda_source
 
 import ehrql
 from ehrql.main import get_sql_strings
@@ -75,6 +76,13 @@ def pytest_terminal_summary(terminalreporter, exitstatus, config):
         print("ERROR: warnings detected")
         if terminalreporter._session.exitstatus == 0:
             terminalreporter._session.exitstatus = 13
+
+
+def pytest_make_parametrize_id(config, val):
+    # Where we use lambdas as test parameters, having the source as the parameter ID
+    # makes it quicker to identify specific test cases in the output
+    if callable(val) and val.__name__ == "<lambda>":
+        return extract_lambda_source(val).removeprefix("lambda: ")
 
 
 @pytest.fixture(scope="session")

--- a/tests/unit/test_query_language.py
+++ b/tests/unit/test_query_language.py
@@ -1008,6 +1008,10 @@ def test_validate_patient_series_type(type_, required_types, expected_error):
             lambda: case(patients.i, otherwise="none"),
             "cases must be specified in the form:",
         ),
+        (
+            lambda: case(),
+            "`case()` expression requires at least one case",
+        ),
     ],
 )
 def test_case_expression_errors(expr, expected_error):

--- a/tests/unit/test_query_language.py
+++ b/tests/unit/test_query_language.py
@@ -993,6 +993,10 @@ def test_validate_patient_series_type(type_, required_types, expected_error):
             lambda: when(patients.i == 10).then(patients),
             "Expecting a series but got a frame (`patients`): are you missing a column name?",
         ),
+        (
+            lambda: when(patients.i).then("exists"),
+            "Expecting a boolean series, got series of type 'int'",
+        ),
     ],
 )
 def test_case_expression_errors(expr, expected_error):

--- a/tests/unit/test_query_language.py
+++ b/tests/unit/test_query_language.py
@@ -1004,6 +1004,10 @@ def test_validate_patient_series_type(type_, required_types, expected_error):
             ),
             "invalid syntax for `otherwise` in `case()` expression",
         ),
+        (
+            lambda: case(patients.i, otherwise="none"),
+            "cases must be specified in the form:",
+        ),
     ],
 )
 def test_case_expression_errors(expr, expected_error):

--- a/tests/unit/test_query_language.py
+++ b/tests/unit/test_query_language.py
@@ -1016,6 +1016,13 @@ def test_validate_patient_series_type(type_, required_types, expected_error):
             lambda: case(when(patients.i == 0).then(None)),
             "case()` expression cannot have all `None` values",
         ),
+        (
+            lambda: case(
+                when(patients.i == 1).then("a"),
+                when(patients.i == 1).then("b"),
+            ),
+            "duplicated condition in `case()` expression",
+        ),
     ],
 )
 def test_case_expression_errors(expr, expected_error):

--- a/tests/unit/test_query_language.py
+++ b/tests/unit/test_query_language.py
@@ -1012,6 +1012,10 @@ def test_validate_patient_series_type(type_, required_types, expected_error):
             lambda: case(),
             "`case()` expression requires at least one case",
         ),
+        (
+            lambda: case(when(patients.i == 0).then(None)),
+            "case()` expression cannot have all `None` values",
+        ),
     ],
 )
 def test_case_expression_errors(expr, expected_error):

--- a/tests/unit/test_query_language.py
+++ b/tests/unit/test_query_language.py
@@ -997,6 +997,13 @@ def test_validate_patient_series_type(type_, required_types, expected_error):
             lambda: when(patients.i).then("exists"),
             "Expecting a boolean series, got series of type 'int'",
         ),
+        (
+            lambda: case(
+                when(patients.i < 10).then("small"),
+                when(patients.i > 10).then("large").otherwise("none"),
+            ),
+            "invalid syntax for `otherwise` in `case()` expression",
+        ),
     ],
 )
 def test_case_expression_errors(expr, expected_error):

--- a/tests/unit/test_query_language.py
+++ b/tests/unit/test_query_language.py
@@ -985,6 +985,14 @@ def test_validate_patient_series_type(type_, required_types, expected_error):
             lambda: case(when(patients.i < 10), otherwise="none"),
             "`when(...)` clause missing a `.then(...)` value in `case()` expression",
         ),
+        (
+            lambda: when(patients).then("exists"),
+            "Expecting a series but got a frame (`patients`): are you missing a column name?",
+        ),
+        (
+            lambda: when(patients.i == 10).then(patients),
+            "Expecting a series but got a frame (`patients`): are you missing a column name?",
+        ),
     ],
 )
 def test_case_expression_errors(expr, expected_error):

--- a/tests/unit/test_query_language.py
+++ b/tests/unit/test_query_language.py
@@ -1,4 +1,3 @@
-import operator
 import re
 import traceback
 from datetime import date
@@ -317,29 +316,19 @@ class TestDateSeries:
 
 
 @pytest.mark.parametrize(
-    "lhs,op,rhs,expected_type",
+    "expr,expected_type",
     [
-        (patients.f, "-", 10, FloatPatientSeries),
-        (patients.f, "+", 10, FloatPatientSeries),
-        (patients.f, "<", 10, BoolPatientSeries),
-        (events.f, "-", 10, FloatEventSeries),
-        (events.f, "<", 10, BoolEventSeries),
-        (events.f, ">", 10, BoolEventSeries),
-        (events.f, "<", 10.0, BoolEventSeries),
+        (lambda: patients.f - 10, FloatPatientSeries),
+        (lambda: patients.f + 10, FloatPatientSeries),
+        (lambda: patients.f < 10, BoolPatientSeries),
+        (lambda: events.f - 10, FloatEventSeries),
+        (lambda: events.f < 10, BoolEventSeries),
+        (lambda: events.f > 10, BoolEventSeries),
+        (lambda: events.f < 10.0, BoolEventSeries),
     ],
 )
-def test_automatic_cast(lhs, op, rhs, expected_type):
-    if op == "+":
-        result = lhs + rhs
-    elif op == "-":
-        result = lhs - rhs
-    elif op == ">":
-        result = lhs > rhs
-    elif op == "<":
-        result = lhs < rhs
-    else:
-        assert False
-    assert isinstance(result, expected_type)
+def test_automatic_cast(expr, expected_type):
+    assert isinstance(expr(), expected_type)
 
 
 def test_is_in_rejects_unknown_types():
@@ -488,141 +477,133 @@ def test_boolean_operators_raise_errors():
 
 
 @pytest.mark.parametrize(
-    "lhs,op,rhs",
+    "expr",
     [
-        (100, operator.add, patients.date_of_birth),
-        (100, operator.sub, patients.date_of_birth),
-        (patients.date_of_birth, operator.add, 100),
-        (patients.date_of_birth, operator.sub, 100),
-        (100, operator.add, days(100)),
-        (100, operator.sub, days(100)),
-        (days(100), operator.add, 100),
-        (days(100), operator.sub, 100),
-        (date(2010, 1, 1), operator.add, patients.date_of_birth - "2000-01-01"),
+        lambda: 100 + patients.date_of_birth,
+        lambda: 100 - patients.date_of_birth,
+        lambda: patients.date_of_birth + 100,
+        lambda: patients.date_of_birth - 100,
+        lambda: 100 + days(100),
+        lambda: 100 - days(100),
+        lambda: days(100) + 100,
+        lambda: days(100) - 100,
+        lambda: date(2010, 1, 1) + patients.date_of_birth - "2000-01-01",
     ],
 )
-def test_unsupported_date_operations(lhs, op, rhs):
+def test_unsupported_date_operations(expr):
     with pytest.raises(TypeError, match="unsupported operand type"):
-        op(lhs, rhs)
+        expr()
 
 
 @pytest.mark.parametrize(
-    "lhs,op,rhs,expected",
+    "expr,expected",
     [
         # Test each type of Duration constructor
-        ("2020-01-01", operator.add, days(10), date(2020, 1, 11)),
-        ("2020-01-01", operator.add, weeks(1), date(2020, 1, 8)),
-        ("2020-01-01", operator.add, months(10), date(2020, 11, 1)),
-        ("2020-01-01", operator.add, years(10), date(2030, 1, 1)),
+        (lambda: "2020-01-01" + days(10), date(2020, 1, 11)),
+        (lambda: "2020-01-01" + weeks(1), date(2020, 1, 8)),
+        (lambda: "2020-01-01" + months(10), date(2020, 11, 1)),
+        (lambda: "2020-01-01" + years(10), date(2030, 1, 1)),
         # Order reversed
-        (days(10), operator.add, "2020-01-01", date(2020, 1, 11)),
+        (lambda: days(10) + "2020-01-01", date(2020, 1, 11)),
         # Subtraction
-        ("2020-01-01", operator.sub, years(10), date(2010, 1, 1)),
+        (lambda: "2020-01-01" - years(10), date(2010, 1, 1)),
         # Date objects rather than ISO strings
-        (date(2020, 1, 1), operator.add, years(10), date(2030, 1, 1)),
-        (years(10), operator.add, date(2020, 1, 1), date(2030, 1, 1)),
-        (date(2020, 1, 1), operator.sub, years(10), date(2010, 1, 1)),
+        (lambda: date(2020, 1, 1) + years(10), date(2030, 1, 1)),
+        (lambda: years(10) + date(2020, 1, 1), date(2030, 1, 1)),
+        (lambda: date(2020, 1, 1) - years(10), date(2010, 1, 1)),
         # Test addition of Durations
-        (days(10), operator.add, days(5), days(15)),
-        (weeks(10), operator.add, weeks(5), weeks(15)),
-        (months(10), operator.add, months(5), months(15)),
-        (years(10), operator.add, years(5), years(15)),
+        (lambda: days(10) + days(5), days(15)),
+        (lambda: weeks(10) + weeks(5), weeks(15)),
+        (lambda: months(10) + months(5), months(15)),
+        (lambda: years(10) + years(5), years(15)),
         # Test subtraction of Durations
-        (days(10), operator.sub, days(5), days(5)),
-        (weeks(10), operator.sub, weeks(5), weeks(5)),
-        (months(10), operator.sub, months(5), months(5)),
-        (years(10), operator.sub, years(5), years(5)),
+        (lambda: days(10) - days(5), days(5)),
+        (lambda: weeks(10) - weeks(5), weeks(5)),
+        (lambda: months(10) - months(5), months(5)),
+        (lambda: years(10) - years(5), years(5)),
         # Test comparison of Durations
-        (days(5), operator.eq, days(5), True),
-        (months(5), operator.eq, years(5), False),
-        (weeks(5), operator.eq, weeks(4), False),
-        (weeks(1), operator.eq, days(7), False),
-        (days(5), operator.ne, days(5), False),
-        (months(5), operator.ne, years(5), True),
+        (lambda: days(5) == days(5), True),
+        (lambda: months(5) == years(5), False),
+        (lambda: weeks(5) == weeks(4), False),
+        (lambda: weeks(1) == days(7), False),
+        (lambda: days(5) != days(5), False),
+        (lambda: months(5) != years(5), True),
     ],
 )
-def test_static_date_operations(lhs, op, rhs, expected):
-    assert op(lhs, rhs) == expected
+def test_static_date_operations(expr, expected):
+    assert expr() == expected
 
 
 @pytest.mark.parametrize(
-    "lhs,op,rhs,expected_type",
+    "expr,expected_type",
     [
         # Test each type of Duration constructor
-        (patients.date_of_birth, operator.add, days(10), DatePatientSeries),
-        (patients.date_of_birth, operator.add, weeks(10), DatePatientSeries),
-        (patients.date_of_birth, operator.add, months(10), DatePatientSeries),
-        (patients.date_of_birth, operator.add, years(10), DatePatientSeries),
+        (lambda: patients.date_of_birth + days(10), DatePatientSeries),
+        (lambda: patients.date_of_birth + weeks(10), DatePatientSeries),
+        (lambda: patients.date_of_birth + months(10), DatePatientSeries),
+        (lambda: patients.date_of_birth + years(10), DatePatientSeries),
         # Order reversed
-        (days(10), operator.add, patients.date_of_birth, DatePatientSeries),
+        (lambda: days(10) + patients.date_of_birth, DatePatientSeries),
         # Subtraction
-        (patients.date_of_birth, operator.sub, days(10), DatePatientSeries),
+        (lambda: patients.date_of_birth - days(10), DatePatientSeries),
         # Date differences
-        (patients.date_of_birth, operator.sub, "2020-01-01", DateDifference),
-        (patients.date_of_birth, operator.sub, date(2020, 1, 1), DateDifference),
+        (lambda: patients.date_of_birth - "2020-01-01", DateDifference),
+        (lambda: patients.date_of_birth - date(2020, 1, 1), DateDifference),
         # Order reversed
-        ("2020-01-01", operator.sub, patients.date_of_birth, DateDifference),
-        (date(2020, 1, 1), operator.sub, patients.date_of_birth, DateDifference),
+        (lambda: "2020-01-01" - patients.date_of_birth, DateDifference),
+        (lambda: date(2020, 1, 1) - patients.date_of_birth, DateDifference),
         # DateDifference attributes
         (
-            (patients.date_of_birth - "2020-01-01").days,
-            operator.add,
-            1,
+            lambda: (patients.date_of_birth - "2020-01-01").days + 1,
             IntPatientSeries,
         ),
         (
-            (patients.date_of_birth - "2020-01-01").weeks,
-            operator.add,
-            1,
+            lambda: (patients.date_of_birth - "2020-01-01").weeks + 1,
             IntPatientSeries,
         ),
         (
-            (patients.date_of_birth - "2020-01-01").months,
-            operator.add,
-            1,
+            lambda: (patients.date_of_birth - "2020-01-01").months + 1,
             IntPatientSeries,
         ),
         (
-            (patients.date_of_birth - "2020-01-01").years,
-            operator.add,
-            1,
+            lambda: (patients.date_of_birth - "2020-01-01").years + 1,
             IntPatientSeries,
         ),
         # Test with a "dynamic" duration
-        (patients.date_of_birth, operator.add, days(patients.i), DatePatientSeries),
-        (patients.date_of_birth, operator.add, weeks(patients.i), DatePatientSeries),
-        (patients.date_of_birth, operator.add, months(patients.i), DatePatientSeries),
-        (patients.date_of_birth, operator.add, years(patients.i), DatePatientSeries),
+        (lambda: patients.date_of_birth + days(patients.i), DatePatientSeries),
+        (lambda: patients.date_of_birth + weeks(patients.i), DatePatientSeries),
+        (lambda: patients.date_of_birth + months(patients.i), DatePatientSeries),
+        (lambda: patients.date_of_birth + years(patients.i), DatePatientSeries),
         # Test with a dynamic duration and a static date
-        (date(2020, 1, 1), operator.add, days(patients.i), DatePatientSeries),
-        (date(2020, 1, 1), operator.add, weeks(patients.i), DatePatientSeries),
-        (date(2020, 1, 1), operator.add, months(patients.i), DatePatientSeries),
-        (date(2020, 1, 1), operator.add, years(patients.i), DatePatientSeries),
+        (lambda: date(2020, 1, 1) + days(patients.i), DatePatientSeries),
+        (lambda: date(2020, 1, 1) + weeks(patients.i), DatePatientSeries),
+        (lambda: date(2020, 1, 1) + months(patients.i), DatePatientSeries),
+        (lambda: date(2020, 1, 1) + years(patients.i), DatePatientSeries),
         # Test comparison of Durations
-        (days(patients.i), operator.eq, days(patients.i), BoolPatientSeries),
-        (months(patients.i), operator.eq, years(patients.i), bool),
-        (days(patients.i), operator.ne, days(patients.i), BoolPatientSeries),
-        (months(patients.i), operator.ne, years(patients.i), bool),
+        (lambda: days(patients.i) == days(patients.i), BoolPatientSeries),
+        (lambda: months(patients.i) == years(patients.i), bool),
+        (lambda: days(patients.i) != days(patients.i), BoolPatientSeries),
+        (lambda: months(patients.i) != years(patients.i), bool),
     ],
 )
-def test_ehrql_date_operations(lhs, op, rhs, expected_type):
-    assert isinstance(op(lhs, rhs), expected_type)
+def test_ehrql_date_operations(expr, expected_type):
+    assert isinstance(expr(), expected_type)
 
 
 @pytest.mark.parametrize(
-    "lhs,op,rhs",
+    "expr",
     [
-        (days(10), operator.add, months(10)),
-        (days(10), operator.sub, months(10)),
-        (days(10), operator.add, years(10)),
-        (days(10), operator.sub, years(10)),
-        (months(10), operator.add, years(10)),
-        (months(10), operator.sub, years(10)),
+        lambda: days(10) + months(10),
+        lambda: days(10) - months(10),
+        lambda: days(10) + years(10),
+        lambda: days(10) - years(10),
+        lambda: months(10) + years(10),
+        lambda: months(10) - years(10),
     ],
 )
-def test_incompatible_duration_operations(lhs, op, rhs):
+def test_incompatible_duration_operations(expr):
     with pytest.raises(TypeError):
-        op(lhs, rhs)
+        expr()
 
 
 fn_names = sorted(
@@ -908,27 +889,27 @@ def test_query_model_type_errors():
     "code,exc_class,expected_note",
     [
         (
-            "patients.no_such_column",
+            lambda: patients.no_such_column,
             AttributeError,
             "",
         ),
         (
-            "patients.i + 'foo'",
+            lambda: patients.i + "foo",
             TypeError,
             "",
         ),
         (
-            "patients.i == 1 | patients.i == 2",
+            lambda: patients.i == 1 | patients.i == 2,
             TypeError,
             "WARNING: The `|` operator has surprising precedence rules",
         ),
         (
-            "patients.i == 1 & patients.i == 2",
+            lambda: patients.i == 1 & patients.i == 2,
             TypeError,
             "WARNING: The `&` operator has surprising precedence rules",
         ),
         (
-            "~ patients.i == 1",
+            lambda: ~patients.i == 1,
             TypeError,
             "WARNING: The `~` operator has surprising precedence rules",
         ),
@@ -936,7 +917,7 @@ def test_query_model_type_errors():
 )
 def test_modify_exception(code, exc_class, expected_note):
     with pytest.raises(exc_class) as exc:
-        eval(code)
+        code()
     exception = modify_exception(exc.value)
     notes = "\n".join(getattr(exception, "__notes__", []))
     assert isinstance(exception, exc_class)

--- a/tests/unit/test_query_language.py
+++ b/tests/unit/test_query_language.py
@@ -332,7 +332,17 @@ def test_automatic_cast(expr, expected_type):
 
 
 def test_is_in_rejects_unknown_types():
-    with pytest.raises(TypeError, match="Invalid argument type"):
+    with pytest.raises(TypeError, match="Not a valid ehrQL type: <object"):
+        patients.i.is_in(object())
+
+
+def test_is_in_rejects_scalars():
+    with pytest.raises(
+        TypeError,
+        match=re.escape(
+            "Note `is_in()` usually expects a list of values rather than a single value"
+        ),
+    ):
         patients.i.is_in(1)
 
 


### PR DESCRIPTION
This doesn't add any new invalid constructs (apart from the edge case of duplicated conditions) but it does raise what are hopefully much more helpful errors for already invalid constructs.

For example, compare the before and after errors for missing `.otherwise()`:
```
Expecting an ehrQL series, got type 'WhenThen'

---

Missing `.otherwise(...)` condition on a `when(...).then(...)` expression
```

For using the `otherwise()` method where you should use the keyword argument:
```
AttributeError: 'StrPatientSeries' object has no attribute '_condition'

---

TypeError: invalid syntax for `otherwise` in `case()` expression, instead of:

    case(
        when(...).then(...).otherwise(...)
    )

You should write:

    case(
        when(...).then(...),
        otherwise=...
    )
```

And for not providing a non-null value:
```
AssertionError: Could not match TypeVar ~T in Case(cases={Function.EQ(lhs=SelectColumn(source=
SelectPatientTable(name='patients', schema=TableSchema(date_of_birth=Column(datetime.date, constraints=()), 
i=Column(int, constraints=()), f=Column(float, constraints=()))), name='i'), rhs=Value(value=0)): None}, 
default=None)

---

TypeError: `case()` expression cannot have all `None` values
```

Closes #1440