### PR TITLE
Exit with specific status codes for specific types of failure

### DIFF
--- a/ehrql/backends/base.py
+++ b/ehrql/backends/base.py
@@ -41,6 +41,9 @@ class BaseBackend:
         """
         return query
 
+    def get_exit_status_for_exception(self, exception):
+        return None
+
 
 class SQLBackend(BaseBackend):
     query_engine_class = None

--- a/tests/integration/backends/test_emis.py
+++ b/tests/integration/backends/test_emis.py
@@ -1,6 +1,8 @@
 from datetime import date, datetime
 
+import pytest
 import sqlalchemy
+from trino import exceptions as trino_exceptions
 
 from ehrql import create_dataset
 from ehrql.backends.emis import EMISBackend
@@ -76,6 +78,28 @@ def get_all_backend_columns_with_types(trino_database):
 
             # Drop the temp table
             temp_table.drop(trino_database.engine())
+
+
+@pytest.mark.parametrize(
+    "exception",
+    [
+        # These are trino errors that we may want to support in future with
+        # custom exit codes, but currently inherit from the base method
+        # Database errors
+        trino_exceptions.DatabaseError,
+        # OperationError is a subclass of DatabaseError
+        trino_exceptions.OperationalError,
+        # TrinoQueryError is encountered for over-complex/over-nested queries
+        trino_exceptions.TrinoQueryError,
+        # TrinoUserError is encountered for out of range numbers
+        trino_exceptions.TrinoUserError,
+        # TrinoUserError is encountered for bad/out of range dates
+        trino_exceptions.TrinoDataError,
+    ],
+)
+def test_backend_exceptions(exception):
+    backend = EMISBackend()
+    assert backend.get_exit_status_for_exception(exception) is None
 
 
 @register_test_for(emis.clinical_events)

--- a/tests/integration/backends/test_tpp.py
+++ b/tests/integration/backends/test_tpp.py
@@ -3,6 +3,7 @@ from datetime import date
 
 import pytest
 import sqlalchemy
+from pymssql import exceptions as pymssql_exceptions
 
 from ehrql import create_dataset
 from ehrql.backends.tpp import TPPBackend
@@ -129,6 +130,48 @@ def get_all_backend_columns_with_types(mssql_database):
         column_type = column_types[table, column]
         column_args = {"type": type_name, "collation": collation}
         yield table, column, column_type, column_args
+
+
+@pytest.mark.parametrize(
+    "exception,exit_code,custom_err",
+    [
+        (
+            pymssql_exceptions.OperationalError("Unexpected EOF from the server"),
+            3,
+            "Intermittent database error",
+        ),
+        (
+            pymssql_exceptions.OperationalError("DBPROCESS is dead or not enabled"),
+            3,
+            "Intermittent database error",
+        ),
+        (
+            pymssql_exceptions.OperationalError(
+                "Invalid object name 'CodedEvent_SNOMED'"
+            ),
+            4,
+            "CodedEvent_SNOMED table is currently not available",
+        ),
+        (pymssql_exceptions.DataError("Database data error"), 5, "Database error"),
+        (
+            pymssql_exceptions.InternalError("Other database internal error"),
+            5,
+            "Database error",
+        ),
+        (
+            pymssql_exceptions.DatabaseError("A plain old database error"),
+            5,
+            "Database error",
+        ),
+        (Exception("Other non-database error exception"), None, None),
+    ],
+)
+def test_backend_exceptions(exception, exit_code, custom_err):
+    backend = TPPBackend()
+    assert backend.get_exit_status_for_exception(exception) == exit_code
+
+    if custom_err is not None:  # pragma: no cover
+        assert any(custom_err in note for note in exception.__notes__)
 
 
 @register_test_for(tpp.addresses)

--- a/tests/lib/fixtures.py
+++ b/tests/lib/fixtures.py
@@ -1,3 +1,14 @@
+database_operational_error_dataset_definition = """
+from ehrql import Dataset, years
+from ehrql.tables.core import patients
+
+dataset = Dataset()
+dataset.define_population(patients.date_of_birth.year >= 1900)
+dataset.extended_dob = patients.date_of_birth + years(9999)
+
+dataset.configure_dummy_data(population_size=10)
+"""
+
 trivial_dataset_definition = """
 from ehrql import Dataset
 from ehrql.tables.tpp import patients


### PR DESCRIPTION
Fixes #1102 

For database tasks (generate_dataset_with_dsn, generate_measures_with_dsn), exit with specific exit codes supplied
by the backend.