### PR TITLE
Fix capitalisation in example data

### DIFF
--- a/ehrql/example-data/practice_registrations.csv
+++ b/ehrql/example-data/practice_registrations.csv
@@ -6,8 +6,8 @@ patient_id,start_date,end_date,practice_pseudo_id,practice_stp,practice_nuts1_re
 4,2019-01-02,,7199,E54000026,East
 5,2007-07-21,2018-05-23,8595,E54000024,East
 6,2020-09-14,,5045,E54000017,West Midlands
-7,2013-12-05,,7588,E54000050,Yorkshire and the Humber
-7,2017-05-12,,5121,E54000050,Yorkshire and the Humber
+7,2013-12-05,,7588,E54000050,Yorkshire and The Humber
+7,2017-05-12,,5121,E54000050,Yorkshire and The Humber
 8,2020-01-19,,1858,E54000012,West Midlands
 9,1995-03-01,2017-11-10,8189,E54000023,East
 10,2001-10-24,,7783,E54000037,South West

--- a/tests/unit/test_example_data.py
+++ b/tests/unit/test_example_data.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+
+import pytest
+
+import ehrql
+from ehrql.query_engines.local_file import LocalFileQueryEngine
+from ehrql.query_language import EventFrame
+from ehrql.tables import core, tpp
+
+
+# Example csv files are given for all core tables (although the tutorial imports them from the tpp module)
+CORE_TABLES = [getattr(core, table) for table in core.__all__]
+# Example csv files are given for these tables that are currently only available for tpp
+TPP_TABLES = [tpp.addresses, tpp.practice_registrations]
+
+EXAMPLE_TABLES = CORE_TABLES + TPP_TABLES
+EXAMPLE_DATA_DIR = Path(ehrql.__file__).parent / "example-data"
+
+
+@pytest.mark.parametrize("ql_table", EXAMPLE_TABLES)
+def test_populate_database_using_example_data(ql_table: EventFrame):
+    # The engine populates the database with the example data and validates the column specs in the process
+    engine = LocalFileQueryEngine(EXAMPLE_DATA_DIR)
+    engine.populate_database([ql_table._qm_node])


### PR DESCRIPTION
Fixes #2106.

- Incorrect capitalisation in the example `practice_registrations` data leads to a ValueError being raised when used
- Capitalisation is now fixed and a new unit test is added to check that all example data files can be loaded correctly.