### PR TITLE
Handle non-dataclass objects in graph renderer

### DIFF
--- a/ehrql/query_model/graphs.py
+++ b/ehrql/query_model/graphs.py
@@ -50,12 +50,12 @@ def find_edges(src):
 
 
 def get_id(node):
-    if dataclasses.is_dataclass(node):
-        return id(node)
-    else:
+    if isinstance(node, int | float | str):
         # Sometimes primitive values are not interned, which means eg two strings with
         # the same content can have different ids
         return node
+    else:
+        return id(node)
 
 
 def get_label(node):


### PR DESCRIPTION
The query graph renderer is only used internally, and then only really for demonstration purposes, so it's not heavily tested. This fixes an issue wherey query graph objects which are not dataclasses (e.g. `Position` enums or `RowsReader` instances) would cause the renderer to fall over. We do this by inverting the logic to explicitly check for problematic primitive types.