### PR TITLE
Fix occasional assertion failure in nextgen dummy data

### DIFF
--- a/ehrql/dummy_data_nextgen/generator.py
+++ b/ehrql/dummy_data_nextgen/generator.py
@@ -285,9 +285,10 @@ class DummyPatientGenerator:
                 # TODO: Currently this code only runs when the column is date_of_birth
                 # so condition is always hit. Remove this pragma when that stops being
                 # the case.
-                if column_info.get_constraint(
-                    Constraint.FirstOfMonth
-                ):  # pragma: no branch
+                if (
+                    column_info.get_constraint(Constraint.FirstOfMonth)
+                    and minimum.day != 1
+                ):
                     if minimum.month == 12:
                         minimum = minimum.replace(year=minimum.year + 1, month=1, day=1)
                     else:

--- a/ehrql/query_model/nodes.py
+++ b/ehrql/query_model/nodes.py
@@ -141,6 +141,9 @@ class AggregatedSeries(OneRowPerPatientSeries): ...
 class Value(OneRowPerPatientSeries[T]):
     value: T
 
+    def _repr_pretty_(self, p, cycle):
+        p.pretty(self.value)
+
     def __post_init__(self):
         super().__post_init__()
         # Because we need to be strict about equality (see `__eq__()` below) we can only
@@ -192,10 +195,16 @@ class SelectTable(ManyRowsPerPatientFrame):
     name: str
     schema: TableSchema
 
+    def _repr_pretty_(self, p, cycle):
+        p.pretty(self.name)
+
 
 class SelectPatientTable(OneRowPerPatientFrame):
     name: str
     schema: TableSchema
+
+    def _repr_pretty_(self, p, cycle):
+        p.text(self.name)
 
 
 class InlinePatientTable(OneRowPerPatientFrame):
@@ -223,6 +232,10 @@ class InlinePatientTable(OneRowPerPatientFrame):
 class SelectColumn(Series):
     source: Frame
     name: str
+
+    def _repr_pretty_(self, p, cycle):
+        p.pretty(self.source)
+        p.text("." + self.name)
 
 
 class Filter(ManyRowsPerPatientFrame):
@@ -293,37 +306,86 @@ class Function:
         lhs: Series[T]
         rhs: Series[T]
 
+        def _repr_pretty_(self, p, cycle):
+            p.pretty(self.lhs)
+            p.text(" == ")
+            p.pretty(self.rhs)
+
     class NE(Series[bool]):
         lhs: Series[T]
         rhs: Series[T]
+
+        def _repr_pretty_(self, p, cycle):
+            p.pretty(self.lhs)
+            p.text(" != ")
+            p.pretty(self.rhs)
 
     class LT(Series[bool]):
         lhs: Series[Comparable]
         rhs: Series[Comparable]
 
+        def _repr_pretty_(self, p, cycle):
+            p.pretty(self.lhs)
+            p.text(" < ")
+            p.pretty(self.rhs)
+
     class LE(Series[bool]):
         lhs: Series[Comparable]
         rhs: Series[Comparable]
+
+        def _repr_pretty_(self, p, cycle):
+            p.pretty(self.lhs)
+            p.text(" <= ")
+            p.pretty(self.rhs)
 
     class GT(Series[bool]):
         lhs: Series[Comparable]
         rhs: Series[Comparable]
 
+        def _repr_pretty_(self, p, cycle):
+            p.pretty(self.lhs)
+            p.text(" > ")
+            p.pretty(self.rhs)
+
     class GE(Series[bool]):
         lhs: Series[Comparable]
         rhs: Series[Comparable]
+
+        def _repr_pretty_(self, p, cycle):
+            p.pretty(self.lhs)
+            p.text(" >= ")
+            p.pretty(self.rhs)
 
     # Boolean
     class And(Series[bool]):
         lhs: Series[bool]
         rhs: Series[bool]
 
+        def _repr_pretty_(self, p, cycle):
+            p.text("(")
+            p.pretty(self.lhs)
+            p.text(") & (")
+            p.pretty(self.rhs)
+            p.text(")")
+
     class Or(Series[bool]):
         lhs: Series[bool]
         rhs: Series[bool]
 
+        def _repr_pretty_(self, p, cycle):
+            p.text("(")
+            p.pretty(self.lhs)
+            p.text(") | (")
+            p.pretty(self.rhs)
+            p.text(")")
+
     class Not(Series[bool]):
         source: Series[bool]
+
+        def _repr_pretty_(self, p, cycle):
+            p.text("~(")
+            p.pretty(self.source)
+            p.text(")")
 
     # Null handling
     class IsNull(Series[bool]):

--- a/tests/generative/test_query_model.py
+++ b/tests/generative/test_query_model.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import hypothesis as hyp
 import hypothesis.strategies as st
 import pytest
-from hypothesis.vendor.pretty import _singleton_pprinters
+from hypothesis.vendor.pretty import _singleton_pprinters, pretty
 
 from ehrql.dummy_data import DummyDataGenerator
 from ehrql.query_model.introspection import all_unique_nodes
@@ -116,6 +116,7 @@ class EnabledTests(Enum):
     dummy_data = auto()
     main_query = auto()
     all_population = auto()
+    pretty_printing = auto()
 
 
 if TEST_NAMES_TO_RUN := set(
@@ -150,6 +151,9 @@ def test_query_model(
         run_dummy_data_test(population, variable)
     if EnabledTests.main_query in test_types:
         run_test(query_engines, data, population, variable, recorder)
+    if EnabledTests.pretty_printing in test_types:
+        pretty(population)
+        pretty(data)
 
     if EnabledTests.all_population in test_types:
         # We run the test again using a simplified population definition which includes all

--- a/tests/unit/test_query_language.py
+++ b/tests/unit/test_query_language.py
@@ -635,6 +635,7 @@ fn_names = sorted(
         "__radd__",
         "__rsub__",
         "_cast",
+        "_repr_pretty_",
     },
 )
 


### PR DESCRIPTION
There turned out to be a bug for some date queries that could only be satisfied by a single date where the minimum would get forced above the maximum. This fixes that.

It also improves the formatting of many queries to more closely match how they're written in ehrql when printed by Hypothesis because manually translating this example annoyed me. I've not covered the complete set, only most of the ones I was interested in, but it's easy to add more as and when we need them.

We're hitting a minor Hypothesis bug in this (I'll fix it later) which means that we've got a superfluous `Series` type wrapped around the query being printed, but this doesn't really matter for actually using it.