### PR TITLE
Add example targeting hard to hit coverage

### DIFF
--- a/tests/unit/dummy_data_nextgen/test_specific_datasets.py
+++ b/tests/unit/dummy_data_nextgen/test_specific_datasets.py
@@ -196,6 +196,7 @@ def birthday_range_query(draw):
 
 @example(query=patients.date_of_birth < date(1900, 12, 31), target_size=1000)
 @example(query=patients.date_of_birth >= date(1900, 1, 2), target_size=1000)
+@example(query=patients.date_of_birth >= date(2000, 12, 1), target_size=1000)
 @settings(deadline=None)
 @given(query=birthday_range_query(), target_size=st.integers(1, 1000))
 @mock.patch("ehrql.dummy_data_nextgen.generator.time")


### PR DESCRIPTION
There's a line in the new generator that is apparently only covered unreliably by this Hypothesis test. This adds an example to the test that reliably hits that line.