### PR TITLE
Replace dependabot, use github app token for PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,13 +1,6 @@
 version: 2
 
 updates:
-  - package-ecosystem: "pip"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 20
-    commit-message:
-      prefix: "chore: "
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -1,0 +1,26 @@
+name: Update python dependencies
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron:  "0 23 * * *"
+
+jobs:
+  update-dependencies:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: "opensafely-core/setup-action@v1"
+      with:
+        python-version: "3.10"
+        install-just: true
+
+    - uses: actions/create-github-app-token@v1
+      id: generate-token
+      with:
+        app-id: 1031449  # opensafely-core Create PR app
+        private-key: ${{ secrets.CREATE_PR_APP_PRIVATE_KEY }}
+
+    - uses: opensafely-core/update-dependencies-action@v1
+      with:
+        token: ${{ steps.generate-token.outputs.token }}

--- a/.github/workflows/update-external-studies.yml
+++ b/.github/workflows/update-external-studies.yml
@@ -27,6 +27,13 @@ jobs:
       - name: Disable pre-commit hooks
         run: git config core.hooksPath /dev/null
 
+      - name: Generate app token
+        uses: actions/create-github-app-token@v1
+        id: generate-token
+        with:
+          app-id: 1031449  # opensafely-core Create PR app
+          private-key: ${{ secrets.CREATE_PR_APP_PRIVATE_KEY }}
+
       - name: Create a Pull Request if there are any changes
         id: create_pr
         uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f # v7.0.5
@@ -38,20 +45,11 @@ jobs:
           committer: "opensafely-github-bot <opensafely-github-bot@users.noreply.github.com>"
           commit-message: "chore: Update `external_studies` test code"
           title: "Update `external_studies` test code"
-          body: |
-            To get tests to run on this PR there's an odd workflow:
-             - Approve it
-             - Close it
-             - Re-open it
-             - Re-enable automerge
-
-            You can read more on why this is needed in the `create-pull-request` [docs][1].
-
-            [1]: https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#triggering-further-workflow-runs
+          token: ${{ steps.generate-token.outputs.token }}
 
       # The PR will still require manual approval, this just reduces it to a one-click process
       - name: Enable automerge
         if: steps.create_pr.outputs.pull-request-operation == 'created'
         run: gh pr merge --auto --squash ${{ steps.create_pr.outputs.pull-request-number }}
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}

--- a/.github/workflows/update-pledge.yml
+++ b/.github/workflows/update-pledge.yml
@@ -20,6 +20,13 @@ jobs:
       - name: "Ensure `bin/pledge` is at latest version"
         run: just update-pledge
 
+      - name: Generate app token
+        uses: actions/create-github-app-token@v1
+        id: generate-token
+        with:
+          app-id: 1031449  # opensafely-core Create PR app
+          private-key: ${{ secrets.CREATE_PR_APP_PRIVATE_KEY }}
+
       - name: "Create a Pull Request if there are any changes"
         id: create_pr
         uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f # v7.0.5
@@ -31,20 +38,11 @@ jobs:
           committer: "opensafely-github-bot <opensafely-github-bot@users.noreply.github.com>"
           commit-message: "fix: Update `bin/pledge`"
           title: "Update `bin/pledge`"
-          body: |
-            To get tests to run on this PR there's an odd workflow:
-             - Approve it
-             - Close it
-             - Re-open it
-             - Re-enable automerge
-
-            You can read more on why this is needed in the `create-pull-request` [docs][1].
-
-            [1]: https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#triggering-further-workflow-runs
+          token: ${{ steps.generate-token.outputs.token }}
 
       # The PR will still require manual approval, this just reduces it to a one-click process
       - name: Enable automerge
         if: steps.create_pr.outputs.pull-request-operation == 'created'
         run: gh pr merge --auto --squash ${{ steps.create_pr.outputs.pull-request-number }}
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}

--- a/justfile
+++ b/justfile
@@ -38,6 +38,10 @@ pip-compile *ARGS: devenv
     $BIN/pip-compile --allow-unsafe --generate-hashes --strip-extras "$@"
 
 
+update-dependencies: devenv
+  just pip-compile -U requirements.prod.in
+  just pip-compile -U requirements.dev.in
+
 # Ensure dev and prod requirements installed and up to date
 devenv: virtualenv
     #!/usr/bin/env bash


### PR DESCRIPTION
- Replace the python dependency updates with our custom update-dependencies-action, which updates all dependencies and opens a PR if necessary. We keep dependabot for Github Action updates only.
- Use the github app tokens in update-pledge and update-external-studies so any PRs they create will trigger the relevant workflows

