### PR TITLE
Disable deadline when running Hypothesis tests

### DIFF
--- a/tests/unit/dummy_data_nextgen/test_specific_datasets.py
+++ b/tests/unit/dummy_data_nextgen/test_specific_datasets.py
@@ -2,7 +2,7 @@ from datetime import date
 from unittest import mock
 
 import pytest
-from hypothesis import example, given
+from hypothesis import example, given, settings
 from hypothesis import strategies as st
 
 from ehrql import create_dataset, years
@@ -196,6 +196,7 @@ def birthday_range_query(draw):
 
 @example(query=patients.date_of_birth < date(1900, 12, 31), target_size=1000)
 @example(query=patients.date_of_birth >= date(1900, 1, 2), target_size=1000)
+@settings(deadline=None)
 @given(query=birthday_range_query(), target_size=st.integers(1, 1000))
 @mock.patch("ehrql.dummy_data_nextgen.generator.time")
 def test_combined_age_range_in_one_shot(patched_time, query, target_size):


### PR DESCRIPTION
This test seems to fail somewhat erratically on CI with the deadline set. It never fails locally and didn't fail on the PR or the first time it ran on main, so I don't think the deadline check is doing anything useful here (possibly it only fails when the runner VMs at GitHub are under load or something).

Probably the right thing to do would be to disable the deadline globally on CI, but this is a more narrow fix to just get the build working reliably.