### PR TITLE
Enable `unveil` in user-supplied code sandbox

### DIFF
--- a/tests/unit/test_loaders.py
+++ b/tests/unit/test_loaders.py
@@ -224,9 +224,6 @@ def test_isolation_report(tmp_path):
             "touch": "BLOCKED",
             "open_socket": "BLOCKED",
             "exec": "BLOCKED",
-            # Until we can assume "unveil" support we can't block the subprocess reading
-            # its parent's environment variables out of /proc; but we leave this test
-            # code in place in preparation.
-            "read_env_vars": "ALLOWED",
+            "read_env_vars": "BLOCKED",
         },
     }


### PR DESCRIPTION
This tightens even further the restrictions placed on the sandboxed process in which we run user-supplied code. Thanks to a recent upgrade of the VM guest OS the `unveil` feature is now supported which provides more fine-grained control over what paths are readable by the sandboxed process. This means we can prevent the process reading its parent's environment variables. There was never anything the process could _do_ with these variables (being denied all network access and filesystem write access) but it's better if it can't read them at all.