### PR TITLE
Rename database column to demonstrate a working MappedTable

### DIFF
--- a/tests/unit/backends/test_base.py
+++ b/tests/unit/backends/test_base.py
@@ -130,7 +130,7 @@ def test_backend_definition_is_allowed_extra_tables_and_columns():
 
         patients = MappedTable(
             source="patient",
-            columns=dict(date_of_birth="date_of_birth", sex="sex"),
+            columns=dict(date_of_birth="DoB", sex="sex"),
         )
         events = MappedTable(
             source="patient",


### PR DESCRIPTION
* wanted to see this to verify that MappedTable::validate_against_table_schema() was functioning as expected
* the use of [set(self.column_map)](https://github.com/opensafely-core/ehrql/blob/main/ehrql/backends/base.py#L131) looked wrong to the untrained eye, but is actually correct
* do the same mapping as [the QueryTable test](https://github.com/opensafely-core/ehrql/blob/main/tests/unit/backends/test_base.py#L151)