### PR TITLE
Fix assimilation of `pledge` binary within Github Actions

### DIFF
--- a/justfile
+++ b/justfile
@@ -335,7 +335,7 @@ update-pledge: devenv
     # can run directly without needing a shell. See:
     # https://justine.lol/apeloader/
     echo "Assimilating ..."
-    bin/pledge --assimilate
+    sh bin/pledge --assimilate
 
     echo "Complete."
     echo "$ZIP_URL" > "$URL_RECORD_FILE"


### PR DESCRIPTION
Cosmopolitan/APE is dark magic and something has changed within the Github Actions runtime which means that executing the APE binary directly doesn't work and we need to do it via a shell. Once the binary has been "assimilated" it can then becomes a native binary which can be executed normally.