### PR TITLE
Prevent pip-compile showing absolute constraint paths

### DIFF
--- a/justfile
+++ b/justfile
@@ -40,7 +40,7 @@ pip-compile *ARGS: devenv
 
 update-dependencies: devenv
   just pip-compile -U requirements.prod.in
-  just pip-compile -U requirements.dev.in
+  just pip-compile -U requirements.dev.in -c requirements.prod.txt
 
 # Ensure dev and prod requirements installed and up to date
 devenv: virtualenv

--- a/requirements.dev.in
+++ b/requirements.dev.in
@@ -1,8 +1,6 @@
---constraint requirements.prod.txt
-
 # Additional dev requirements
 # To generate a requirements file that includes both prod and dev requirements, run:
-# pip-compile --generate-hashes --output-file=requirements.dev.txt requirements.dev.in
+# pip-compile --generate-hashes --output-file=requirements.dev.txt --constraint requirements.prod.txt requirements.dev.in
 
 docker
 hypothesis


### PR DESCRIPTION
If the --constraints path is included in a requirements.*.in file, the absolute path is shown in the comments in the requirements.*.txt output. This appears to be related to a pip upgrade. Specifying the --constraints path as a command line arg instead results in the expected relative paths.

We can likely change back when this issue is addressed: https://github.com/jazzband/pip-tools/issues/2131