### PR TITLE
Fix MSSQL retry code to work as intended

### DIFF
--- a/ehrql/utils/sqlalchemy_exec_utils.py
+++ b/ehrql/utils/sqlalchemy_exec_utils.py
@@ -55,7 +55,8 @@ def execute_with_retry_factory(
 ):
     """
     Wraps a `Connection.execute` method in logic which retries on certain classes of
-    error, using an expontential backoff strategy
+    error, using an expontential backoff strategy.
+    Consumes the iterator returned by the wrapped method and returns the results as a list instead.
     """
 
     def execute_with_retry(*args, **kwargs):
@@ -66,7 +67,7 @@ def execute_with_retry_factory(
             if retries > 0:
                 log(f"Retrying query (attempt {retries} / {max_retries})")
             try:
-                return execute(*args, **kwargs)
+                return list(execute(*args, **kwargs))
             except (OperationalError, InternalError) as e:
                 if retries >= max_retries:
                     raise

--- a/tests/unit/utils/test_sqlalchemy_exec_utils.py
+++ b/tests/unit/utils/test_sqlalchemy_exec_utils.py
@@ -62,47 +62,31 @@ def test_fetch_table_in_batches(table_size, batch_size, expected_query_count):
 ERROR = OperationalError("A bad thing happend", {}, None)
 
 
-def test_execute_with_retry():
-    tracker = {"error": True, "finished": []}
-
-    def log(msg):
-        tracker["logs"] = tracker.get("logs", []) + [msg]
-
-    num_parts = 4
-
-    def execute():  # Return an iterator to mimic Connection.execute
-        # Succeed for 0, 1, fail for 2 on the first go, then succeed for 2, 3
-        def execute_part(part, tr):
-            if "error" in tr and part == 2:
-                tr.pop("error")
-                raise ERROR
-            return part
-
-        return (execute_part(part, tracker) for part in range(num_parts))
-
-    execute_with_retry = execute_with_retry_factory(
-        execute, max_retries=3, retry_sleep=0, backoff_factor=2, log=log
-    )
-
-    # Do something with the results
-    for part in execute_with_retry():
-        tracker["finished"].append(part)
-
-    assert tracker["finished"] == list(range(num_parts))
-    assert "Retrying query (attempt 1 / 3)" in tracker["logs"]
-    assert "Retrying query (attempt 2 / 3)" not in tracker["logs"]
-
-
 @mock.patch("time.sleep")
-def test_sleep_between_retries(sleep):
-    execute = mock.Mock(side_effect=[ERROR, ERROR, ERROR, "its OK now"])
-    execute_with_retry = execute_with_retry_factory(
-        execute, max_retries=3, retry_sleep=10, backoff_factor=2
+def test_execute_with_retry(sleep):
+    log_messages = []
+
+    def error_during_iteration():
+        yield 1
+        yield 2
+        raise ERROR
+
+    execute = mock.Mock(
+        side_effect=[ERROR, ERROR, error_during_iteration(), ("it's", "OK", "now")]
     )
+    execute_with_retry = execute_with_retry_factory(
+        execute,
+        max_retries=3,
+        retry_sleep=10,
+        backoff_factor=2,
+        log=log_messages.append,
+    )
+
     # list() is always called on the successful return value
-    assert execute_with_retry() == list("its OK now")
+    assert execute_with_retry() == ["it's", "OK", "now"]
     assert execute.call_count == 4
     assert sleep.mock_calls == [mock.call(t) for t in [10, 20, 40]]
+    assert "Retrying query (attempt 3 / 3)" in log_messages
 
 
 @mock.patch("time.sleep")


### PR DESCRIPTION
Fixes #2144.

- Consume the iterator returned by `Connection.execute` within the while loop designed to retry downloads in case of transient DBPROCESS errors (The current code is not working as intended as it only passes the iterator along leaving for things to fail downstream) 
- Added a test that mimics the transient errors the retry code aims to catch