### PR TITLE
fix: remove structlog and just use stdlib logging

### DIFF
--- a/ehrql/dummy_data/generator.py
+++ b/ehrql/dummy_data/generator.py
@@ -1,11 +1,10 @@
 import functools
 import itertools
+import logging
 import random
 import string
 import time
 from datetime import date, timedelta
-
-import structlog
 
 from ehrql.dummy_data.query_info import QueryInfo
 from ehrql.query_engines.in_memory import InMemoryQueryEngine
@@ -15,7 +14,7 @@ from ehrql.tables import Constraint
 from ehrql.utils.regex_utils import create_regex_generator
 
 
-log = structlog.getLogger()
+log = logging.getLogger()
 
 
 CHARS = string.ascii_letters + string.digits + ".-+_"
@@ -106,7 +105,7 @@ class DummyDataGenerator:
             log.info(f"Generated {generated} patients, found {found} matching")
 
             if time.time() - start > self.timeout:
-                log.warn(
+                log.warning(
                     f"Failed to find {self.population_size} matching patients within "
                     f"{self.timeout} seconds — giving up"
                 )

--- a/ehrql/dummy_data_nextgen/generator.py
+++ b/ehrql/dummy_data_nextgen/generator.py
@@ -1,11 +1,10 @@
 import functools
 import itertools
+import logging
 import random
 import string
 import time
 from datetime import date, timedelta
-
-import structlog
 
 from ehrql.dummy_data_nextgen.query_info import QueryInfo
 from ehrql.query_engines.in_memory import InMemoryQueryEngine
@@ -15,7 +14,7 @@ from ehrql.tables import Constraint
 from ehrql.utils.regex_utils import create_regex_generator
 
 
-log = structlog.getLogger()
+log = logging.getLogger()
 
 
 CHARS = string.ascii_letters + string.digits + ".-+_"
@@ -107,7 +106,7 @@ class DummyDataGenerator:
             log.info(f"Generated {generated} patients, found {found} matching")
 
             if time.time() - start > self.timeout:
-                log.warn(
+                log.warning(
                     f"Failed to find {self.population_size} matching patients within "
                     f"{self.timeout} seconds — giving up"
                 )

--- a/ehrql/main.py
+++ b/ehrql/main.py
@@ -1,11 +1,10 @@
 import json
+import logging
 import os
 import shutil
 import sys
 from contextlib import nullcontext
 from pathlib import Path
-
-import structlog
 
 from ehrql import assurance, sandbox
 from ehrql.dummy_data import DummyDataGenerator
@@ -47,7 +46,7 @@ from ehrql.utils.sqlalchemy_query_utils import (
 )
 
 
-log = structlog.getLogger()
+log = logging.getLogger()
 
 
 def generate_dataset(

--- a/ehrql/query_engines/base_sql.py
+++ b/ehrql/query_engines/base_sql.py
@@ -1,10 +1,10 @@
 import datetime
+import logging
 import secrets
 from functools import cached_property
 
 import sqlalchemy
 import sqlalchemy.engine.interfaces
-import structlog
 from sqlalchemy import distinct
 from sqlalchemy.sql import operators
 from sqlalchemy.sql.elements import BindParameter
@@ -46,7 +46,7 @@ from ehrql.utils.sqlalchemy_query_utils import (
 from .base import BaseQueryEngine
 
 
-log = structlog.getLogger()
+log = logging.getLogger()
 
 
 PLACEHOLDER_PATIENT_ID = sqlalchemy.column("PLACEHOLDER_PATIENT_ID")

--- a/ehrql/query_engines/mssql.py
+++ b/ehrql/query_engines/mssql.py
@@ -1,5 +1,6 @@
+import logging
+
 import sqlalchemy
-import structlog
 from sqlalchemy.schema import CreateIndex, DropTable
 from sqlalchemy.sql.functions import Function as SQLFunction
 
@@ -22,7 +23,7 @@ from ehrql.utils.sqlalchemy_query_utils import (
 )
 
 
-log = structlog.getLogger()
+log = logging.getLogger()
 
 
 class MSSQLQueryEngine(BaseSQLQueryEngine):

--- a/ehrql/query_engines/trino.py
+++ b/ehrql/query_engines/trino.py
@@ -1,5 +1,6 @@
+import logging
+
 import sqlalchemy
-import structlog
 from sqlalchemy.sql.functions import Function as SQLFunction
 
 from ehrql.query_engines.base_sql import BaseSQLQueryEngine, get_cyclic_coalescence
@@ -12,7 +13,7 @@ from ehrql.utils.sqlalchemy_query_utils import (
 )
 
 
-log = structlog.getLogger()
+log = logging.getLogger()
 
 
 class TrinoQueryEngine(BaseSQLQueryEngine):

--- a/ehrql/utils/log_utils.py
+++ b/ehrql/utils/log_utils.py
@@ -15,7 +15,7 @@ CONFIG = {
     "formatters": {
         "formatter": {
             "()": EHRQLFormatter,
-            "format": "{asctime} [{levelname_lower:<7}] {message}",
+            "format": "[{levelname_lower:<7}] {message}",
             "datefmt": "%Y-%m-%d %H:%M:%S",
             "style": "{",
         }

--- a/ehrql/utils/log_utils.py
+++ b/ehrql/utils/log_utils.py
@@ -9,37 +9,38 @@ class EHRQLFormatter(logging.Formatter):
         return logging.Formatter.format(self, record)
 
 
-def init_logging():
-    logging.config.dictConfig(
-        {
-            "version": 1,
-            "disable_existing_loggers": False,
-            "formatters": {
-                "formatter": {
-                    "()": EHRQLFormatter,
-                    "format": "{asctime} [{levelname_lower:<9}] {message}",
-                    "datefmt": "%Y-%m-%d %H:%M:%S",
-                    "style": "{",
-                }
-            },
-            "handlers": {
-                "console": {
-                    "level": "DEBUG",
-                    "class": "logging.StreamHandler",
-                    "formatter": "formatter",
-                }
-            },
-            "root": {
-                "handlers": ["console"],
-                "level": os.getenv("LOG_LEVEL", "CRITICAL"),
-            },
-            "loggers": {
-                "sqlalchemy.engine": {
-                    "level": "INFO" if os.getenv("LOG_SQL") else "WARN",
-                },
-            },
+CONFIG = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "formatters": {
+        "formatter": {
+            "()": EHRQLFormatter,
+            "format": "{asctime} [{levelname_lower:<7}] {message}",
+            "datefmt": "%Y-%m-%d %H:%M:%S",
+            "style": "{",
         }
-    )
+    },
+    "handlers": {
+        "console": {
+            "level": "DEBUG",
+            "class": "logging.StreamHandler",
+            "formatter": "formatter",
+        }
+    },
+    "root": {
+        "handlers": ["console"],
+        "level": os.getenv("LOG_LEVEL", "CRITICAL"),
+    },
+    "loggers": {
+        "sqlalchemy.engine": {
+            "level": "INFO" if os.getenv("LOG_SQL") else "WARN",
+        },
+    },
+}
+
+
+def init_logging():
+    logging.config.dictConfig(CONFIG)
 
 
 def kv(kv_pairs):

--- a/ehrql/utils/mssql_log_utils.py
+++ b/ehrql/utils/mssql_log_utils.py
@@ -5,6 +5,8 @@ from collections import defaultdict
 
 import sqlalchemy
 
+from ehrql.utils import log_utils
+
 
 # It's not great that our logging utilities need to know about how the logs get
 # formatted, but this makes a big difference to the readability of the logs.
@@ -48,8 +50,7 @@ def execute_with_log(connection, query, log, query_id=None):
     # In order to make the logs visually parseable rather than just a wall of text we
     # want some visual space between logs for each query. The simplest way to achieve
     # this is to append some newlines to the last thing we log here.
-    append_str_to_last_value(timings, "\n\n")
-    log(f"{int(duration)} seconds:", **timings)
+    log(f"{int(duration)} seconds: {log_utils.kv(timings)}\n\n")
 
 
 SQLSERVER_STATISTICS_REGEX = re.compile(
@@ -182,8 +183,3 @@ def indent(s, prefix=LOG_INDENT):
     """
     first_line, sep, rest = s.partition("\n")
     return first_line + sep + textwrap.indent(rest, prefix)
-
-
-def append_str_to_last_value(dictionary, suffix):
-    last_key, last_value = list(dictionary.items())[-1]
-    dictionary[last_key] = f"{last_value}{suffix}"

--- a/ehrql/utils/mssql_log_utils.py
+++ b/ehrql/utils/mssql_log_utils.py
@@ -10,7 +10,7 @@ from ehrql.utils import log_utils
 
 # It's not great that our logging utilities need to know about how the logs get
 # formatted, but this makes a big difference to the readability of the logs.
-LOG_INDENT = " " * 32
+LOG_INDENT = " " * 30
 
 
 def execute_with_log(connection, query, log, query_id=None):

--- a/ehrql/utils/mssql_log_utils.py
+++ b/ehrql/utils/mssql_log_utils.py
@@ -10,7 +10,7 @@ from ehrql.utils import log_utils
 
 # It's not great that our logging utilities need to know about how the logs get
 # formatted, but this makes a big difference to the readability of the logs.
-LOG_INDENT = " " * 30
+LOG_INDENT = " " * 10
 
 
 def execute_with_log(connection, query, log, query_id=None):

--- a/requirements.prod.in
+++ b/requirements.prod.in
@@ -1,6 +1,5 @@
 pyarrow
 sqlalchemy
-structlog
 
 # Database driver for MS-SQL
 pymssql

--- a/requirements.prod.txt
+++ b/requirements.prod.txt
@@ -441,10 +441,6 @@ sqlean-py==3.47.0 \
     --hash=sha256:f9069e1c80820622cf6ac51372f80dbadacb4f5492abf912b28b6e93bd8ec315 \
     --hash=sha256:fb7ab546feb994f730db8be07f5effe9545279bf7b4f2bfa0ac4d9492dea80c9
     # via -r requirements.prod.in
-structlog==24.4.0 \
-    --hash=sha256:597f61e80a91cc0749a9fd2a098ed76715a1c8a01f73e336b746504d1aad7610 \
-    --hash=sha256:b27bfecede327a6d2da5fbc96bd859f114ecc398a6389d664f62085ee7ae6fc4
-    # via -r requirements.prod.in
 trino==0.330.0 \
     --hash=sha256:1e731be22bc6fb4ce6537287419c3d221faaa8d089f5a05b0f01ef25b860e96e \
     --hash=sha256:535f612d754338cfefa4b3fe86b63c8c000d21cb5ea476ae4ec4390d5cc37659

--- a/tests/integration/utils/test_mssql_log_utils.py
+++ b/tests/integration/utils/test_mssql_log_utils.py
@@ -23,11 +23,11 @@ class TableB(Base):
 def test_execute_with_log(mssql_database):
     log_lines = []
 
-    # Simulate approximately how structlog will format our logs
+    # Simulate approximately how logging will format our logs
     def log(event, **kwargs):
         attrs = " ".join(f"{k}={v}" for k, v in kwargs.items())
         log_lines.append(
-            f"2023-01-01 10:00:00 [info     ] {event}{' ' if attrs else ''}{attrs}"
+            f"2023-01-01 10:00:00 [info   ] {event}{' ' if attrs else ''}{attrs}"
         )
 
     mssql_database.setup(
@@ -60,28 +60,27 @@ def test_execute_with_log(mssql_database):
     assert results == [(1,), (3,)]
 
     assert log_lines[0] == (
-        "2023-01-01 10:00:00 [info     ] SQL:\n"
-        "                                SELECT 1"
+        "2023-01-01 10:00:00 [info   ] SQL:\n" "                              SELECT 1"
     )
 
     assert log_lines[1] == (
-        "2023-01-01 10:00:00 [info     ] 0 seconds: exec_cpu_ms=0 exec_elapsed_ms=0 exec_cpu_ratio=0.0 parse_cpu_ms=0 parse_elapsed_ms=0\n"
+        "2023-01-01 10:00:00 [info   ] 0 seconds: exec_cpu_ms=0 exec_elapsed_ms=0 exec_cpu_ratio=0.0 parse_cpu_ms=0 parse_elapsed_ms=0\n"
         "\n"
     )
 
     assert log_lines[2] == (
-        "2023-01-01 10:00:00 [info     ] SQL:\n"
-        "                                SELECT * INTO [#tmp_table] FROM (SELECT table_a.pk AS pk \n"
-        "                                FROM table_a \n"
-        "                                WHERE table_a.pk < %(pk_1)s UNION ALL SELECT table_b.pk AS pk \n"
-        "                                FROM table_b \n"
-        "                                WHERE table_b.pk < %(pk_2)s) AS anon_1"
+        "2023-01-01 10:00:00 [info   ] SQL:\n"
+        "                              SELECT * INTO [#tmp_table] FROM (SELECT table_a.pk AS pk \n"
+        "                              FROM table_a \n"
+        "                              WHERE table_a.pk < %(pk_1)s UNION ALL SELECT table_b.pk AS pk \n"
+        "                              FROM table_b \n"
+        "                              WHERE table_b.pk < %(pk_2)s) AS anon_1"
     )
 
     assert log_lines[3] == (
-        "2023-01-01 10:00:00 [info     ] scans logical physical read_ahead lob_logical lob_physical lob_read_ahead table\n"
-        "                                1     2       0        0          0           0            0              table_b\n"
-        "                                1     2       0        0          0           0            0              table_a"
+        "2023-01-01 10:00:00 [info   ] scans logical physical read_ahead lob_logical lob_physical lob_read_ahead table\n"
+        "                              1     2       0        0          0           0            0              table_b\n"
+        "                              1     2       0        0          0           0            0              table_a"
     )
 
     assert re.search(

--- a/tests/integration/utils/test_mssql_log_utils.py
+++ b/tests/integration/utils/test_mssql_log_utils.py
@@ -4,6 +4,7 @@ import sqlalchemy
 from sqlalchemy.orm import DeclarativeBase, mapped_column
 
 from ehrql.query_engines.mssql_dialect import SelectStarInto
+from ehrql.utils import log_utils
 from ehrql.utils.mssql_log_utils import execute_with_log
 
 
@@ -25,7 +26,7 @@ def test_execute_with_log(mssql_database):
 
     # Simulate approximately how logging will format our logs
     def log(event, **kwargs):
-        attrs = " ".join(f"{k}={v}" for k, v in kwargs.items())
+        attrs = log_utils.kv(kwargs)
         log_lines.append(
             f"2023-01-01 10:00:00 [info   ] {event}{' ' if attrs else ''}{attrs}"
         )

--- a/tests/integration/utils/test_mssql_log_utils.py
+++ b/tests/integration/utils/test_mssql_log_utils.py
@@ -27,9 +27,7 @@ def test_execute_with_log(mssql_database):
     # Simulate approximately how logging will format our logs
     def log(event, **kwargs):
         attrs = log_utils.kv(kwargs)
-        log_lines.append(
-            f"2023-01-01 10:00:00 [info   ] {event}{' ' if attrs else ''}{attrs}"
-        )
+        log_lines.append(f"[info   ] {event}{' ' if attrs else ''}{attrs}")
 
     mssql_database.setup(
         TableA(pk=1),
@@ -60,28 +58,26 @@ def test_execute_with_log(mssql_database):
 
     assert results == [(1,), (3,)]
 
-    assert log_lines[0] == (
-        "2023-01-01 10:00:00 [info   ] SQL:\n" "                              SELECT 1"
-    )
+    assert log_lines[0] == ("[info   ] SQL:\n" "          SELECT 1")
 
     assert log_lines[1] == (
-        "2023-01-01 10:00:00 [info   ] 0 seconds: exec_cpu_ms=0 exec_elapsed_ms=0 exec_cpu_ratio=0.0 parse_cpu_ms=0 parse_elapsed_ms=0\n"
+        "[info   ] 0 seconds: exec_cpu_ms=0 exec_elapsed_ms=0 exec_cpu_ratio=0.0 parse_cpu_ms=0 parse_elapsed_ms=0\n"
         "\n"
     )
 
     assert log_lines[2] == (
-        "2023-01-01 10:00:00 [info   ] SQL:\n"
-        "                              SELECT * INTO [#tmp_table] FROM (SELECT table_a.pk AS pk \n"
-        "                              FROM table_a \n"
-        "                              WHERE table_a.pk < %(pk_1)s UNION ALL SELECT table_b.pk AS pk \n"
-        "                              FROM table_b \n"
-        "                              WHERE table_b.pk < %(pk_2)s) AS anon_1"
+        "[info   ] SQL:\n"
+        "          SELECT * INTO [#tmp_table] FROM (SELECT table_a.pk AS pk \n"
+        "          FROM table_a \n"
+        "          WHERE table_a.pk < %(pk_1)s UNION ALL SELECT table_b.pk AS pk \n"
+        "          FROM table_b \n"
+        "          WHERE table_b.pk < %(pk_2)s) AS anon_1"
     )
 
     assert log_lines[3] == (
-        "2023-01-01 10:00:00 [info   ] scans logical physical read_ahead lob_logical lob_physical lob_read_ahead table\n"
-        "                              1     2       0        0          0           0            0              table_b\n"
-        "                              1     2       0        0          0           0            0              table_a"
+        "[info   ] scans logical physical read_ahead lob_logical lob_physical lob_read_ahead table\n"
+        "          1     2       0        0          0           0            0              table_b\n"
+        "          1     2       0        0          0           0            0              table_a"
     )
 
     assert re.search(

--- a/tests/unit/utils/test_log_utils.py
+++ b/tests/unit/utils/test_log_utils.py
@@ -1,0 +1,9 @@
+from ehrql.utils import log_utils
+
+
+def test_kv():
+    assert log_utils.kv({}) == ""
+    assert (
+        log_utils.kv({"foo": "foo", "bar": 1, "baz": [1, 2, 3]})
+        == "foo=foo bar=1 baz=[1, 2, 3]"
+    )

--- a/tests/unit/utils/test_mssql_log_utils.py
+++ b/tests/unit/utils/test_mssql_log_utils.py
@@ -1,5 +1,4 @@
 from ehrql.utils.mssql_log_utils import (
-    append_str_to_last_value,
     format_table_io,
     indent,
     parse_statistics_messages,
@@ -154,9 +153,3 @@ def test_indent():
     )
 
     assert indent(lines, prefix="    ") == expected
-
-
-def test_append_str_to_last_value():
-    d = {"a": "foo", "b": "bar", "c": 123}
-    append_str_to_last_value(d, "\n")
-    assert d == {"a": "foo", "b": "bar", "c": "123\n"}


### PR DESCRIPTION
We were not using most of the features of structlog in ehrql log
outputs.  The two we were using were coloured output, which we think we
want to remove anyway, as it causes issue using logs in productions.
The other was k=v formatted extra values, which we only use in one
place.

stdlib logging can do the same job, and we just include the k=v tags
a bit more manually when needed.  This removes a dependency, which is
always nice, but also means that the ehrql sandbox can work without
*any* external dependencies, which is quite a nice property.

We may end up reintroducing coloured outputs again, but hopefully not by
embedding ANSI colour codes in log files.

We also tweak the formatting, since we can do more easily now, removing timestamps and some whitespace.