### PR TITLE
Plumbing for next-gen dummy data

### DIFF
--- a/docs/includes/generated_docs/language__dataset.md
+++ b/docs/includes/generated_docs/language__dataset.md
@@ -72,4 +72,18 @@ dataset.configure_dummy_data(population_size=10000)
 ```
 </div>
 
+<div class="attr-heading" id="Dataset.configure_next_gen_dummy_data">
+  <tt><strong>configure_next_gen_dummy_data</strong>(<em>population_size</em>)</tt>
+  <a class="headerlink" href="#Dataset.configure_next_gen_dummy_data" title="Permanent link">🔗</a>
+</div>
+<div markdown="block" class="indent">
+Configure the dummy data to be generated, using the 'next generation' dummy data.
+
+Note that this feature is currently experimental and is not fully documented yet.
+
+```py
+dataset.configure_next_gen_dummy_data(population_size=10000)
+```
+</div>
+
 </div>

--- a/docs/includes/generated_docs/language__measures.md
+++ b/docs/includes/generated_docs/language__measures.md
@@ -91,6 +91,20 @@ measures.configure_dummy_data(population_size=10000)
 ```
 </div>
 
+<div class="attr-heading" id="Measures.configure_next_gen_dummy_data">
+  <tt><strong>configure_next_gen_dummy_data</strong>(<em>population_size</em>)</tt>
+  <a class="headerlink" href="#Measures.configure_next_gen_dummy_data" title="Permanent link">🔗</a>
+</div>
+<div markdown="block" class="indent">
+Configure the dummy data to be generated, using the 'next generation' dummy data.
+
+Note that this feature is currently experimental and is not fully documented yet.
+
+```py
+measures.configure_next_gen_dummy_data(population_size=10000)
+```
+</div>
+
 <div class="attr-heading" id="Measures.configure_disclosure_control">
   <tt><strong>configure_disclosure_control</strong>(<em>enabled=True</em>)</tt>
   <a class="headerlink" href="#Measures.configure_disclosure_control" title="Permanent link">🔗</a>

--- a/ehrql/dummy_data_nextgen/__init__.py
+++ b/ehrql/dummy_data_nextgen/__init__.py
@@ -1,4 +1,5 @@
 from ehrql.dummy_data_nextgen.generator import DummyDataGenerator
+from ehrql.dummy_data_nextgen.measures import DummyMeasuresDataGenerator
 
 
-__all__ = ["DummyDataGenerator"]
+__all__ = ["DummyDataGenerator", "DummyMeasuresDataGenerator"]

--- a/ehrql/dummy_data_nextgen/generator.py
+++ b/ehrql/dummy_data_nextgen/generator.py
@@ -46,6 +46,7 @@ class DummyDataGenerator:
         self.patient_generator = DummyPatientGenerator(
             self.variable_definitions, self.random_seed, self.today
         )
+        log.info("Using next generation dummy data generation")
 
     def get_data(self):
         generator = self.patient_generator

--- a/ehrql/measures/measures.py
+++ b/ehrql/measures/measures.py
@@ -295,6 +295,20 @@ class Measures:
         ```
         """
         self.dummy_data_config.population_size = population_size
+        self.dummy_data_config.next_gen = False
+
+    def configure_next_gen_dummy_data(self, *, population_size):
+        """
+        Configure the dummy data to be generated, using the 'next generation' dummy data.
+
+        Note that this feature is currently experimental and is not fully documented yet.
+
+        ```py
+        measures.configure_next_gen_dummy_data(population_size=10000)
+        ```
+        """
+        self.dummy_data_config.population_size = population_size
+        self.dummy_data_config.next_gen = True
 
     def configure_disclosure_control(self, *, enabled=True):
         """

--- a/ehrql/query_language.py
+++ b/ehrql/query_language.py
@@ -45,6 +45,7 @@ class Error(Exception):
 @dataclasses.dataclass
 class DummyDataConfig:
     population_size: int = 10
+    next_gen: bool = False
 
 
 class Dataset:
@@ -111,6 +112,20 @@ class Dataset:
         ```
         """
         self.dummy_data_config.population_size = population_size
+        self.dummy_data_config.next_gen = False
+
+    def configure_next_gen_dummy_data(self, *, population_size):
+        """
+        Configure the dummy data to be generated, using the 'next generation' dummy data.
+
+        Note that this feature is currently experimental and is not fully documented yet.
+
+        ```py
+        dataset.configure_next_gen_dummy_data(population_size=10000)
+        ```
+        """
+        self.dummy_data_config.population_size = population_size
+        self.dummy_data_config.next_gen = True
 
     def __setattr__(self, name, value):
         if name == "population":

--- a/tests/acceptance/test_embedded_study.py
+++ b/tests/acceptance/test_embedded_study.py
@@ -10,6 +10,7 @@ from tests.lib.fixtures import (
     no_dataset_attribute_dataset_definition,
     parameterised_dataset_definition,
     trivial_dataset_definition,
+    trivial_dataset_definition_next_gen,
 )
 from tests.lib.tpp_schema import AllowedPatientsWithTypeOneDissent, Patient
 
@@ -152,8 +153,15 @@ def test_validate_dummy_data_error_path(study, tmp_path, capsys):
     assert "invalid literal for int" in captured.err
 
 
-def test_generate_dummy_data(study):
-    study.setup_from_string(trivial_dataset_definition)
+@pytest.mark.parametrize(
+    "dataset_definition_fixture",
+    (
+        trivial_dataset_definition,
+        trivial_dataset_definition_next_gen,
+    ),
+)
+def test_generate_dummy_data(study, dataset_definition_fixture):
+    study.setup_from_string(dataset_definition_fixture)
     study.generate(database=None, backend="expectations", extension=".csv")
     lines = study._dataset_path.read_text().splitlines()
     assert lines[0] == "patient_id,year"
@@ -177,9 +185,16 @@ def test_generate_dummy_data_with_dummy_tables(study, tmp_path):
     ]
 
 
-def test_create_dummy_tables(study, tmp_path):
+@pytest.mark.parametrize(
+    "dataset_definition_fixture",
+    (
+        trivial_dataset_definition,
+        trivial_dataset_definition_next_gen,
+    ),
+)
+def test_create_dummy_tables(study, tmp_path, dataset_definition_fixture):
     dummy_tables_path = tmp_path / "subdir" / "dummy_data"
-    study.setup_from_string(trivial_dataset_definition)
+    study.setup_from_string(dataset_definition_fixture)
     study.create_dummy_tables(dummy_tables_path)
     lines = (dummy_tables_path / "patients.csv").read_text().splitlines()
     assert lines[0] == "patient_id,date_of_birth"

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -115,6 +115,34 @@ def test_generate_measures_dummy_data_generated(tmp_path, disclosure_control_ena
 
 
 @pytest.mark.parametrize("disclosure_control_enabled", [False, True])
+def test_generate_measures_next_gen_dummy_data_generated(
+    tmp_path, disclosure_control_enabled
+):
+    measure_definitions = tmp_path / "measures.py"
+    measure_definitions.write_text(
+        MEASURE_DEFINITIONS
+        + "\nmeasures.configure_next_gen_dummy_data(population_size=10)"
+    )
+    output_file = tmp_path / "output.csv"
+
+    generate_measures(
+        measure_definitions,
+        output_file,
+        # Defaults
+        dsn=None,
+        backend_class=None,
+        query_engine_class=None,
+        dummy_tables_path=None,
+        dummy_data_file=None,
+        environ={},
+        user_args=(),
+    )
+    assert output_file.read_text().startswith(
+        "measure,interval_start,interval_end,ratio,numerator,denominator,sex"
+    )
+
+
+@pytest.mark.parametrize("disclosure_control_enabled", [False, True])
 def test_generate_measures_dummy_data_supplied(tmp_path, disclosure_control_enabled):
     measure_definitions = tmp_path / "measures.py"
     if disclosure_control_enabled:

--- a/tests/lib/fixtures.py
+++ b/tests/lib/fixtures.py
@@ -21,6 +21,18 @@ dataset.year = year
 dataset.configure_dummy_data(population_size=10)
 """
 
+trivial_dataset_definition_next_gen = """
+from ehrql import Dataset
+from ehrql.tables.tpp import patients
+
+dataset = Dataset()
+year = patients.date_of_birth.year
+dataset.define_population(year >= 1940)
+dataset.year = year
+
+dataset.configure_next_gen_dummy_data(population_size=10)
+"""
+
 no_dataset_attribute_dataset_definition = """
 from ehrql import Dataset
 from ehrql.tables.tpp import patients

--- a/tests/unit/measures/test_dummy_data.py
+++ b/tests/unit/measures/test_dummy_data.py
@@ -1,5 +1,7 @@
 from datetime import date
 
+import pytest
+
 from ehrql import years
 from ehrql.measures import INTERVAL, DummyMeasuresDataGenerator, Measures
 from ehrql.tables import Constraint, EventFrame, PatientFrame, Series, table
@@ -87,7 +89,11 @@ def test_population_is_nonzero_when_no_groups():
     assert generator.generator.population_size > 0
 
 
-def test_configured_population_size():
+@pytest.mark.parametrize(
+    "configure_dummy_data_method",
+    ["configure_dummy_data", "configure_next_gen_dummy_data"],
+)
+def test_configured_population_size(configure_dummy_data_method):
     measures = Measures()
     measures.define_measure(
         "had_event",
@@ -96,7 +102,7 @@ def test_configured_population_size():
         intervals=years(1).starting_on("2020-01-01"),
     )
 
-    measures.configure_dummy_data(population_size=10)
+    getattr(measures, configure_dummy_data_method)(population_size=10)
 
     generator = DummyMeasuresDataGenerator(measures, measures.dummy_data_config)
     assert generator.generator.population_size == 10

--- a/tests/unit/test_query_language.py
+++ b/tests/unit/test_query_language.py
@@ -121,6 +121,31 @@ def test_dataset():
     }
 
 
+def test_dataset_next_gen_dummy_data():
+    year_of_birth = patients.date_of_birth.year
+    dataset = Dataset()
+    dataset.define_population(year_of_birth <= 2000)
+    dataset.year_of_birth = year_of_birth
+    dataset.configure_next_gen_dummy_data(population_size=234)
+
+    assert dataset.year_of_birth is year_of_birth
+    assert dataset.dummy_data_config.population_size == 234
+    assert dataset.dummy_data_config.next_gen
+
+
+def test_dataset_dummy_data_configured_twice():
+    year_of_birth = patients.date_of_birth.year
+    dataset = Dataset()
+    dataset.define_population(year_of_birth <= 2000)
+    dataset.year_of_birth = year_of_birth
+    dataset.configure_next_gen_dummy_data(population_size=200)
+    dataset.configure_dummy_data(population_size=100)
+
+    assert dataset.year_of_birth is year_of_birth
+    assert dataset.dummy_data_config.population_size == 100
+    assert not dataset.dummy_data_config.next_gen
+
+
 def test_dataset_preserves_variable_order():
     dataset = Dataset()
     dataset.define_population(patients.exists_for_patient())


### PR DESCRIPTION
Allows users to configure dummy data to opt in to the next-gen package, by calling
```
dataset.configure_next_gen_dummy_data()
```
instead of 
```
dataset.configure_dummy_data()
```

Currently the signature is identical for the two methods; only population size is configurable.

Note that users could configure dummy data twice (as they could before); whichever definition is last is the one used.
