### PR TITLE
Give context-appropriate hint for domain mismatch errors

### DIFF
--- a/ehrql/query_language.py
+++ b/ehrql/query_language.py
@@ -1068,14 +1068,26 @@ def _build(qm_cls, *args, **kwargs):
     try:
         return qm_cls(*args, **kwargs)
     except qm.DomainMismatchError:
+        hints = (
+            " * Reduce one series to have only one value per patient by using\n"
+            "   an aggregation like `maximum_for_patient()`.\n\n"
+            " * Pick a single row for each patient from the table using\n"
+            "   `first_for_patient()`."
+        )
+        if qm_cls is qm.Function.EQ:
+            hints = (
+                " * Use `x.is_in(y)` instead of `x == y` to check if values from\n"
+                "   one series match any of the patient's values in the other.\n\n"
+                f"{hints}"
+            )
         raise Error(
             "\n"
             "Cannot combine series which are drawn from different tables and both\n"
             "have more than one value per patient.\n"
             "\n"
-            "Hint: try reducing one series to have only one value per patient by\n"
-            "using an aggregation like `maximum_for_patient()` or pick a single\n"
-            "row for each patient from the table using `first_for_patient()`."
+            "To address this, try one of the following:\n"
+            "\n"
+            f"{hints}"
             # Use `from None` to hide the chained exception
         ) from None
     except qm.TypeValidationError as exc:

--- a/tests/unit/test_query_language.py
+++ b/tests/unit/test_query_language.py
@@ -886,6 +886,21 @@ def test_domain_mismatch_errors_are_wrapped():
         match="Cannot combine series which are drawn from different tables",
     ) as exc:
         events.f + other_events.f
+    assert "is_in" not in str(exc.value)
+    assert_not_chained_exception(exc)
+
+
+def test_domain_mismatch_errors_using_equality_provide_hint():
+    @table
+    class other_events(EventFrame):
+        f = Series(float)
+
+    with pytest.raises(
+        Error,
+        match="Cannot combine series which are drawn from different tables",
+    ) as exc:
+        events.f == other_events.f
+    assert "Use `x.is_in(y)` instead of `x == y`" in str(exc.value)
     assert_not_chained_exception(exc)
 
 


### PR DESCRIPTION
Since #1873 we attempt to give a helpful error message for "domian mismatch" errors with some hints as to how to go about fixing it. However we fail to mention the possible solution of using `is_in()` which we've supported since #1795.

This is actively unhelpful for users who might reasonably assume that the options suggested are the only ones available. For example, see:
https://bennettoxford.slack.com/archives/C33TWNQ1J/p1731320032663639

This is only relevant where the problematic operation is an equality comparison, so we only add the hint in that context.

The error now looks like this:

    Cannot combine series which are drawn from different tables and both
    have more than one value per patient.

    To address this, try one of the following:

     * Use `x.is_in(y)` instead of `x == y` to check if values from
       one series match any of the patient's values in the other.

     * Reduce one series to have only one value per patient by using
       an aggregation like `maximum_for_patient()`.

     * Pick a single row for each patient from the table using
       `first_for_patient()`.