### PR TITLE
Temporarily revert to denylist for T1OO

### DIFF
--- a/tests/integration/backends/test_tpp.py
+++ b/tests/integration/backends/test_tpp.py
@@ -19,7 +19,6 @@ from tests.lib.tpp_schema import (
     OPA,
     OPA_ARCHIVED,
     UKRR,
-    AllowedPatientsWithTypeOneDissent,
     APCS_Cost,
     APCS_Cost_ARCHIVED,
     APCS_Cost_JRC20231009_LastFilesToContainAllHistoricalCostData,
@@ -52,6 +51,7 @@ from tests.lib.tpp_schema import (
     Organisation,
     Patient,
     PatientAddress,
+    PatientsWithTypeOneDissent,
     PotentialCareHomeAddress,
     RegistrationHistory,
     Relationship,
@@ -3112,8 +3112,8 @@ def test_t1oo_patients_excluded_as_specified(mssql_database, suffix, expected):
         Patient(Patient_ID=2, DateOfBirth=date(2002, 1, 1)),
         Patient(Patient_ID=3, DateOfBirth=date(2003, 1, 1)),
         Patient(Patient_ID=4, DateOfBirth=date(2004, 1, 1)),
-        AllowedPatientsWithTypeOneDissent(Patient_ID=1),
-        AllowedPatientsWithTypeOneDissent(Patient_ID=4),
+        PatientsWithTypeOneDissent(Patient_ID=2),
+        PatientsWithTypeOneDissent(Patient_ID=3),
     )
 
     dataset = create_dataset()


### PR DESCRIPTION
This reflects the new interim agreement with respect to T1OOs. This change is only required while TPP update the logic for populating the allowlist. Once that is complete we can switch back to using the allowlist. For this reason I am leaving some of the end-to-end test setup in place even though it is not strictly required while using the denylist.

Reverts some of #2072