### PR TITLE
Make dummy_tables_path optional for starting the ehrQL sandbox

### DIFF
--- a/docs/explanation/running-ehrql.md
+++ b/docs/explanation/running-ehrql.md
@@ -30,17 +30,18 @@ by allowing you to interactively query some dummy tables.
 :computer:
 To start the sandbox, from the `learning-ehrql` directory, run:
 
-    opensafely exec ehrql:v1 sandbox example-data
+    opensafely exec ehrql:v1 sandbox
 
 You will now be in a session with an interactive Python console,
 and you should see something like this:
 
 ```pycon
-Python 3.11.3 (main, Apr  5 2023, 14:15:06) [GCC 9.4.0] on linux
-Type "help", "copyright", "credits" or "license" for more information.
-(InteractiveConsole)
+ehrQL Sandbox Console
+Dummy tables used: example-data
 >>>
 ```
+
+By default, the sandbox uses the CSV files in `example-data` to represent the data tables you will be querying. You may also [specify a path for dummy tables](../includes/generated_docs/cli.md#--sandbox).
 
 The `>>>` is the Python prompt for user input.
 When you see this, you can input Python statements,

--- a/docs/includes/generated_docs/cli.md
+++ b/docs/includes/generated_docs/cli.md
@@ -372,7 +372,7 @@ Dotted import path to Backend class, or one of: `emis`, `tpp`
   sandbox
 </h2>
 ```
-ehrql sandbox DUMMY_TABLES_PATH [--help]
+ehrql sandbox [DUMMY_TABLES_PATH] [--help]
 ```
 Start the ehrQL sandbox environment.
 
@@ -382,7 +382,9 @@ Start the ehrQL sandbox environment.
 </div>
 <div markdown="block" class="indent">
 Path to directory of data files (one per table), supported formats are:
-`.arrow`, `.csv`, `.csv.gz`
+`.arrow`, `.csv`, `.csv.gz`.
+If not provided, the `example-data` directory will be used. If `example-data` does not exist,
+ehrQL will ask for permission to create it.
 
 </div>
 

--- a/docs/tutorial/working-with-tables/index.md
+++ b/docs/tutorial/working-with-tables/index.md
@@ -1,13 +1,14 @@
 In this section, you will work with tables in the sandbox.
 The *sandbox* is an environment for experimenting with ehrQL
-that contains a small amount of dummy data.
+that contains a small amount of dummy data. By default, the
+sandbox uses the CSV files in `example-data` as dummy data.
 
 ## Start the sandbox
 
 In the terminal, type
 
 ```
-opensafely exec ehrql:v1 sandbox example-data
+opensafely exec ehrql:v1 sandbox
 ```
 
 and press ++enter++.

--- a/ehrql/docs/cli.py
+++ b/ehrql/docs/cli.py
@@ -56,6 +56,13 @@ def get_argument(action):
             "usage_long": ", ".join(action.option_strings),
             "description": action.help,
         }
+    elif isinstance(action, argparse._StoreAction) and action.nargs == "?":
+        return {
+            "id": action.dest,
+            "usage_short": f"[{action.dest.upper()}]",
+            "usage_long": action.dest.upper(),
+            "description": action.help,
+        }
     elif isinstance(action, argparse._StoreAction) and not action.required:
         return {
             "id": action.option_strings[-1].lstrip("-"),

--- a/ehrql/sandbox.py
+++ b/ehrql/sandbox.py
@@ -29,7 +29,8 @@ def run(dummy_tables_path):
     readline.set_completer(rlcompleter.Completer(namespace).complete)
 
     # Start running a Python REPL.
-    code.interact(local=namespace)
+    banner = f"ehrQL Sandbox Console\n Dummy tables used: {dummy_tables_path}"
+    code.interact(banner=banner, local=namespace)
 
 
 def excepthook(type_, exc, tb):


### PR DESCRIPTION
Fixes #2184.

- Make the sandbox command default to using `example-data` if `dummy_tables_path` is not provided. 
- If `example-data` does not exist, ask to dump it in the current directory (rationale in the ticket).
- To preserve the existing syntax, `dummy_tables_path` is an optional *positional* argument, so update `cli.py` to accommodate this.
- Add a banner message at the beginning of the sandbox stating the location of the dummy tables used, now that this is not an explicit argument for starting the sandbox. This replaces the default `InteractiveConsole` banner message.