### PR TITLE
Update example project.yaml in docs to version 4 template

### DIFF
--- a/docs/explanation/output-formats.md
+++ b/docs/explanation/output-formats.md
@@ -75,10 +75,7 @@ opensafely exec ehrql:v1 generate-dataset "./dataset-definition.py" --dummy-tabl
 ### Example `project.yaml`
 
 ```yaml
-version: "3.0"
-
-expectations:
-  population_size: 1000
+version: "4.0"
 
 actions:
   extract_data:

--- a/docs/explanation/running-ehrql.md
+++ b/docs/explanation/running-ehrql.md
@@ -324,10 +324,7 @@ you need to have a file called `project.yaml`.
 `project.yaml` in your `learning-ehrql` directory:
 
 ```yaml
-version: '3.0'
-
-expectations:
-  population_size: 1000
+version: '4.0'
 
 actions:
   generate_dataset:

--- a/docs/tutorial/example-study/project.yaml
+++ b/docs/tutorial/example-study/project.yaml
@@ -1,7 +1,4 @@
-version: "3.0"
-
-expectations:
-  population_size: 1000
+version: "4.0"
 
 actions:
   generate_dataset:


### PR DESCRIPTION
- Part of [upgrading pipeline to version 4](https://github.com/orgs/opensafely-core/projects/15/views/1?pane=issue&itemId=81337702&issue=opensafely-core%7Cpipeline%7C224)
- Version 4 of pipeline removes support for cohort extractor and the `project.yaml` file should not have an `expectations` section.
- Update the ehrQL docs to use the v4.0 format