### PR TITLE
Add helper for querying `ons_deaths` "cause of death" fields

### DIFF
--- a/docs/how-to/examples.md
+++ b/docs/how-to/examples.md
@@ -152,6 +152,26 @@ dataset.define_population(patients.exists_for_patient())
 
 :notepad_spiral: There are currently [multiple](https://github.com/opensafely-core/ehrql/blob/d29ff8ab2cebf3522258c408f8225b7a76f7b6f2/ehrql/tables/beta/core.py#L78-L92) cause of death fields. We aim to resolve these to a single feature in the future.
 
+
+### Finding patients with a particular cause of death
+
+The `ons_deaths` table has multiple "cause of death" fields. Using the
+[`cause_of_death_is_in()`](../reference/schemas/core.md#ons_deaths.cause_of_death_is_in)
+method we can match a codelist against all of these at once.
+
+```ehrql
+from ehrql import create_dataset, codelist_from_csv
+from ehrql.tables.core import ons_deaths, patients
+
+dataset = create_dataset()
+
+cause_of_death_X_codelist = codelist_from_csv("XXX", column="YYY")
+
+dataset.died_with_X = ons_deaths.cause_of_death_is_in(cause_of_death_X_codelist)
+dataset.define_population(patients.exists_for_patient())
+```
+
+
 ### Finding each patient's sex
 
 ```ehrql

--- a/docs/includes/generated_docs/schemas/core.md
+++ b/docs/includes/generated_docs/schemas/core.md
@@ -139,9 +139,11 @@ Registered deaths
 Date and cause of death based on information recorded when deaths are
 certified and registered in England and Wales from February 2019 onwards.
 The data provider is the Office for National Statistics (ONS).
+This table is updated approximately weekly in OpenSAFELY.
 
-This table includes the underlying cause of death and up to 15 medical conditions mentioned on the death certificate.
-These codes (`cause_of_death_01` to `cause_of_death_15`) are not ordered meaningfully.
+This table includes the underlying cause of death and up to 15 medical conditions
+mentioned on the death certificate.  These codes (`cause_of_death_01` to
+`cause_of_death_15`) are not ordered meaningfully.
 
 More information about this table can be found in following documents provided by the ONS:
 
@@ -154,9 +156,11 @@ a small number of patients have multiple registered deaths.
 This table contains the earliest registered death.
 The `ehrql.tables.raw.core.ons_deaths` table contains all registered deaths.
 
-!!! tip
-    If you need to query for place of death, please note that
-    this is only available in the `tpp` backend
+!!! warning
+    There is also a lag in ONS death recording caused amongst other things by things
+    like autopsies and inquests delaying reporting on cause of death. This is
+    evident in the [OpenSAFELY historical database coverage
+    report](https://reports.opensafely.org/reports/opensafely-tpp-database-history/#ons_deaths)
 <div markdown="block" class="definition-list-wrapper">
   <div class="title">Columns</div>
   <dl markdown="block">
@@ -179,7 +183,7 @@ Patient's date of death.
     <code>ICD-10 code</code>
   </dt>
   <dd markdown="block">
-Patient's underlying cause of death of death.
+Patient's underlying cause of death.
 
   </dd>
 </div>
@@ -361,6 +365,38 @@ Medical condition mentioned on the death certificate.
   <dd markdown="block">
 Medical condition mentioned on the death certificate.
 
+  </dd>
+</div>
+
+  </dl>
+</div>
+<div markdown="block" class="definition-list-wrapper">
+  <div class="title">Methods</div>
+  <dl markdown="block">
+<div markdown="block">
+  <dt id="ons_deaths.cause_of_death_is_in">
+    <strong>cause_of_death_is_in(</strong>codelist<strong>)</strong>
+    <a class="headerlink" href="#ons_deaths.cause_of_death_is_in" title="Permanent link">🔗</a>
+    <code></code>
+  </dt>
+  <dd markdown="block">
+Match `codelist` against the `underlying_cause_of_death` field and all 15
+separate `cause_of_death` fields.
+
+This method evaluates as `True` if _any_ code in the codelist matches _any_ of
+these fields.
+    <details markdown="block">
+    <summary>View method definition</summary>
+```py
+columns = [
+    "underlying_cause_of_death",
+    *[f"cause_of_death_{i:02d}" for i in range(1, 16)],
+]
+conditions = [getattr(ons_deaths, column).is_in(codelist) for column in columns]
+return functools.reduce(operator.or_, conditions)
+
+```
+    </details>
   </dd>
 </div>
 

--- a/docs/includes/generated_docs/schemas/emis.md
+++ b/docs/includes/generated_docs/schemas/emis.md
@@ -140,9 +140,11 @@ Registered deaths
 Date and cause of death based on information recorded when deaths are
 certified and registered in England and Wales from February 2019 onwards.
 The data provider is the Office for National Statistics (ONS).
+This table is updated approximately weekly in OpenSAFELY.
 
-This table includes the underlying cause of death and up to 15 medical conditions mentioned on the death certificate.
-These codes (`cause_of_death_01` to `cause_of_death_15`) are not ordered meaningfully.
+This table includes the underlying cause of death and up to 15 medical conditions
+mentioned on the death certificate.  These codes (`cause_of_death_01` to
+`cause_of_death_15`) are not ordered meaningfully.
 
 More information about this table can be found in following documents provided by the ONS:
 
@@ -155,9 +157,11 @@ a small number of patients have multiple registered deaths.
 This table contains the earliest registered death.
 The `ehrql.tables.raw.core.ons_deaths` table contains all registered deaths.
 
-!!! tip
-    If you need to query for place of death, please note that
-    this is only available in the `tpp` backend
+!!! warning
+    There is also a lag in ONS death recording caused amongst other things by things
+    like autopsies and inquests delaying reporting on cause of death. This is
+    evident in the [OpenSAFELY historical database coverage
+    report](https://reports.opensafely.org/reports/opensafely-tpp-database-history/#ons_deaths)
 <div markdown="block" class="definition-list-wrapper">
   <div class="title">Columns</div>
   <dl markdown="block">
@@ -180,7 +184,7 @@ Patient's date of death.
     <code>ICD-10 code</code>
   </dt>
   <dd markdown="block">
-Patient's underlying cause of death of death.
+Patient's underlying cause of death.
 
   </dd>
 </div>
@@ -362,6 +366,38 @@ Medical condition mentioned on the death certificate.
   <dd markdown="block">
 Medical condition mentioned on the death certificate.
 
+  </dd>
+</div>
+
+  </dl>
+</div>
+<div markdown="block" class="definition-list-wrapper">
+  <div class="title">Methods</div>
+  <dl markdown="block">
+<div markdown="block">
+  <dt id="ons_deaths.cause_of_death_is_in">
+    <strong>cause_of_death_is_in(</strong>codelist<strong>)</strong>
+    <a class="headerlink" href="#ons_deaths.cause_of_death_is_in" title="Permanent link">🔗</a>
+    <code></code>
+  </dt>
+  <dd markdown="block">
+Match `codelist` against the `underlying_cause_of_death` field and all 15
+separate `cause_of_death` fields.
+
+This method evaluates as `True` if _any_ code in the codelist matches _any_ of
+these fields.
+    <details markdown="block">
+    <summary>View method definition</summary>
+```py
+columns = [
+    "underlying_cause_of_death",
+    *[f"cause_of_death_{i:02d}" for i in range(1, 16)],
+]
+conditions = [getattr(ons_deaths, column).is_in(codelist) for column in columns]
+return functools.reduce(operator.or_, conditions)
+
+```
+    </details>
   </dd>
 </div>
 

--- a/docs/includes/generated_docs/schemas/tpp.md
+++ b/docs/includes/generated_docs/schemas/tpp.md
@@ -1738,9 +1738,9 @@ certified and registered in England and Wales from February 2019 onwards.
 The data provider is the Office for National Statistics (ONS).
 This table is updated approximately weekly in OpenSAFELY.
 
-This table includes the underlying cause of death , place of death and up
-to 15 medical conditions mentioned on the death certificate.
-These codes (`cause_of_death_01` to `cause_of_death_15`) are not ordered meaningfully.
+This table includes the underlying cause of death and up to 15 medical conditions
+mentioned on the death certificate.  These codes (`cause_of_death_01` to
+`cause_of_death_15`) are not ordered meaningfully.
 
 More information about this table can be found in following documents provided by the ONS:
 
@@ -1751,11 +1751,17 @@ More information about this table can be found in following documents provided b
 In the associated database table [ONS_Deaths](https://reports.opensafely.org/reports/opensafely-tpp-database-schema/#ONS_Deaths),
 a small number of patients have multiple registered deaths.
 This table contains the earliest registered death.
-The `ehrql.tables.raw.tpp.ons_deaths` table contains all registered deaths.
+The `ehrql.tables.raw.core.ons_deaths` table contains all registered deaths.
 
 !!! warning
-    There is also a lag in ONS death recording caused amongst other things by things like autopsies and inquests delaying
-    reporting on cause of death. This is evident in the [OpenSAFELY historical database coverage report](https://reports.opensafely.org/reports/opensafely-tpp-database-history/#ons_deaths)
+    There is also a lag in ONS death recording caused amongst other things by things
+    like autopsies and inquests delaying reporting on cause of death. This is
+    evident in the [OpenSAFELY historical database coverage
+    report](https://reports.opensafely.org/reports/opensafely-tpp-database-history/#ons_deaths)
+
+!!! tip
+    Note that this version of the table, which includes a place of death field, is
+    only available in the `tpp` schema and not the `core` schema.
 <div markdown="block" class="definition-list-wrapper">
   <div class="title">Columns</div>
   <dl markdown="block">
@@ -1772,26 +1778,13 @@ Patient's date of death.
 </div>
 
 <div markdown="block">
-  <dt id="ons_deaths.place">
-    <strong>place</strong>
-    <a class="headerlink" href="#ons_deaths.place" title="Permanent link">🔗</a>
-    <code>string</code>
-  </dt>
-  <dd markdown="block">
-Patient's place of death.
-
- * Possible values: `Care Home`, `Elsewhere`, `Home`, `Hospice`, `Hospital`, `Other communal establishment`
-  </dd>
-</div>
-
-<div markdown="block">
   <dt id="ons_deaths.underlying_cause_of_death">
     <strong>underlying_cause_of_death</strong>
     <a class="headerlink" href="#ons_deaths.underlying_cause_of_death" title="Permanent link">🔗</a>
     <code>ICD-10 code</code>
   </dt>
   <dd markdown="block">
-Patient's underlying cause of death of death.
+Patient's underlying cause of death.
 
   </dd>
 </div>
@@ -1973,6 +1966,51 @@ Medical condition mentioned on the death certificate.
   <dd markdown="block">
 Medical condition mentioned on the death certificate.
 
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="ons_deaths.place">
+    <strong>place</strong>
+    <a class="headerlink" href="#ons_deaths.place" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+Patient's place of death.
+
+ * Possible values: `Care Home`, `Elsewhere`, `Home`, `Hospice`, `Hospital`, `Other communal establishment`
+  </dd>
+</div>
+
+  </dl>
+</div>
+<div markdown="block" class="definition-list-wrapper">
+  <div class="title">Methods</div>
+  <dl markdown="block">
+<div markdown="block">
+  <dt id="ons_deaths.cause_of_death_is_in">
+    <strong>cause_of_death_is_in(</strong>codelist<strong>)</strong>
+    <a class="headerlink" href="#ons_deaths.cause_of_death_is_in" title="Permanent link">🔗</a>
+    <code></code>
+  </dt>
+  <dd markdown="block">
+Match `codelist` against the `underlying_cause_of_death` field and all 15
+separate `cause_of_death` fields.
+
+This method evaluates as `True` if _any_ code in the codelist matches _any_ of
+these fields.
+    <details markdown="block">
+    <summary>View method definition</summary>
+```py
+columns = [
+    "underlying_cause_of_death",
+    *[f"cause_of_death_{i:02d}" for i in range(1, 16)],
+]
+conditions = [getattr(ons_deaths, column).is_in(codelist) for column in columns]
+return functools.reduce(operator.or_, conditions)
+
+```
+    </details>
   </dd>
 </div>
 

--- a/ehrql/tables/core.py
+++ b/ehrql/tables/core.py
@@ -159,9 +159,11 @@ class ons_deaths(PatientFrame):
     Date and cause of death based on information recorded when deaths are
     certified and registered in England and Wales from February 2019 onwards.
     The data provider is the Office for National Statistics (ONS).
+    This table is updated approximately weekly in OpenSAFELY.
 
-    This table includes the underlying cause of death and up to 15 medical conditions mentioned on the death certificate.
-    These codes (`cause_of_death_01` to `cause_of_death_15`) are not ordered meaningfully.
+    This table includes the underlying cause of death and up to 15 medical conditions
+    mentioned on the death certificate.  These codes (`cause_of_death_01` to
+    `cause_of_death_15`) are not ordered meaningfully.
 
     More information about this table can be found in following documents provided by the ONS:
 
@@ -174,10 +176,11 @@ class ons_deaths(PatientFrame):
     This table contains the earliest registered death.
     The `ehrql.tables.raw.core.ons_deaths` table contains all registered deaths.
 
-    !!! tip
-        If you need to query for place of death, please note that
-        this is only available in the `tpp` backend
-
+    !!! warning
+        There is also a lag in ONS death recording caused amongst other things by things
+        like autopsies and inquests delaying reporting on cause of death. This is
+        evident in the [OpenSAFELY historical database coverage
+        report](https://reports.opensafely.org/reports/opensafely-tpp-database-history/#ons_deaths)
     """
 
     date = Series(

--- a/ehrql/tables/core.py
+++ b/ehrql/tables/core.py
@@ -186,7 +186,7 @@ class ons_deaths(PatientFrame):
     )
     underlying_cause_of_death = Series(
         ICD10Code,
-        description="Patient's underlying cause of death of death.",
+        description="Patient's underlying cause of death.",
     )
     # TODO: Revisit this when we have support for multi-valued fields
     cause_of_death_01 = Series(

--- a/ehrql/tables/tpp.py
+++ b/ehrql/tables/tpp.py
@@ -889,7 +889,7 @@ class occupation_on_covid_vaccine_record(EventFrame):
 
 
 @table
-class ons_deaths(PatientFrame):
+class ons_deaths(ehrql.tables.core.ons_deaths.__class__):
     """
     Registered deaths
 
@@ -898,9 +898,9 @@ class ons_deaths(PatientFrame):
     The data provider is the Office for National Statistics (ONS).
     This table is updated approximately weekly in OpenSAFELY.
 
-    This table includes the underlying cause of death , place of death and up
-    to 15 medical conditions mentioned on the death certificate.
-    These codes (`cause_of_death_01` to `cause_of_death_15`) are not ordered meaningfully.
+    This table includes the underlying cause of death and up to 15 medical conditions
+    mentioned on the death certificate.  These codes (`cause_of_death_01` to
+    `cause_of_death_15`) are not ordered meaningfully.
 
     More information about this table can be found in following documents provided by the ONS:
 
@@ -911,17 +911,19 @@ class ons_deaths(PatientFrame):
     In the associated database table [ONS_Deaths](https://reports.opensafely.org/reports/opensafely-tpp-database-schema/#ONS_Deaths),
     a small number of patients have multiple registered deaths.
     This table contains the earliest registered death.
-    The `ehrql.tables.raw.tpp.ons_deaths` table contains all registered deaths.
+    The `ehrql.tables.raw.core.ons_deaths` table contains all registered deaths.
 
     !!! warning
-        There is also a lag in ONS death recording caused amongst other things by things like autopsies and inquests delaying
-        reporting on cause of death. This is evident in the [OpenSAFELY historical database coverage report](https://reports.opensafely.org/reports/opensafely-tpp-database-history/#ons_deaths)
+        There is also a lag in ONS death recording caused amongst other things by things
+        like autopsies and inquests delaying reporting on cause of death. This is
+        evident in the [OpenSAFELY historical database coverage
+        report](https://reports.opensafely.org/reports/opensafely-tpp-database-history/#ons_deaths)
+
+    !!! tip
+        Note that this version of the table, which includes a place of death field, is
+        only available in the `tpp` schema and not the `core` schema.
     """
 
-    date = Series(
-        datetime.date,
-        description=("Patient's date of death."),
-    )
     place = Series(
         str,
         description="Patient's place of death.",
@@ -937,71 +939,6 @@ class ons_deaths(PatientFrame):
                 ]
             ),
         ],
-    )
-    underlying_cause_of_death = Series(
-        ICD10Code,
-        description="Patient's underlying cause of death of death.",
-    )
-    # TODO: Revisit this when we have support for multi-valued fields
-    cause_of_death_01 = Series(
-        ICD10Code,
-        description="Medical condition mentioned on the death certificate.",
-    )
-    cause_of_death_02 = Series(
-        ICD10Code,
-        description="Medical condition mentioned on the death certificate.",
-    )
-    cause_of_death_03 = Series(
-        ICD10Code,
-        description="Medical condition mentioned on the death certificate.",
-    )
-    cause_of_death_04 = Series(
-        ICD10Code,
-        description="Medical condition mentioned on the death certificate.",
-    )
-    cause_of_death_05 = Series(
-        ICD10Code,
-        description="Medical condition mentioned on the death certificate.",
-    )
-    cause_of_death_06 = Series(
-        ICD10Code,
-        description="Medical condition mentioned on the death certificate.",
-    )
-    cause_of_death_07 = Series(
-        ICD10Code,
-        description="Medical condition mentioned on the death certificate.",
-    )
-    cause_of_death_08 = Series(
-        ICD10Code,
-        description="Medical condition mentioned on the death certificate.",
-    )
-    cause_of_death_09 = Series(
-        ICD10Code,
-        description="Medical condition mentioned on the death certificate.",
-    )
-    cause_of_death_10 = Series(
-        ICD10Code,
-        description="Medical condition mentioned on the death certificate.",
-    )
-    cause_of_death_11 = Series(
-        ICD10Code,
-        description="Medical condition mentioned on the death certificate.",
-    )
-    cause_of_death_12 = Series(
-        ICD10Code,
-        description="Medical condition mentioned on the death certificate.",
-    )
-    cause_of_death_13 = Series(
-        ICD10Code,
-        description="Medical condition mentioned on the death certificate.",
-    )
-    cause_of_death_14 = Series(
-        ICD10Code,
-        description="Medical condition mentioned on the death certificate.",
-    )
-    cause_of_death_15 = Series(
-        ICD10Code,
-        description="Medical condition mentioned on the death certificate.",
     )
 
 


### PR DESCRIPTION
This adds a method: `ons_deaths.cause_of_death_is_in(codelist)` which matches a codelist against the `underlying_cause_of_death` field and all 15 `cause_of_death_NN` fields.

This resurrects work which was nearly completed in #1366 but abandoned due to the complexity caused by duplicate records (which was addressed separately in #1359). I was reminded of this by the recent review of all existing ehrQL, which identified that a copy-pasted Python helper was still being used for this.

Closes #1363

