### PR TITLE
Replace unmaintained Slack notify action

### DIFF
--- a/.github/workflows/generative-tests.yml
+++ b/.github/workflows/generative-tests.yml
@@ -64,7 +64,7 @@ jobs:
 
       - name: "Notify Slack on Failure"
         if: failure() && github.ref_name == 'main'
-        uses: voxmedia/github-action-slack-notify-build@3665186a8c1a022b28a1dbe0954e73aa9081ea9e # v1.6.0
+        uses: zuplo/github-action-slack-notify-build@cf8e7e66a21d76a8125ea9648979c30920195552 # v2
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
         with:


### PR DESCRIPTION
The [`voxmedia`](https://github.com/voxmedia/github-action-slack-notify-build) action is now unmaintained.

We're using the [`zuplo` fork](https://github.com/zuplo/github-action-slack-notify-build) in [research-template-docker](https://github.com/opensafely-core/research-template-docker/tree/3c8d227d086d2a097ce5f9bd65d2abf3c2ea6d6f/.github/workflows).

It's a direct replacement.