### PR TITLE
Fix Python version in workflow file

### DIFF
--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: "opensafely-core/setup-action@v1"
       with:
-        python-version: "3.10"
+        python-version: "3.11"
         install-just: true
 
     - uses: actions/create-github-app-token@v1

--- a/justfile
+++ b/justfile
@@ -216,7 +216,7 @@ test-unit *ARGS: devenv
 # Set GENTEST_EXAMPLES to change the number of examples generated.
 # Set GENTEST_MAX_DEPTH to change the depth of generated query trees.
 #
-# Run generative tests using more than the small determinstic set of examples used in CI
+# Run generative tests using more than the small deterministic set of examples used in CI
 test-generative *ARGS: devenv
     GENTEST_EXAMPLES=${GENTEST_EXAMPLES:-200} \
     GENTEST_RANDOMIZE=${GENTEST_RANDOMIZE:-t} \


### PR DESCRIPTION
Ideally we wouldn't have to specify this version repeatedly in each action and could re-use the value from `.python-version` (which Github's `setup-python` action supports). I've made a ticket here:
 * https://github.com/opensafely-core/setup-action/issues/14 