### PR TITLE
Improve performance and shrink quality of Hypothesis tests

### DIFF
--- a/tests/generative/generic_strategies.py
+++ b/tests/generative/generic_strategies.py
@@ -1,0 +1,40 @@
+from hypothesis import strategies as st
+
+
+# This is a variable that will normally be set to True, but which shrinking is
+# allowed to make False.
+#
+# Examples of where this is useful:
+#
+# * Turning off expensive test operations that you want to check but don't care
+#   about running if they turn out not to be relevant to the error you're
+#   seeing.
+# * Giving the shrinker a place to terminate generation in places where you've
+#   decided to do it yourself because e.g. the data was getting too large.
+usually = st.integers(0, 255).map(lambda n: n > 0)
+
+
+@st.composite
+def usually_all_of(draw, options, min_size=1):
+    """Generates a list of distinct elements drawn from `options`, of size at least
+    `min_size`. In the normal course of things, this will usually be all of `options`,
+    but the shrinker is allowed to remove elements from it, which can speed up
+    test execution during shrinking significantly."""
+    flags = draw(st.lists(usually, min_size=len(options), max_size=len(options)))
+
+    # In order to make sure enough of these are set, we set some
+    # of the flags to true. We do this unconditionally on whether enough
+    # flags are already set so that when shrinking we don't start to generate
+    # more data when some of the flags are shrunk to false.
+    extra_flags = draw(
+        st.lists(
+            st.integers(0, len(options) - 1),
+            min_size=min_size,
+            max_size=min_size,
+            unique=True,
+        )
+    )
+    n_set = flags.count(True)
+    for i in extra_flags[: max(min_size - n_set, 0)]:
+        flags[i] = True
+    return [option for option, include in zip(options, flags) if include]

--- a/tests/generative/test_query_model.py
+++ b/tests/generative/test_query_model.py
@@ -78,6 +78,12 @@ settings = dict(
     max_examples=(int(os.environ.get("GENTEST_EXAMPLES", 10))),
     deadline=None,
     derandomize=not os.environ.get("GENTEST_RANDOMIZE"),
+    # The explain phase is comparatively expensive here given how
+    # costly data generation is for our tests here, so we turn it
+    # off by default.
+    phases=(set(hyp.Phase) - {hyp.Phase.explain})
+    if os.environ.get("GENTEST_EXPLAIN") != "true"
+    else hyp.Phase,
 )
 
 


### PR DESCRIPTION
This is a number of small niceties and general improvements to the Hypothesis tests that I've spotted and seem useful to include.

Each of the changes should be relatively self contained and explain itself, but short summary:

1. This allows the shrinker to disable various things (tests to run, database backends) that it determines aren't necessary for the test to fail, which should make the tests much faster when shrinking.
2. The explain phase turns out to be really slow for your tests (this is downstream of data generation being slow, which is downstream of Hypothesis being slow for generating large data), so this disables them by default.
3. The max depth logic breaks shrinking, because it will often prevent it from shrinking the example to one that doesn't hit the max depth limit. This fixes that by always inserting a decision point the shrinker can use to force termination to happen.

There still seem to be some cases where this triggers bad shrinks, but I've not yet been able to reproduce them reliably (there's some nondeterminism going on there that I don't quite understand and need to figure out)