### PR TITLE
Update MSSQL test Docker image

### DIFF
--- a/tests/lib/databases.py
+++ b/tests/lib/databases.py
@@ -177,7 +177,12 @@ def make_mssql_database(containers):
 def run_mssql(container_name, containers, password, mssql_port):  # pragma: no cover
     containers.run_bg(
         name=container_name,
-        image="mcr.microsoft.com/mssql/server:2017-CU30-ubuntu-18.04",
+        # This is *not* the version that TPP run for us in production which, as of
+        # 2024-09-24, is SQL Server 2016 (13.0.5893.48). That version is not available
+        # as a Docker image, so we run the oldest supported version instead. Both the
+        # production server and our test server set the "compatibility level" to the
+        # same value so the same feature set should be supported.
+        image="mcr.microsoft.com/mssql/server:2019-CU28-ubuntu-20.04",
         volumes={
             MSSQL_SETUP_DIR: {"bind": "/mssql", "mode": "ro"},
         },

--- a/tests/support/mssql/entrypoint.sh
+++ b/tests/support/mssql/entrypoint.sh
@@ -46,12 +46,13 @@ if [ "$1" = '/opt/mssql/bin/sqlservr' ]; then
 
     function _sqlcmd() {
       # Extra arguments:
+      #    -C : trust server certificate
       #    -b : exit with 1 on error rather than 0
       # -h -1 : no headers in output
       #    -W : trim trailing whitespace
-      /opt/mssql-tools/bin/sqlcmd \
+      /opt/mssql-tools18/bin/sqlcmd \
         -S localhost -U sa -P "$MSSQL_SA_PASSWORD" -d master \
-        -b -h -1 -W \
+        -C -b -h -1 -W \
         "$@"
     }
 

--- a/tests/unit/utils/test_mssql_log_utils.py
+++ b/tests/unit/utils/test_mssql_log_utils.py
@@ -40,10 +40,14 @@ def test_parse_statistics_messages():
             b" Scan count 1, logical reads 7, physical reads 0, read-ahead reads 0,"
             b" lob logical reads 0, lob physical reads 0, lob read-ahead reads 0."
         ),
+        # Newer version of SQL Server return IO stats in a different order and with
+        # additional items, so check we handle those correctly
         (
             b"Table '#tmp_1______________________________________________________________________________________________________________0000000014D9'."
-            b" Scan count 1, logical reads 4, physical reads 0, read-ahead reads 0,"
-            b" lob logical reads 0, lob physical reads 0, lob read-ahead reads 0."
+            b" Scan count 1, logical reads 4, physical reads 0, page server reads 0,"
+            b" read-ahead reads 0, page server read-ahead reads 0, lob logical reads 0,"
+            b" lob physical reads 0, lob page server reads 0, lob read-ahead reads 0,"
+            b" lob page server read-ahead reads 0."
         ),
         (
             b"Table '#tmp_1______________________________________________________________________________________________________________0000000014B1'."


### PR DESCRIPTION
The previous version was incompatible with the updated kernel now used by Github Actions runners. See:
https://github.com/microsoft/mssql-docker/issues/868

The fix has been backported as far as the 2019 image, but not to the 2017 image. Seeing that the 2017 image didn't match what was being run in production in any case we might as well upgrade.

This requires a few small changes:

 * The `sqlcmd` tool has moved from `/opt/mssql-tools/bin` to `/opt/mssql-tools18/bin`. This is due to the newer image using the `mssql-tools18` apt package. Note that references to the old path are still present in the codebase because _our_ Docker image still installs the `mssql-tools` package.

 * The `sqlcmd` invocation now requires the `-C` option to automatically trust the server certificate.

 * The precise sequence in which IO statistics are returned has changed and so we update the code which parses these to be insensitive to changes in order.