### PR TITLE
Generating dob and dod together

### DIFF
--- a/ehrql/dummy_data/query_info.py
+++ b/ehrql/dummy_data/query_info.py
@@ -260,7 +260,26 @@ def query_to_column_constraints(query):
             return {
                 column: [
                     Constraint.GeneralRange(
-                        minimum=reference_date - timedelta(days=365 * difference)
+                        minimum=reference_date.replace(
+                            year=reference_date.year - difference
+                        )
+                    )
+                ]
+            }
+        case Function.LT(
+            lhs=Function.DateAddYears(
+                lhs=SelectColumn() as column,
+                rhs=Value(value=difference),
+            ),
+            rhs=Value(value=reference_date),
+        ):
+            return {
+                column: [
+                    Constraint.GeneralRange(
+                        maximum=reference_date.replace(
+                            year=reference_date.year - difference
+                        ),
+                        includes_maximum=False,
                     )
                 ]
             }

--- a/tests/unit/dummy_data/test_query_to_constraints.py
+++ b/tests/unit/dummy_data/test_query_to_constraints.py
@@ -1,6 +1,6 @@
 from datetime import date
 
-from ehrql import create_dataset
+from ehrql import create_dataset, years
 from ehrql.dummy_data.query_info import (
     normalize_constraints,
     query_to_column_constraints,
@@ -74,3 +74,16 @@ def test_or_query_does_not_includes_constraints_on_only_one_size():
     constraints = query_to_column_constraints(variable_definitions["population"])
 
     assert len(constraints) == 0
+
+
+def test_gt_query_with_date_addition():
+    dataset = create_dataset()
+
+    index_date = date(2022, 3, 1)
+    died_more_than_10_years_ago = (patients.date_of_death + years(10)) < index_date
+    dataset.define_population(died_more_than_10_years_ago)
+
+    variable_definitions = compile(dataset)
+    constraints = query_to_column_constraints(variable_definitions["population"])
+
+    assert len(constraints) == 1


### PR DESCRIPTION
Adds a match case for a LT query with a DateAddYears as the LHS. Since the test I wrote for it involved date of death, which was handled as a special case and not generated by `generate_random_value()`, this also involves handling generation of date of death values. We generate dob and dod separately, and retry until the values are sensible (i.e. dob is before dod, and age at death is no more than 105 years).