### PR TITLE
Update T1OO logic

### DIFF
--- a/tests/acceptance/test_embedded_study.py
+++ b/tests/acceptance/test_embedded_study.py
@@ -10,15 +10,18 @@ from tests.lib.fixtures import (
     parameterised_dataset_definition,
     trivial_dataset_definition,
 )
-from tests.lib.tpp_schema import Patient
+from tests.lib.tpp_schema import Patient, RegistrationHistory
 
 
 @pytest.mark.parametrize("extension", list(FILE_FORMATS.keys()))
 def test_generate_dataset(study, mssql_database, extension):
     mssql_database.setup(
         Patient(Patient_ID=1, DateOfBirth=datetime(1934, 5, 5)),
+        RegistrationHistory(Patient_ID=1, StartDate=datetime(2000, 1, 1)),
         Patient(Patient_ID=2, DateOfBirth=datetime(1943, 5, 5)),
+        RegistrationHistory(Patient_ID=2, StartDate=datetime(2000, 1, 1)),
         Patient(Patient_ID=3, DateOfBirth=datetime(1999, 5, 5)),
+        RegistrationHistory(Patient_ID=3, StartDate=datetime(2000, 1, 1)),
     )
 
     study.setup_from_string(trivial_dataset_definition)
@@ -36,8 +39,11 @@ def test_generate_dataset(study, mssql_database, extension):
 def test_parameterised_dataset_definition(study, mssql_database):
     mssql_database.setup(
         Patient(Patient_ID=1, DateOfBirth=datetime(1934, 5, 5)),
+        RegistrationHistory(Patient_ID=1, StartDate=datetime(2000, 1, 1)),
         Patient(Patient_ID=2, DateOfBirth=datetime(1943, 5, 5)),
+        RegistrationHistory(Patient_ID=2, StartDate=datetime(2000, 1, 1)),
         Patient(Patient_ID=3, DateOfBirth=datetime(1999, 5, 5)),
+        RegistrationHistory(Patient_ID=3, StartDate=datetime(2000, 1, 1)),
     )
 
     study.setup_from_string(parameterised_dataset_definition)

--- a/tests/docker/test_cli.py
+++ b/tests/docker/test_cli.py
@@ -5,11 +5,17 @@ import pytest
 
 from tests.lib import fixtures
 from tests.lib.docker import ContainerError
-from tests.lib.tpp_schema import Patient
+from tests.lib.tpp_schema import Patient, RegistrationHistory
 
 
 def test_generate_dataset_in_container(study, mssql_database):
-    mssql_database.setup(Patient(Patient_ID=1, DateOfBirth=datetime(1943, 5, 5)))
+    mssql_database.setup(
+        Patient(
+            Patient_ID=1,
+            DateOfBirth=datetime(1943, 5, 5),
+        ),
+        RegistrationHistory(Patient_ID=1, StartDate=datetime(2000, 1, 1)),
+    )
 
     study.setup_from_string(fixtures.trivial_dataset_definition)
     study.generate_in_docker(mssql_database, "ehrql.backends.tpp.TPPBackend")

--- a/tests/integration/backends/test_tpp.py
+++ b/tests/integration/backends/test_tpp.py
@@ -2827,13 +2827,7 @@ def test_is_in_queries_on_columns_with_nonstandard_collation(
     [
         (
             "?opensafely_include_t1oo=false",
-            [
-                (1, 1951),
-                (4, 1954),
-                (5, 1955),
-                (7, 1957),
-                (9, 1959),
-            ],
+            [(1, 1951), (5, 1955), (7, 1957), (9, 1959), (12, 1962)],
         ),
         (
             "?opensafely_include_t1oo=true",
@@ -2849,6 +2843,7 @@ def test_is_in_queries_on_columns_with_nonstandard_collation(
                 (9, 1959),
                 (10, 1960),
                 (11, 1961),
+                (12, 1962),
             ],
         ),
     ],
@@ -2871,7 +2866,7 @@ def test_t1oo_patients_excluded_as_specified(mssql_database, suffix, expected):
         RegistrationHistory(
             Patient_ID=3, StartDate=date(2020, 1, 1), EndDate=date(2024, 7, 1)
         ),
-        # 4 - Included: no opt-out, has deregistered, but death recorded shortly after dereg
+        # 4 - Excluded: no opt-out, has deregistered, but death recorded shortly after dereg
         Patient(
             Patient_ID=4, DateOfBirth=date(1954, 1, 1), DateOfDeath=date(2024, 7, 28)
         ),
@@ -2924,6 +2919,15 @@ def test_t1oo_patients_excluded_as_specified(mssql_database, suffix, expected):
         # as I can see, but we should handle all the edge cases)
         Patient(
             Patient_ID=11, DateOfBirth=date(1961, 1, 1), DateOfDeath=date(2024, 6, 1)
+        ),
+        # 12 - Included: no opt-out, death recorded, but no deregistration recorded
+        # Ensure our t1oo logic works with a null EndDate (end date
+        # is 9999-12-31, converted to Null in the ehrql TPPBackend)
+        Patient(
+            Patient_ID=12, DateOfBirth=date(1962, 1, 1), DateOfDeath=date(2024, 7, 28)
+        ),
+        RegistrationHistory(
+            Patient_ID=12, StartDate=date(2020, 1, 1), EndDate=date(9999, 12, 31)
         ),
     )
 

--- a/tests/integration/backends/test_tpp.py
+++ b/tests/integration/backends/test_tpp.py
@@ -2810,6 +2810,9 @@ def test_is_in_queries_on_columns_with_nonstandard_collation(
         backend=TPPBackend(
             config={"TEMP_DATABASE_NAME": "temp_tables"},
         ),
+        # Disable T1OO filter for test so we don't need to worry about creating
+        # registration histories
+        dsn=mssql_engine.database.host_url() + "?opensafely_include_t1oo=true",
     )
 
     # Check that the expected patients match


### PR DESCRIPTION
We expand the logic to exclude de-registered patients on the basis that they may have registered a T1OO elsewhere which has not propagated to our database. Patients who died at the time of deregistration (or shortly after, to account for data flow issues) are **not** excluded on the basis that their deregistration is due to their death and not to their registering elsewhere.