### PR TITLE
Add a `quiz` module with a `check_answer` function

### DIFF
--- a/ehrql/query_engines/in_memory_database.py
+++ b/ehrql/query_engines/in_memory_database.py
@@ -91,6 +91,9 @@ class PatientTable:
     def __repr__(self):
         return frame_to_ascii_table(self.to_records())
 
+    def _repr_markdown_(self):
+        return records_to_markdown(self.to_records())
+
     def __getitem__(self, name):
         return self.name_to_col[name]
 
@@ -171,6 +174,9 @@ class EventTable:
     def __repr__(self):
         return frame_to_ascii_table(self.to_records())
 
+    def _repr_markdown_(self):
+        return records_to_markdown(self.to_records())
+
     def __getitem__(self, name):
         return self.name_to_col[name]
 
@@ -239,6 +245,9 @@ class PatientColumn:
     def __repr__(self):
         return series_to_ascii_table(self.to_records())
 
+    def _repr_markdown_(self):
+        return records_to_markdown(self.to_records())
+
     def __getitem__(self, patient):
         return self.patient_to_value.get(patient, self.default)
 
@@ -292,6 +301,9 @@ class EventColumn:
 
     def __repr__(self):
         return series_to_ascii_table(self.to_records())
+
+    def _repr_markdown_(self):
+        return records_to_markdown(self.to_records())
 
     def __getitem__(self, patient):
         return self.patient_to_rows.get(patient, Rows({}))
@@ -520,3 +532,15 @@ def series_to_ascii_table(records):
         )
         for record in records
     )
+
+
+def records_to_markdown(records):
+    lines = []
+    headers_written = False
+    for record in records:
+        if not headers_written:
+            lines.append(" | ".join(record.keys()))
+            lines.append(" | ".join("---" for _ in record.keys()))
+            headers_written = True
+        lines.append(" | ".join(map(str, record.values())))
+    return "\n".join(f"| {line.strip()} |" for line in lines)

--- a/ehrql/quiz.py
+++ b/ehrql/quiz.py
@@ -1,19 +1,142 @@
 from typing import Any
 
-from ehrql.query_engines.sandbox import SandboxQueryEngine
+from ehrql.query_engines.in_memory_database import PatientColumn, PatientTable
+from ehrql.query_engines.sandbox import EmptyDataset, SandboxQueryEngine
 from ehrql.query_language import BaseFrame, BaseSeries, Dataset
 
 
 def check_answer(
     engine: SandboxQueryEngine, answer: Any, expected: Dataset | BaseFrame | BaseSeries
 ) -> str:
-    if type(answer) is not type(expected):
-        return (
-            f"Expected {type(expected).__name__}, got {type(answer).__name__} instead."
-        )
+    if not isinstance(answer, type(expected)):
+        answer_type_name = get_type_name(answer)
+        expected_type_name = get_type_name(expected)
+        return f"Expected {expected_type_name}, got {answer_type_name} instead."
 
-    ev_answer = engine.evaluate(answer)
-    ev_expected = engine.evaluate(expected)
+    ev_answer = evaluate(engine, answer)
+    ev_expected = evaluate(engine, expected)
 
     if ev_answer == ev_expected:
         return "Correct!"
+
+    checks = [
+        check_dataset_not_empty,
+        check_dataset_columns,
+        check_patient_ids,
+        check_patient_table_values,
+        check_patient_column_values,
+    ]
+
+    for check in checks:
+        msg = check(ev_answer, ev_expected)
+        if msg is None:
+            continue  # to the next check
+        return msg
+    return "Incorrect!"
+
+
+def get_type_name(obj: Any) -> str:
+    # Simplify the type name for better error messages
+    if isinstance(obj, BaseFrame):
+        return "Table"
+    elif isinstance(obj, BaseSeries):
+        return "Series"
+    return type(obj).__name__
+
+
+def evaluate(
+    engine: SandboxQueryEngine, answer: Dataset | BaseFrame | BaseSeries
+) -> Any:
+    if isinstance(answer, Dataset):
+        return engine.evaluate_dataset(answer)
+    return engine.evaluate(answer)
+
+
+def check_dataset_not_empty(ev_ans: Any, ev_exp: Any) -> str | None:
+    if isinstance(ev_ans, EmptyDataset):
+        if isinstance(ev_exp, EmptyDataset):
+            return "Correct!"  # Special case: Not an error
+        return "The dataset is empty."
+    return None
+
+
+def check_dataset_columns(ev_ans: Any, ev_exp: Any) -> str | None:
+    # Named so because we do not expect PatientTables from Frames to have varying columns
+    if isinstance(ev_exp, PatientTable):
+        return _check_missing_extra(
+            ev_ans, ev_exp, "column", getter=lambda t: t.name_to_col.keys()
+        )
+    return None
+
+
+def check_patient_ids(ev_ans: Any, ev_exp: Any) -> str | None:
+    if isinstance(ev_exp, PatientTable):
+        return _check_missing_extra(
+            ev_ans, ev_exp, "patient", getter=lambda t: t.patients()
+        )
+    return None
+
+
+def check_patient_table_values(ev_ans: Any, ev_exp: Any) -> str | None:
+    if isinstance(ev_exp, PatientTable):
+        return _check_columns_one_by_one(
+            ev_ans,
+            ev_exp,
+            check_patient_column_values,
+            column_names=list(ev_exp.name_to_col.keys() - {"patient_id"}),
+            # Patient ID handled separately
+        )
+    return None
+
+
+def check_patient_column_values(
+    ev_ans, ev_exp, column_name: str | None = None
+) -> str | None:
+    if isinstance(ev_exp, PatientColumn):
+        column_name = f" `{column_name}` " if column_name else " "
+        incorrect = sorted(
+            ev_ans.patient_to_value.items() - ev_exp.patient_to_value.items()
+        )
+        for k, v in incorrect:  # Only show the first incorrect value
+            return f"Incorrect{column_name}value for patient {k}: expected {str(ev_exp[k])}, got {str(v)} instead."
+    return None
+
+
+# Utils functions
+def get_items_missing_extra(
+    set_ans: set,
+    set_exp: set,
+    item_name: str,
+) -> tuple[str | None, str | None]:
+    missing = list(map(str, sorted(set_exp - set_ans)))
+    missing = f"Missing {item_name}(s): {', '.join(missing)}." if missing else None
+    extra = list(map(str, sorted(set_ans - set_exp)))
+    extra = f"Found extra {item_name}(s): {', '.join(extra)}." if extra else None
+    return missing, extra
+
+
+def _check_missing_extra(
+    ev_ans: Any,
+    ev_exp: Any,
+    item_name: str,
+    getter: callable,
+) -> str | None:
+    missing_columns, extra_columns = get_items_missing_extra(
+        getter(ev_ans), getter(ev_exp), item_name
+    )
+    if missing_columns or extra_columns:
+        return "\n".join(filter(None, [missing_columns, extra_columns]))
+    return None
+
+
+def _check_columns_one_by_one(
+    ev_ans: Any,
+    ev_exp: Any,
+    check_column_values: callable,
+    column_names: list[str],
+) -> str | None:
+    for name in column_names:
+        msg = check_column_values(ev_ans[name], ev_exp[name], name)
+        if msg is None:
+            continue
+        return msg

--- a/ehrql/quiz.py
+++ b/ehrql/quiz.py
@@ -94,7 +94,7 @@ def check_dataset_columns(ev_ans: Any, ev_exp: Any) -> str | None:
 
 
 def check_patient_ids(ev_ans: Any, ev_exp: Any) -> str | None:
-    if isinstance(ev_exp, PatientTable):
+    if isinstance(ev_exp, PatientTable) or isinstance(ev_exp, PatientColumn):
         return _check_missing_extra(
             ev_ans, ev_exp, "patient", getter=lambda t: t.patients()
         )

--- a/ehrql/quiz.py
+++ b/ehrql/quiz.py
@@ -1,0 +1,19 @@
+from typing import Any
+
+from ehrql.query_engines.sandbox import SandboxQueryEngine
+from ehrql.query_language import BaseFrame, BaseSeries, Dataset
+
+
+def check_answer(
+    engine: SandboxQueryEngine, answer: Any, expected: Dataset | BaseFrame | BaseSeries
+) -> str:
+    if type(answer) is not type(expected):
+        return (
+            f"Expected {type(expected).__name__}, got {type(answer).__name__} instead."
+        )
+
+    ev_answer = engine.evaluate(answer)
+    ev_expected = engine.evaluate(expected)
+
+    if ev_answer == ev_expected:
+        return "Correct!"

--- a/tests/unit/query_engines/test_in_memory_database.py
+++ b/tests/unit/query_engines/test_in_memory_database.py
@@ -61,6 +61,77 @@ def test_event_column_repr():
     assert EventColumn.parse(repr(c)) == c
 
 
+def test_patient_table_repr_markdown():
+    t = PatientTable.parse(
+        """
+          |  i1 |  i2
+        --+-----+-----
+        1 | 101 | 111
+        2 | 201 | 211
+        """
+    )
+    assert t._repr_markdown_() == (
+        "| patient_id | i1 | i2 |\n"
+        "| --- | --- | --- |\n"
+        "| 1 | 101 | 111 |\n"
+        "| 2 | 201 | 211 |"
+    )
+
+
+def test_event_table_repr_markdown():
+    t = EventTable.parse(
+        """
+          |   |  i1 |  i2
+        --+---+-----+-----
+        1 | 0 | 101 | 111
+        1 | 1 | 102 | 112
+        1 | 2 | 103 | 113
+        2 | 3 | 203 | 211
+        2 | 4 | 202 | 212
+        2 | 5 | 201 | 213
+        """
+    )
+    assert t._repr_markdown_() == (
+        "| patient_id | row_id | i1 | i2 |\n"
+        "| --- | --- | --- | --- |\n"
+        "| 1 | 0 | 101 | 111 |\n"
+        "| 1 | 1 | 102 | 112 |\n"
+        "| 1 | 2 | 103 | 113 |\n"
+        "| 2 | 3 | 203 | 211 |\n"
+        "| 2 | 4 | 202 | 212 |\n"
+        "| 2 | 5 | 201 | 213 |"
+    )
+
+
+def test_patient_column_repr_markdown():
+    c = PatientColumn.parse(
+        """
+        1 | 101
+        2 | 201
+        """
+    )
+    assert c._repr_markdown_() == (
+        "| patient_id | value |\n" "| --- | --- |\n" "| 1 | 101 |\n" "| 2 | 201 |"
+    )
+
+
+def test_event_column_repr_markdown():
+    c = EventColumn.parse(
+        """
+        1 | 0 | 101
+        1 | 1 | 102
+        2 | 2 | 201
+        """
+    )
+    assert c._repr_markdown_() == (
+        "| patient_id | row_id | value |\n"
+        "| --- | --- | --- |\n"
+        "| 1 | 0 | 101 |\n"
+        "| 1 | 1 | 102 |\n"
+        "| 2 | 2 | 201 |"
+    )
+
+
 def test_rows_repr():
     rows = Rows({0: 101, 1: 102, 2: 103})
     assert repr(rows) == "Rows({0: 101, 1: 102, 2: 103})"

--- a/tests/unit/test_quiz.py
+++ b/tests/unit/test_quiz.py
@@ -5,7 +5,7 @@ import pytest
 from ehrql import quiz
 from ehrql.query_engines.sandbox import SandboxQueryEngine
 from ehrql.query_language import Dataset
-from ehrql.tables.core import patients
+from ehrql.tables.core import clinical_events, patients
 
 
 @pytest.fixture
@@ -38,9 +38,19 @@ def dataset_smoketest(
         (patients, patients.date_of_birth, "Expected Series, got Table instead."),
     ],
 )
-def test_wrong_type(answer, expected, message):
+def test_wrong_type_before_evaluation(answer, expected, message):
     msg = quiz.check_answer(engine=None, answer=answer, expected=expected)
     assert msg == message
+
+
+def test_event_frame_not_converted_to_patient_frame(engine):
+    # Wrong type after evaluation
+    msg = quiz.check_answer(
+        engine=engine,
+        answer=clinical_events,
+        expected=clinical_events.sort_by(clinical_events.date).last_for_patient(),
+    )
+    assert msg == "Expected PatientTable, got EventTable instead."
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_quiz.py
+++ b/tests/unit/test_quiz.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+
+import pytest
+
+from ehrql import quiz
+from ehrql.query_engines.sandbox import SandboxQueryEngine
+from ehrql.query_language import Dataset
+from ehrql.tables.core import patients
+
+
+@pytest.fixture
+def engine():
+    path = Path(__file__).parents[2] / "ehrql" / "example-data"
+    return SandboxQueryEngine(str(path))
+
+
+def test_check_answer_wrong_type():
+    msg = quiz.check_answer(engine=None, answer=1, expected=Dataset())
+    assert msg == "Expected Dataset, got int instead."
+
+
+def test_check_answer_series_correct(engine):
+    msg = quiz.check_answer(
+        engine=engine, answer=patients.date_of_birth, expected=patients.date_of_birth
+    )
+    assert msg == "Correct!"


### PR DESCRIPTION
Closes #2212. Context provided in the ticket.

- Uses two commits from @evansd 's experimental marimo branch
- In the new `quiz` module, there is current only a `check_answer` function and the smaller functions that it calls. It is expected for `check_answer` to be used in some larger quiz framework. 

- Is a draft PR at the moment as the tests might benefit from some improvements using hypothesis. 