### PR TITLE
Add a debug ehrQL command

### DIFF
--- a/docs/includes/generated_docs/cli.md
+++ b/docs/includes/generated_docs/cli.md
@@ -89,6 +89,14 @@ Internal command for testing code isolation support.
 Output the dataset definition's query graph
 </p>
 
+<div class="attr-heading">
+  <a href="#debug"><tt>debug</tt></a>
+</div>
+<p class="indent">
+Internal command for getting debugging information from a dataset
+definition; used by the [OpenSAFELY VSCode extension][opensafely-vscode].
+</p>
+
 </div>
 
 <div class="attr-heading" id="ehrql.help">
@@ -638,6 +646,7 @@ Database connection string.
 ```
 ehrql serialize-definition DEFINITION_FILE [--help]
       [--definition-type DEFINITION_TYPE] [--output OUTPUT_FILE]
+      [--dummy-tables DUMMY_TABLES_PATH] [--display-format RENDER_FORMAT]
       [ -- ... PARAMETERS ...]
 ```
 Internal command for serializing a definition file to a JSON representation.
@@ -667,7 +676,7 @@ show this help message and exit
   <a class="headerlink" href="#serialize-definition.definition-type" title="Permanent link">🔗</a>
 </div>
 <div markdown="block" class="indent">
-Options: `dataset`, `measures`, `test`
+Options: `dataset`, `measures`, `test`, `debug`
 
 </div>
 
@@ -677,6 +686,29 @@ Options: `dataset`, `measures`, `test`
 </div>
 <div markdown="block" class="indent">
 Output file path (stdout by default)
+
+</div>
+
+<div class="attr-heading" id="serialize-definition.dummy-tables">
+  <tt>--dummy-tables DUMMY_TABLES_PATH</tt>
+  <a class="headerlink" href="#serialize-definition.dummy-tables" title="Permanent link">🔗</a>
+</div>
+<div markdown="block" class="indent">
+Path to directory of files (one per table) to use as dummy tables
+(see [`create-dummy-tables`](#create-dummy-tables)).
+
+Files may be in any supported format: `.arrow`, `.csv`, `.csv.gz`
+
+This argument is ignored when running against real tables.
+
+</div>
+
+<div class="attr-heading" id="serialize-definition.display-format">
+  <tt>--display-format RENDER_FORMAT</tt>
+  <a class="headerlink" href="#serialize-definition.display-format" title="Permanent link">🔗</a>
+</div>
+<div markdown="block" class="indent">
+Render format for debug command, default ascii
 
 </div>
 
@@ -751,6 +783,74 @@ SVG output file.
 <div class="attr-heading" id="graph-query.user_args">
   <tt>PARAMETERS</tt>
   <a class="headerlink" href="#graph-query.user_args" title="Permanent link">🔗</a>
+</div>
+<div markdown="block" class="indent">
+Parameters are extra arguments you can pass to your Python definition file. They must be
+supplied after all ehrQL arguments and separated from the ehrQL arguments with a
+double-dash ` -- `.
+
+
+</div>
+
+
+<h2 id="debug" data-toc-label="debug" markdown>
+  debug
+</h2>
+```
+ehrql debug DEFINITION_FILE [--help] [--dummy-tables DUMMY_TABLES_PATH]
+      [--display-format RENDER_FORMAT] [ -- ... PARAMETERS ...]
+```
+Internal command for getting debugging information from a dataset
+definition; used by the [OpenSAFELY VSCode extension][opensafely-vscode].
+
+Note that **this in an internal command** and not intended for end users.
+
+[opensafely-vscode]: https://marketplace.visualstudio.com/items?itemName=bennettoxford.opensafely
+
+<div class="attr-heading" id="debug.definition_file">
+  <tt>DEFINITION_FILE</tt>
+  <a class="headerlink" href="#debug.definition_file" title="Permanent link">🔗</a>
+</div>
+<div markdown="block" class="indent">
+Path of the Python file where the dataset is defined.
+
+</div>
+
+<div class="attr-heading" id="debug.help">
+  <tt>-h, --help</tt>
+  <a class="headerlink" href="#debug.help" title="Permanent link">🔗</a>
+</div>
+<div markdown="block" class="indent">
+show this help message and exit
+
+</div>
+
+<div class="attr-heading" id="debug.dummy-tables">
+  <tt>--dummy-tables DUMMY_TABLES_PATH</tt>
+  <a class="headerlink" href="#debug.dummy-tables" title="Permanent link">🔗</a>
+</div>
+<div markdown="block" class="indent">
+Path to directory of files (one per table) to use as dummy tables
+(see [`create-dummy-tables`](#create-dummy-tables)).
+
+Files may be in any supported format: `.arrow`, `.csv`, `.csv.gz`
+
+This argument is ignored when running against real tables.
+
+</div>
+
+<div class="attr-heading" id="debug.display-format">
+  <tt>--display-format RENDER_FORMAT</tt>
+  <a class="headerlink" href="#debug.display-format" title="Permanent link">🔗</a>
+</div>
+<div markdown="block" class="indent">
+Render format for debug command, default ascii
+
+</div>
+
+<div class="attr-heading" id="debug.user_args">
+  <tt>PARAMETERS</tt>
+  <a class="headerlink" href="#debug.user_args" title="Permanent link">🔗</a>
 </div>
 <div markdown="block" class="indent">
 Parameters are extra arguments you can pass to your Python definition file. They must be

--- a/ehrql/__init__.py
+++ b/ehrql/__init__.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 from ehrql.codes import codelist_from_csv
+from ehrql.debug import show
 from ehrql.measures import INTERVAL, Measures, create_measures
 from ehrql.query_language import (
     Dataset,
@@ -34,6 +35,7 @@ __all__ = [
     "maximum_of",
     "minimum_of",
     "months",
+    "show",
     "weeks",
     "when",
     "years",

--- a/ehrql/__main__.py
+++ b/ehrql/__main__.py
@@ -15,11 +15,13 @@ from ehrql.file_formats import (
     split_directory_and_extension,
 )
 from ehrql.loaders import DEFINITION_LOADERS, DefinitionError
+from ehrql.renderers import DISPLAY_RENDERERS
 from ehrql.utils.string_utils import strip_indent
 
 from .main import (
     assure,
     create_dummy_tables,
+    debug_dataset_definition,
     dump_dataset_sql,
     dump_example_data,
     generate_dataset,
@@ -161,6 +163,7 @@ def create_parser(user_args, environ):
     add_serialize_definition(subparsers, environ, user_args)
     add_isolation_report(subparsers, environ, user_args)
     add_graph_query(subparsers, environ, user_args)
+    add_debug_dataset_definition(subparsers, environ, user_args)
 
     return parser
 
@@ -375,6 +378,20 @@ def add_run_sandbox(subparsers, environ, user_args):
     )
 
 
+def add_debug_dataset_definition(subparsers, environ, user_args):
+    parser = subparsers.add_parser(
+        "debug",
+        help="Debug an ehrQL dataset definition.",
+        formatter_class=RawTextHelpFormatter,
+    )
+    parser.set_defaults(function=debug_dataset_definition)
+    parser.set_defaults(environ=environ)
+    parser.set_defaults(user_args=user_args)
+    add_dataset_definition_file_argument(parser, environ)
+    add_dummy_tables_argument(parser, environ)
+    add_display_renderer_argument(parser, environ)
+
+
 def add_assure(subparsers, environ, user_args):
     parser = subparsers.add_parser(
         "assure",
@@ -475,6 +492,8 @@ def add_serialize_definition(subparsers, environ, user_args):
         type=existing_python_file,
         metavar="definition_file",
     )
+    add_dummy_tables_argument(parser, environ)
+    add_display_renderer_argument(parser, environ)
 
 
 def add_isolation_report(subparsers, environ, user_args):
@@ -587,6 +606,30 @@ def add_backend_argument(parser, environ):
         default=environ.get("OPENSAFELY_BACKEND"),
         dest="backend_class",
     )
+
+
+def add_display_renderer_argument(parser, environ):
+    parser.add_argument(
+        "--display-format",
+        help=strip_indent(
+            """
+            Render format for debug command, default ascii
+            """
+        ),
+        dest="render_format",
+        default="ascii",
+        type=renderer,
+    )
+
+
+def renderer(value):
+    if value not in DISPLAY_RENDERERS:
+        raise ArgumentTypeError(
+            f"'{value}' is not a supported display format, "
+            f"must be one of: "
+            f"{backtick_join((renderer_format) for renderer_format in DISPLAY_RENDERERS)}"
+        )
+    return value
 
 
 def existing_file(value):

--- a/ehrql/__main__.py
+++ b/ehrql/__main__.py
@@ -381,7 +381,16 @@ def add_run_sandbox(subparsers, environ, user_args):
 def add_debug_dataset_definition(subparsers, environ, user_args):
     parser = subparsers.add_parser(
         "debug",
-        help="Debug an ehrQL dataset definition.",
+        help=strip_indent(
+            """
+            Internal command for getting debugging information from a dataset
+            definition; used by the [OpenSAFELY VSCode extension][opensafely-vscode].
+
+            Note that **this in an internal command** and not intended for end users.
+
+            [opensafely-vscode]: https://marketplace.visualstudio.com/items?itemName=bennettoxford.opensafely
+            """
+        ),
         formatter_class=RawTextHelpFormatter,
     )
     parser.set_defaults(function=debug_dataset_definition)

--- a/ehrql/debug.py
+++ b/ehrql/debug.py
@@ -1,8 +1,12 @@
 import inspect
 import sys
 
+from ehrql.renderers import truncate_table
 
-def show(element, label: str | None = None):
+
+def show(
+    element, label: str | None = None, head: int | None = None, tail: int | None = None
+):
     """
     Show the output of the specified element within a dataset definition
 
@@ -12,13 +16,41 @@ def show(element, label: str | None = None):
 
     _label_<br>
     Optional label which will be printed in the debug output.
+
+    _head_<br>
+    Show only the first N lines. If the output is an ehrQL column, table or dataset, it will
+    print only the first N lines of the table.
+
+    _tail_<br>
+    Show only the last N lines. If the output is an ehrQL column, table or dataset, it will
+    print only the last N lines of the table.
+
+    head and tail arguments can be combined, e.g. to show the first and last 5 lines of a table:
+
+      show(<table>, head=5, tail=5)
     """
     line_no = inspect.getframeinfo(sys._getframe(1))[1]
     element_repr = repr(element)
+    if head or tail:
+        element_repr = truncate_table(element_repr, head, tail)
     label = f" {label}" if label else ""
     print(f"Debug line {line_no}:{label}", file=sys.stderr)
     print(element_repr, file=sys.stderr)
 
 
-def stop():
-    """This doesn't do anything, it's just an indication that we should stop here"""
+def stop(*, head: int | None = None, tail: int | None = None):
+    """
+    Stop loading the dataset definition and show the contents of the dataset at this point.
+
+    _head_<br>
+    Show only the first N lines of the dataset.
+
+    _tail_<br>
+    Show only the last N lines of the dataset.
+
+    head and tail arguments can be combined, e.g. to show the first and last 5 lines of the dataset:
+
+      stop(head=5, tail=5)
+    """
+    line_no = inspect.getframeinfo(sys._getframe(1))[1]
+    print(f"Stopping at line {line_no}", file=sys.stderr)

--- a/ehrql/debug.py
+++ b/ehrql/debug.py
@@ -1,0 +1,24 @@
+import inspect
+import sys
+
+
+def show(element, label: str | None = None):
+    """
+    Show the output of the specified element within a dataset definition
+
+    _element_<br>
+    Any element within the dataset definition file; can be a string, constant value etc,
+    but will typically be a dataset variable (filtered table, column, or a dataset itself.)
+
+    _label_<br>
+    Optional label which will be printed in the debug output.
+    """
+    line_no = inspect.getframeinfo(sys._getframe(1))[1]
+    element_repr = repr(element)
+    label = f" {label}" if label else ""
+    print(f"Debug line {line_no}:{label}", file=sys.stderr)
+    print(element_repr, file=sys.stderr)
+
+
+def stop():
+    """This doesn't do anything, it's just an indication that we should stop here"""

--- a/ehrql/debug.py
+++ b/ehrql/debug.py
@@ -7,7 +7,11 @@ from ehrql.utils.docs_utils import exclude_from_docs
 
 @exclude_from_docs
 def show(
-    element, label: str | None = None, head: int | None = None, tail: int | None = None
+    element,
+    *other_elements,
+    label: str | None = None,
+    head: int | None = None,
+    tail: int | None = None,
 ):
     """
     Show the output of the specified element within a dataset definition
@@ -32,12 +36,16 @@ def show(
       show(<table>, head=5, tail=5)
     """
     line_no = inspect.getframeinfo(sys._getframe(1))[1]
-    element_repr = repr(element)
+    elements = [element, *other_elements]
+    element_reprs = [repr(el) for el in elements]
     if head or tail:
-        element_repr = truncate_table(element_repr, head, tail)
+        element_reprs = [
+            truncate_table(el_repr, head, tail) for el_repr in element_reprs
+        ]
     label = f" {label}" if label else ""
     print(f"Debug line {line_no}:{label}", file=sys.stderr)
-    print(element_repr, file=sys.stderr)
+    for el_repr in element_reprs:
+        print(el_repr, file=sys.stderr)
 
 
 def stop(*, head: int | None = None, tail: int | None = None):

--- a/ehrql/debug.py
+++ b/ehrql/debug.py
@@ -2,8 +2,10 @@ import inspect
 import sys
 
 from ehrql.renderers import truncate_table
+from ehrql.utils.docs_utils import exclude_from_docs
 
 
+@exclude_from_docs
 def show(
     element, label: str | None = None, head: int | None = None, tail: int | None = None
 ):

--- a/ehrql/docs/language.py
+++ b/ehrql/docs/language.py
@@ -56,10 +56,15 @@ def build_language():
     # The namespace we're going to document includes all the public names in `ehrql`,
     # plus all the classes in `ehrql.query_language` which we haven't explicitly
     # excluded
-    namespace = {name: getattr(ehrql, name) for name in ehrql.__all__}
+    ehrql_namespace = [(name, getattr(ehrql, name)) for name in ehrql.__all__]
+    ql_namespace = vars(ql).items()
+    namespace = {
+        name: value for name, value in ehrql_namespace if is_included_object(value)
+    }
     namespace.update(
-        (name, attr) for name, attr in vars(ql).items() if is_included_class(attr)
+        {name: value for name, value in ql_namespace if is_included_class(value)}
     )
+
     # Add class which exists only for documentation purposes – see above
     namespace["SortedEventFrame"] = SortedEventFrame
 
@@ -170,6 +175,10 @@ def is_included_attr(name, attr):
     if getattr(attr, "exclude_from_docs", None):
         return False
     return inspect.isfunction(attr) or inspect.isdatadescriptor(attr)
+
+
+def is_included_object(value):
+    return not getattr(value, "exclude_from_docs", None)
 
 
 def method_order(details):

--- a/ehrql/main.py
+++ b/ehrql/main.py
@@ -5,6 +5,7 @@ import shutil
 import sys
 from contextlib import nullcontext
 from pathlib import Path
+from tempfile import NamedTemporaryFile
 
 from ehrql import assurance, sandbox
 from ehrql.dummy_data import DummyDataGenerator
@@ -21,6 +22,7 @@ from ehrql.file_formats import (
 from ehrql.loaders import (
     isolation_report,
     load_dataset_definition,
+    load_debug_definition,
     load_definition_unsafe,
     load_measure_definitions,
     load_test_definition,
@@ -32,12 +34,14 @@ from ehrql.measures import (
     get_measure_results,
 )
 from ehrql.query_engines.local_file import LocalFileQueryEngine
+from ehrql.query_engines.sandbox import SandboxQueryEngine
 from ehrql.query_engines.sqlite import SQLiteQueryEngine
 from ehrql.query_model.column_specs import (
     get_column_specs,
     get_column_specs_from_schema,
 )
 from ehrql.query_model.graphs import graph_to_svg
+from ehrql.renderers import DISPLAY_RENDERERS
 from ehrql.serializer import serialize
 from ehrql.utils.itertools_utils import eager_iterator
 from ehrql.utils.sqlalchemy_query_utils import (
@@ -363,6 +367,48 @@ def assure(test_data_file, environ, user_args):
     print(assurance.present(results))
 
 
+def debug_dataset_definition(
+    definition_file,
+    *,
+    environ,
+    user_args,
+    dummy_tables_path=None,
+    render_format="ascii",
+):
+    with NamedTemporaryFile(suffix=".py", dir=definition_file.parent) as tmpfile:
+        _write_debug_definition_to_temp_file(definition_file, Path(tmpfile.name))
+
+        variable_definitions = load_debug_definition(
+            tmpfile.name, user_args, environ, dummy_tables_path, render_format
+        )
+
+    query_engine = SandboxQueryEngine(dummy_tables_path)
+    column_specs = list(get_column_specs(variable_definitions))
+    results = eager_iterator(query_engine.get_results(variable_definitions))
+    records = [
+        {column_specs[i]: value for i, value in enumerate(result)} for result in results
+    ]
+
+    dataset_as_table = DISPLAY_RENDERERS[render_format](records)
+
+    print(dataset_as_table)
+
+
+def _write_debug_definition_to_temp_file(definition_file, tmpfile):
+    # Read the dataset definition up to the first point that a
+    # stop() is found, and rewrite it to a temporary file that
+    # will be passed to the loader
+    with definition_file.open() as infile:
+        lines = []
+        for line in infile.readlines():
+            lines.append(line)
+            if line.strip() == "stop()":
+                break
+
+    lines = "".join(lines)
+    tmpfile.write_text(lines)
+
+
 def test_connection(backend_class, url, environ):
     from sqlalchemy import select
 
@@ -380,10 +426,21 @@ def dump_example_data(environ):
 
 
 def serialize_definition(
-    definition_type, definition_file, output_file, user_args, environ
+    definition_type,
+    definition_file,
+    output_file,
+    user_args,
+    environ,
+    dummy_tables_path=None,
+    render_format=None,
 ):
     result = load_definition_unsafe(
-        definition_type, definition_file, user_args, environ
+        definition_type,
+        definition_file,
+        user_args,
+        environ,
+        dummy_tables_path=dummy_tables_path,
+        render_format=render_format,
     )
     with open_output_file(output_file) as f:
         f.write(serialize(result))

--- a/ehrql/query_engines/in_memory_database.py
+++ b/ehrql/query_engines/in_memory_database.py
@@ -8,6 +8,7 @@ from collections import UserDict, defaultdict
 from dataclasses import dataclass
 
 from ehrql.query_model.nodes import has_one_row_per_patient
+from ehrql.renderers import DISPLAY_RENDERERS
 
 
 class InMemoryDatabase:
@@ -89,17 +90,10 @@ class PatientTable:
         return cls.from_records(col_names, row_records)
 
     def __repr__(self):
-        width = 17
-        lines = []
-        lines.append(" | ".join(name.ljust(width) for name in self.name_to_col))
-        lines.append("-+-".join("-" * width for _ in self.name_to_col))
-        for p in sorted(self["patient_id"].patients()):
-            lines.append(
-                " | ".join(
-                    str(col[p]).ljust(width) for col in self.name_to_col.values()
-                )
-            )
-        return "\n".join(line.strip() for line in lines)
+        return self._render_(DISPLAY_RENDERERS["ascii"])
+
+    def _render_(self, render_fn):
+        return render_fn(self.to_records())
 
     def __getitem__(self, name):
         return self.name_to_col[name]
@@ -179,21 +173,18 @@ class EventTable:
         return cls.from_records(col_names, row_records)
 
     def __repr__(self):
-        width = 17
-        lines = []
-        lines.append(" | ".join(name.ljust(width) for name in self.name_to_col))
-        lines.append("-+-".join("-" * width for _ in self.name_to_col))
-        for p, rows in sorted(self["patient_id"].patient_to_rows.items()):
-            for k in rows:
-                lines.append(
-                    " | ".join(
-                        str(col[p][k]).ljust(width) for col in self.name_to_col.values()
-                    )
-                )
-        return "\n".join(line.strip() for line in lines)
+        return self._render_(DISPLAY_RENDERERS["ascii"])
+
+    def _render_(self, render_fn):
+        return render_fn(self.to_records())
 
     def __getitem__(self, name):
         return self.name_to_col[name]
+
+    def to_records(self):
+        for p, rows in sorted(self["patient_id"].patient_to_rows.items()):
+            for k in rows:
+                yield {name: col[p][k] for name, col in self.name_to_col.items()}
 
     def patients(self):
         return self["patient_id"].patients()
@@ -247,18 +238,27 @@ class PatientColumn:
         """
 
         patient_to_value = {}
-        for line in s.strip().splitlines():
+        lines = s.strip().splitlines()
+        if "patient_id" in lines[0]:  # ignore headers from ascii-formatted tables
+            lines = lines[2:]
+
+        for line in lines:
             p, v = line.split("|")
             patient_to_value[int(p)] = parse_value(v)
         return cls(patient_to_value, default)
 
     def __repr__(self):
-        return "\n".join(
-            f"{p:2} | {v}" for p, v in sorted(self.patient_to_value.items())
-        )
+        return self._render_(DISPLAY_RENDERERS["ascii"])
+
+    def _render_(self, render_fn):
+        return render_fn(self.to_records())
 
     def __getitem__(self, patient):
         return self.patient_to_value.get(patient, self.default)
+
+    def to_records(self):
+        for p, v in sorted(self.patient_to_value.items()):
+            yield {"patient_id": p, "value": v}
 
     def patients(self):
         return set(self.patient_to_value)
@@ -293,7 +293,11 @@ class EventColumn:
         """
 
         patient_to_values = defaultdict(dict)
-        for line in s.strip().splitlines():
+        lines = s.strip().splitlines()
+        if "patient_id" in lines[0]:  # ignore headers from ascii-formatted tables
+            lines = lines[2:]
+
+        for line in lines:
             p, k, v = line.split("|")
             if v.strip() == "---":
                 patient_to_values[int(p)] = {}
@@ -303,14 +307,20 @@ class EventColumn:
         return cls(patient_to_rows)
 
     def __repr__(self):
-        return "\n".join(
-            f"{p:2} | {k:2} | {v}"
-            for p, rows in sorted(self.patient_to_rows.items())
-            for k, v in rows.items()
-        )
+        return self._render_(DISPLAY_RENDERERS["ascii"])
+
+    def _render_(self, render_fn):
+        return render_fn(self.to_records())
 
     def __getitem__(self, patient):
         return self.patient_to_rows.get(patient, Rows({}))
+
+    def to_records(self):
+        return (
+            {"patient_id": p, "row_id": k, "value": v}
+            for p, rows in sorted(self.patient_to_rows.items())
+            for k, v in rows.items()
+        )
 
     def patients(self):
         return set(self.patient_to_rows)

--- a/ehrql/query_engines/in_memory_database.py
+++ b/ehrql/query_engines/in_memory_database.py
@@ -516,3 +516,27 @@ def parse_value(value):
 def nulls_first_order(key):
     # Usable as a key function to `sorted()` which sorts NULLs first
     return (0 if key is None else 1, key)
+
+
+def truncate_records(
+    records: list[dict], head: int | None = None, tail: int | None = None
+):
+    """
+    Truncate a list of records to the first/last N rows,
+    with a row of ... values to indicate where it's been truncated
+
+    These records will be passed to one of the display formatter functions
+    for rendering as ascii or html.
+    """
+    if head is None and tail is None:
+        return records
+
+    if len(records) <= (head or 0) + (tail or 0):
+        return records
+
+    ellipsis_record = {k: "..." for k in records[0].keys()}
+    truncated_records = records[:head] if head is not None else [ellipsis_record]
+    if head and tail:
+        truncated_records.append(ellipsis_record)
+    truncated_records.extend(records[-tail:] if tail is not None else [ellipsis_record])
+    return truncated_records

--- a/ehrql/renderers.py
+++ b/ehrql/renderers.py
@@ -1,0 +1,32 @@
+def records_to_html_table(records: list[dict]):
+    rows = []
+    headers_written = False
+
+    for record in records:
+        if not headers_written:
+            headers = "".join([f"<th>{header}</th>" for header in record.keys()])
+            headers_written = True
+        row = "".join(f"<td>{val}</td>" for val in record.values())
+        rows.append(f"<tr>{row}</tr>")
+    rows = "".join(rows)
+
+    return f"<table><thead>{headers}</thead><tbody>{rows}</tbody></table>"
+
+
+def records_to_ascii_table(records: list[dict]):
+    width = 17
+    lines = []
+    headers_written = False
+    for record in records:
+        if not headers_written:
+            lines.append(" | ".join(name.ljust(width) for name in record.keys()))
+            lines.append("-+-".join("-" * width for _ in record.keys()))
+            headers_written = True
+        lines.append(" | ".join(str(value).ljust(width) for value in record.values()))
+    return "\n".join(line.strip() for line in lines) + "\n"
+
+
+DISPLAY_RENDERERS = {
+    "ascii": records_to_ascii_table,
+    "html": records_to_html_table,
+}

--- a/ehrql/renderers.py
+++ b/ehrql/renderers.py
@@ -1,3 +1,6 @@
+import re
+
+
 def records_to_html_table(records: list[dict]):
     rows = []
     headers_written = False
@@ -24,6 +27,104 @@ def records_to_ascii_table(records: list[dict]):
             headers_written = True
         lines.append(" | ".join(str(value).ljust(width) for value in record.values()))
     return "\n".join(line.strip() for line in lines) + "\n"
+
+
+def _truncate_html_table(table_repr: str, head: int | None, tail: int | None):
+    """
+    Truncate an html table string to the first/last N rows, with a row of ...
+    values to indicate where it's been truncated
+    """
+    regex = re.compile(
+        r"(?P<start>^<table>.*<tbody>)(?P<rows><tr>.*<\/tr>)(?P<end><\/tbody>.*<\/table>)"
+    )
+    match = regex.match(table_repr)
+    if match is None:
+        # if we can't parse the table, return None and let the fallback handle it
+        return
+
+    start = match.group("start")
+    rows = match.group("rows")
+    end = match.group("end")
+
+    # Check we have enough rows to truncate to head and tail
+    if rows.count("<tr>") <= ((head or 0) + (tail or 0)):
+        return table_repr
+
+    # split row on <tr> tokens, remove any empty strings (this will lose the first <tr> of
+    # each row, but we'll add it in again later)
+    rows = [row for row in rows.split("<tr>") if row]
+    # compose an "ellipsis row" to mark the place of truncated rows
+    td_count = rows[0].count("<td>")
+    ellipsis_row = f"{'<td>...</td>'*td_count}</tr>"
+
+    # Build the list of rows we need to include, with ellipsis rows where necessary
+    truncated_rows = []
+
+    head_rows = rows[:head] if head is not None else [ellipsis_row]
+    truncated_rows.extend(head_rows)
+
+    if head is not None and tail is not None:
+        truncated_rows.append(ellipsis_row)
+
+    tail_rows = rows[-tail:] if tail is not None else [ellipsis_row]
+    truncated_rows.extend(tail_rows)
+
+    # re-join the truncated rows with <tr>
+    truncated_rows = "<tr>" + "<tr>".join(truncated_rows)
+    return start + truncated_rows + end
+
+
+def _truncate_lines(
+    table_repr: str, headers: int = 0, head: int | None = None, tail: int | None = None
+):
+    table_rows = [row for row in table_repr.split("\n") if row]
+
+    # Check we have enough rows to truncate to head and tail
+    if len(table_rows) <= (headers + (head or 0) + (tail or 0)):
+        return table_repr
+
+    # compose an "ellipsis row" to mark the place of truncated rows
+    cell_count = table_rows[0].count("|") + 1
+    ellipsis_row = " | ".join("...".ljust(17) for i in range(cell_count)).strip()
+
+    # Build the list of rows we need to include, with ellipsis rows where necessary
+    truncated_rows = table_rows[:headers]
+
+    head_rows = (
+        table_rows[headers : headers + head] if head is not None else [ellipsis_row]
+    )
+    truncated_rows.extend(head_rows)
+
+    if head is not None and tail is not None:
+        truncated_rows.append(ellipsis_row)
+
+    tail_rows = table_rows[-tail:] if tail is not None else [ellipsis_row]
+    truncated_rows.extend(tail_rows)
+
+    return "\n".join(truncated_rows)
+
+
+def truncate_table(table_repr: str, head: int | None, tail: int | None):
+    """
+    Take a table repr (ascii or html format) and truncate it to show only the
+    first and/or last N rows.
+    """
+    if head is None and tail is None:
+        return table_repr
+
+    truncated_repr = None
+
+    if "<table>" in table_repr:
+        truncated_repr = _truncate_html_table(table_repr, head=head, tail=tail)
+    elif "---+---" in table_repr:
+        truncated_repr = _truncate_lines(table_repr, headers=2, head=head, tail=tail)
+
+    # if we didn't detect either an ascii or html table, or the html regex
+    # didn't match as expected, fall back to a simple truncation of lines using
+    # line breaks.
+    if truncated_repr is None:
+        truncated_repr = _truncate_lines(table_repr, head=head, tail=tail)
+    return truncated_repr
 
 
 DISPLAY_RENDERERS = {

--- a/tests/fixtures/good_definition_files/debug_definition.py
+++ b/tests/fixtures/good_definition_files/debug_definition.py
@@ -1,0 +1,12 @@
+# noqa: INP001
+from ehrql import create_dataset
+from ehrql.debug import show, stop
+from ehrql.tables.core import patients
+
+
+dataset = create_dataset()
+dataset.sex = patients.sex
+show("Hello")
+dataset.define_population(patients.date_of_birth.is_on_or_after("2000-01-01"))
+stop()
+dataset.year_of_birth = patients.date_of_birth.year

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -282,3 +282,97 @@ def test_debug_show(tmp_path, capsys):
         """
     ).strip()
     assert capsys.readouterr().err.strip() == expected
+
+
+@pytest.mark.parametrize(
+    "stop,expected_out",
+    [
+        (
+            "stop()",
+            textwrap.dedent(
+                """
+                patient_id
+                -----------------
+                1
+                2
+                3
+                4
+                """
+            ),
+        ),
+        (
+            "stop(head=None, tail=None)",
+            textwrap.dedent(
+                """
+                patient_id
+                -----------------
+                1
+                2
+                3
+                4
+                """
+            ),
+        ),
+        (
+            "stop(head=1)",
+            textwrap.dedent(
+                """
+                patient_id
+                -----------------
+                1
+                ...
+                """
+            ),
+        ),
+        (
+            "stop(tail=1)",
+            textwrap.dedent(
+                """
+                patient_id
+                -----------------
+                ...
+                4
+                """
+            ),
+        ),
+    ],
+)
+def test_debug_stop(tmp_path, capsys, stop, expected_out):
+    definition = textwrap.dedent(
+        f"""\
+        from ehrql import create_dataset
+        from ehrql.debug import show, stop
+        from ehrql.tables.core import patients
+
+        dataset = create_dataset()
+        year = patients.date_of_birth.year
+        dataset.define_population(year>1900)
+        {stop}
+        """
+    )
+
+    definition_path = tmp_path / "debug.py"
+    definition_path.write_text(definition)
+    DUMMY_DATA = textwrap.dedent(
+        """\
+        patient_id,date_of_birth
+        1,1980-06-01
+        2,1985-06-01
+        3,1985-06-01
+        4,1985-06-01
+        """
+    )
+    dummy_tables_path = tmp_path / "dummy_tables"
+    dummy_tables_path.mkdir()
+    dummy_tables_path.joinpath("patients.csv").write_text(DUMMY_DATA)
+
+    debug_dataset_definition(
+        definition_path,
+        dummy_tables_path=dummy_tables_path,
+        environ={},
+        user_args=(),
+    )
+
+    assert (
+        capsys.readouterr().out.strip() == expected_out.strip()
+    ), capsys.readouterr().out.strip()

--- a/tests/unit/query_engines/test_in_memory_database.py
+++ b/tests/unit/query_engines/test_in_memory_database.py
@@ -9,6 +9,7 @@ from ehrql.query_engines.in_memory_database import (
     apply_function,
     apply_function_to_rows_and_values,
     handle_null,
+    truncate_records,
 )
 
 
@@ -592,3 +593,49 @@ def test_apply_function_with_no_event_columns():
 
 def sum_(*args):
     return sum(args)
+
+
+def test_truncate_records():
+    p = PatientColumn.parse(
+        """
+        1 | 101
+        2 | 201
+        3 | 301
+        4 | 401
+        5 | 501
+        """
+    )
+    records = list(p.to_records())
+    assert records == [
+        {"patient_id": 1, "value": 101},
+        {"patient_id": 2, "value": 201},
+        {"patient_id": 3, "value": 301},
+        {"patient_id": 4, "value": 401},
+        {"patient_id": 5, "value": 501},
+    ]
+
+    # truncate to first rows
+    assert truncate_records(records, head=2) == [
+        {"patient_id": 1, "value": 101},
+        {"patient_id": 2, "value": 201},
+        {"patient_id": "...", "value": "..."},
+    ]
+    # truncate to last rows
+    assert truncate_records(records, tail=2) == [
+        {"patient_id": "...", "value": "..."},
+        {"patient_id": 4, "value": 401},
+        {"patient_id": 5, "value": 501},
+    ]
+    # truncate to first and last rows
+    assert truncate_records(records, head=1, tail=1) == [
+        {"patient_id": 1, "value": 101},
+        {"patient_id": "...", "value": "..."},
+        {"patient_id": 5, "value": 501},
+    ]
+    # truncate with no head/tail values - return all records
+    assert truncate_records(records) == records
+    # truncate with head that's > number of records - return all records
+    assert truncate_records(records, head=6) == records
+    # truncate with head/tail that equals number of records - return all records,
+    # no ellipsis records
+    assert truncate_records(records, head=2, tail=3) == records

--- a/tests/unit/test_debug.py
+++ b/tests/unit/test_debug.py
@@ -31,10 +31,26 @@ def test_show_int_variable(capsys):
     assert captured.err.strip() == expected_output, captured.err
 
 
+def test_show_multiple_variables(capsys):
+    expected_output = textwrap.dedent(
+        """
+        Debug line 45:
+        12
+        'Hello'
+        """
+    ).strip()
+
+    foo = 12
+    bar = "Hello"
+    show(foo, bar)
+    captured = capsys.readouterr()
+    assert captured.err.strip() == expected_output, captured.err
+
+
 def test_show_with_label(capsys):
     expected_output = textwrap.dedent(
         """
-        Debug line 42: Number
+        Debug line 58: Number
         14
         """
     ).strip()
@@ -47,7 +63,7 @@ def test_show_with_label(capsys):
 def test_show_formatted_table(capsys):
     expected_output = textwrap.dedent(
         """
-        Debug line 64:
+        Debug line 80:
         patient_id        | value
         ------------------+------------------
         1                 | 101
@@ -69,7 +85,7 @@ def test_show_formatted_table(capsys):
 def test_show_truncated_table(capsys):
     expected_output = textwrap.dedent(
         """
-        Debug line 90:
+        Debug line 106:
         patient_id        | value
         ------------------+------------------
         1                 | 101
@@ -95,10 +111,10 @@ def test_show_truncated_table(capsys):
 def test_stop(capsys):
     stop()
     captured = capsys.readouterr()
-    assert captured.err.strip() == "Stopping at line 96"
+    assert captured.err.strip() == "Stopping at line 112"
 
 
 def test_stop_with_head_and_tail(capsys):
     stop(head=1, tail=1)
     captured = capsys.readouterr()
-    assert captured.err.strip() == "Stopping at line 102"
+    assert captured.err.strip() == "Stopping at line 118"

--- a/tests/unit/test_debug.py
+++ b/tests/unit/test_debug.py
@@ -1,12 +1,13 @@
 import textwrap
 
 from ehrql.debug import show
+from ehrql.query_engines.in_memory_database import PatientColumn
 
 
 def test_show_string(capsys):
     expected_output = textwrap.dedent(
         """
-        Debug line 14:
+        Debug line 15:
         'Hello'
         """
     ).strip()
@@ -19,7 +20,7 @@ def test_show_string(capsys):
 def test_show_int_variable(capsys):
     expected_output = textwrap.dedent(
         """
-        Debug line 28:
+        Debug line 29:
         12
         """
     ).strip()
@@ -33,11 +34,33 @@ def test_show_int_variable(capsys):
 def test_show_with_label(capsys):
     expected_output = textwrap.dedent(
         """
-        Debug line 41: Number
+        Debug line 42: Number
         14
         """
     ).strip()
 
     show(14, label="Number")
+    captured = capsys.readouterr()
+    assert captured.err.strip() == expected_output, captured.err
+
+
+def test_show_formatted_table(capsys):
+    expected_output = textwrap.dedent(
+        """
+        Debug line 64:
+        patient_id        | value
+        ------------------+------------------
+        1                 | 101
+        2                 | 201
+        """
+    ).strip()
+
+    c = PatientColumn.parse(
+        """
+        1 | 101
+        2 | 201
+        """
+    )
+    show(c)
     captured = capsys.readouterr()
     assert captured.err.strip() == expected_output, captured.err

--- a/tests/unit/test_debug.py
+++ b/tests/unit/test_debug.py
@@ -1,0 +1,43 @@
+import textwrap
+
+from ehrql.debug import show
+
+
+def test_show_string(capsys):
+    expected_output = textwrap.dedent(
+        """
+        Debug line 14:
+        'Hello'
+        """
+    ).strip()
+
+    show("Hello")
+    captured = capsys.readouterr()
+    assert captured.err.strip() == expected_output, captured.err
+
+
+def test_show_int_variable(capsys):
+    expected_output = textwrap.dedent(
+        """
+        Debug line 28:
+        12
+        """
+    ).strip()
+
+    foo = 12
+    show(foo)
+    captured = capsys.readouterr()
+    assert captured.err.strip() == expected_output, captured.err
+
+
+def test_show_with_label(capsys):
+    expected_output = textwrap.dedent(
+        """
+        Debug line 41: Number
+        14
+        """
+    ).strip()
+
+    show(14, label="Number")
+    captured = capsys.readouterr()
+    assert captured.err.strip() == expected_output, captured.err

--- a/tests/unit/test_debug.py
+++ b/tests/unit/test_debug.py
@@ -1,6 +1,6 @@
 import textwrap
 
-from ehrql.debug import show
+from ehrql.debug import show, stop
 from ehrql.query_engines.in_memory_database import PatientColumn
 
 
@@ -64,3 +64,41 @@ def test_show_formatted_table(capsys):
     show(c)
     captured = capsys.readouterr()
     assert captured.err.strip() == expected_output, captured.err
+
+
+def test_show_truncated_table(capsys):
+    expected_output = textwrap.dedent(
+        """
+        Debug line 90:
+        patient_id        | value
+        ------------------+------------------
+        1                 | 101
+        ...               | ...
+        4                 | 401
+        """
+    ).strip()
+
+    c = PatientColumn.parse(
+        """
+        1 | 101
+        2 | 201
+        3 | 301
+        4 | 401
+        """
+    )
+
+    show(c, head=1, tail=1)
+    captured = capsys.readouterr()
+    assert captured.err.strip() == expected_output, captured.err
+
+
+def test_stop(capsys):
+    stop()
+    captured = capsys.readouterr()
+    assert captured.err.strip() == "Stopping at line 96"
+
+
+def test_stop_with_head_and_tail(capsys):
+    stop(head=1, tail=1)
+    captured = capsys.readouterr()
+    assert captured.err.strip() == "Stopping at line 102"

--- a/tests/unit/test_renderers.py
+++ b/tests/unit/test_renderers.py
@@ -1,0 +1,89 @@
+import textwrap
+
+import pytest
+
+from ehrql.query_engines.in_memory_database import (
+    PatientColumn,
+    PatientTable,
+)
+from ehrql.renderers import DISPLAY_RENDERERS
+
+
+TABLE = PatientTable.parse(
+    """
+      |  i1 |  i2
+    --+-----+-----
+    1 | 101 | 111
+    2 | 201 | 211
+    3 | 301 | 311
+    4 | 401 | 411
+    5 | 501 | 511
+    """
+)
+
+
+@pytest.mark.parametrize("render_format", ["ascii", "html"])
+def test_render_table(render_format):
+    expected_output = {
+        "ascii": textwrap.dedent(
+            """
+            patient_id        | i1                | i2
+            ------------------+-------------------+------------------
+            1                 | 101               | 111
+            2                 | 201               | 211
+            3                 | 301               | 311
+            4                 | 401               | 411
+            5                 | 501               | 511
+            """
+        ).strip(),
+        "html": (
+            "<table>"
+            "<thead>"
+            "<th>patient_id</th><th>i1</th><th>i2</th>"
+            "</thead>"
+            "<tbody>"
+            "<tr><td>1</td><td>101</td><td>111</td></tr>"
+            "<tr><td>2</td><td>201</td><td>211</td></tr>"
+            "<tr><td>3</td><td>301</td><td>311</td></tr>"
+            "<tr><td>4</td><td>401</td><td>411</td></tr>"
+            "<tr><td>5</td><td>501</td><td>511</td></tr>"
+            "</tbody>"
+            "</table>"
+        ),
+    }
+    rendered = DISPLAY_RENDERERS[render_format](TABLE.to_records()).strip()
+    assert rendered == expected_output[render_format], rendered
+
+
+@pytest.mark.parametrize("render_format", ["ascii", "html"])
+def test_render_column(render_format):
+    expected_output = expected_output = {
+        "ascii": textwrap.dedent(
+            """
+            patient_id        | value
+            ------------------+------------------
+            1                 | 101
+            2                 | 201
+            """
+        ).strip(),
+        "html": (
+            "<table>"
+            "<thead>"
+            "<th>patient_id</th><th>value</th>"
+            "</thead>"
+            "<tbody>"
+            "<tr><td>1</td><td>101</td></tr>"
+            "<tr><td>2</td><td>201</td></tr>"
+            "</tbody>"
+            "</table>"
+        ),
+    }
+
+    c = PatientColumn.parse(
+        """
+        1 | 101
+        2 | 201
+        """
+    )
+    rendered = DISPLAY_RENDERERS[render_format](c.to_records()).strip()
+    assert rendered == expected_output[render_format], rendered

--- a/tests/unit/test_renderers.py
+++ b/tests/unit/test_renderers.py
@@ -1,4 +1,5 @@
 import textwrap
+from itertools import product
 
 import pytest
 
@@ -6,7 +7,7 @@ from ehrql.query_engines.in_memory_database import (
     PatientColumn,
     PatientTable,
 )
-from ehrql.renderers import DISPLAY_RENDERERS
+from ehrql.renderers import DISPLAY_RENDERERS, truncate_table
 
 
 TABLE = PatientTable.parse(
@@ -87,3 +88,175 @@ def test_render_column(render_format):
     )
     rendered = DISPLAY_RENDERERS[render_format](c.to_records()).strip()
     assert rendered == expected_output[render_format], rendered
+
+
+@pytest.mark.parametrize("render_format", ["ascii", "html"])
+def test_render_table_head(render_format):
+    expected_output = {
+        "ascii": textwrap.dedent(
+            """
+            patient_id        | i1                | i2
+            ------------------+-------------------+------------------
+            1                 | 101               | 111
+            2                 | 201               | 211
+            ...               | ...               | ...
+            """
+        ).strip(),
+        "html": (
+            "<table>"
+            "<thead>"
+            "<th>patient_id</th><th>i1</th><th>i2</th>"
+            "</thead>"
+            "<tbody>"
+            "<tr><td>1</td><td>101</td><td>111</td></tr>"
+            "<tr><td>2</td><td>201</td><td>211</td></tr>"
+            "<tr><td>...</td><td>...</td><td>...</td></tr>"
+            "</tbody>"
+            "</table>"
+        ),
+    }
+
+    rendered = DISPLAY_RENDERERS[render_format](TABLE.to_records())
+    truncated = truncate_table(rendered, head=2, tail=None)
+    assert truncated == expected_output[render_format], truncated
+
+
+@pytest.mark.parametrize("render_format", ["ascii", "html"])
+def test_render_table_tail(render_format):
+    expected_output = {
+        "ascii": textwrap.dedent(
+            """
+            patient_id        | i1                | i2
+            ------------------+-------------------+------------------
+            ...               | ...               | ...
+            4                 | 401               | 411
+            5                 | 501               | 511
+            """
+        ).strip(),
+        "html": (
+            "<table>"
+            "<thead>"
+            "<th>patient_id</th><th>i1</th><th>i2</th>"
+            "</thead>"
+            "<tbody>"
+            "<tr><td>...</td><td>...</td><td>...</td></tr>"
+            "<tr><td>4</td><td>401</td><td>411</td></tr>"
+            "<tr><td>5</td><td>501</td><td>511</td></tr>"
+            "</tbody>"
+            "</table>"
+        ),
+    }
+
+    rendered = DISPLAY_RENDERERS[render_format](TABLE.to_records())
+    truncated = truncate_table(rendered, head=None, tail=2)
+    assert truncated == expected_output[render_format], truncated
+
+
+@pytest.mark.parametrize("render_format", ["ascii", "html"])
+def test_render_table_head_and_tail(render_format):
+    expected_output = {
+        "ascii": textwrap.dedent(
+            """
+            patient_id        | i1                | i2
+            ------------------+-------------------+------------------
+            1                 | 101               | 111
+            2                 | 201               | 211
+            ...               | ...               | ...
+            4                 | 401               | 411
+            5                 | 501               | 511
+            """
+        ).strip(),
+        "html": (
+            "<table>"
+            "<thead>"
+            "<th>patient_id</th><th>i1</th><th>i2</th>"
+            "</thead>"
+            "<tbody>"
+            "<tr><td>1</td><td>101</td><td>111</td></tr>"
+            "<tr><td>2</td><td>201</td><td>211</td></tr>"
+            "<tr><td>...</td><td>...</td><td>...</td></tr>"
+            "<tr><td>4</td><td>401</td><td>411</td></tr>"
+            "<tr><td>5</td><td>501</td><td>511</td></tr>"
+            "</tbody>"
+            "</table>"
+        ),
+    }
+
+    rendered = DISPLAY_RENDERERS[render_format](TABLE.to_records())
+    truncated = truncate_table(rendered, head=2, tail=2)
+    assert truncated == expected_output[render_format], truncated
+
+
+@pytest.mark.parametrize(
+    "render_format,head_tail",
+    list(
+        product(["ascii", "html"], [(None, None), (2, 3), (5, None), (None, 6), (3, 3)])
+    ),
+)
+def test_render_table_bad_head_tail(render_format, head_tail):
+    expected_output = {
+        "ascii": textwrap.dedent(
+            """
+            patient_id        | i1                | i2
+            ------------------+-------------------+------------------
+            1                 | 101               | 111
+            2                 | 201               | 211
+            3                 | 301               | 311
+            4                 | 401               | 411
+            5                 | 501               | 511
+            """
+        ).strip(),
+        "html": (
+            "<table>"
+            "<thead>"
+            "<th>patient_id</th><th>i1</th><th>i2</th>"
+            "</thead>"
+            "<tbody>"
+            "<tr><td>1</td><td>101</td><td>111</td></tr>"
+            "<tr><td>2</td><td>201</td><td>211</td></tr>"
+            "<tr><td>3</td><td>301</td><td>311</td></tr>"
+            "<tr><td>4</td><td>401</td><td>411</td></tr>"
+            "<tr><td>5</td><td>501</td><td>511</td></tr>"
+            "</tbody>"
+            "</table>"
+        ),
+    }
+    head, tail = head_tail
+    rendered = DISPLAY_RENDERERS[render_format](TABLE.to_records())
+    truncated = truncate_table(rendered, head=head, tail=tail).strip()
+    assert truncated == expected_output[render_format], (truncated, head, tail)
+
+
+def test_render_head_and_tail_not_a_table():
+    expected_output = textwrap.dedent(
+        """
+        a
+        b
+        ...
+        d
+        e
+        """
+    ).strip()
+
+    input_string = "\n".join(["a", "b", "c", "d", "e"])
+    truncated = truncate_table(input_string, head=2, tail=2).strip()
+    assert truncated == expected_output, truncated
+
+
+def test_truncate_table_bad_html():
+    # If we can't parse something that looks like an html
+    # table as expected, we fall back to the basic line truncator
+    bad_html = (
+        "<table>\n"
+        "<thead>\n"
+        "<th>patient_id</th><th>i1</th><th>i2</th>\n"
+        "</thead>\n"
+        "<tbody>\n"
+        "</tbody>\n"
+        "</table>"
+    )
+
+    expected = "<table>\n" "<thead>\n" "..."
+
+    truncated = truncate_table(bad_html, head=2, tail=None)
+    assert truncated == expected, truncated

--- a/tests/unit/test_sandbox.py
+++ b/tests/unit/test_sandbox.py
@@ -19,10 +19,12 @@ dataset
 """
 
 expected_series_output = """
- 1 | 1980-01-01
- 2 | 1990-02-01
- 3 | 2000-03-01
- 4 | 2010-04-01
+patient_id        | value
+------------------+------------------
+1                 | 1980-01-01
+2                 | 1990-02-01
+3                 | 2000-03-01
+4                 | 2010-04-01
 """.strip()
 
 expected_frame_output = """
@@ -56,7 +58,7 @@ def test_run(capsys, monkeypatch):
     dummy_tables_path = Path(__file__).parents[1] / "fixtures" / "sandbox"
     run(dummy_tables_path)
     captured = capsys.readouterr()
-    assert expected_series_output in captured.out
+    assert expected_series_output in captured.out, captured.out
     assert expected_frame_output in captured.out
     assert expected_dataset_output_1 in captured.out
     assert expected_dataset_output_2 in captured.out


### PR DESCRIPTION
Adds an ehrQL debug command, which uses dummy tables to alllow users to evaluate variables, tables and datasets in a dataset definition.  Called from the command line like:

```
ehrql debug <dataset definition file> --dummy-tables /path/to/dummy/tables
```

In a dataset definition, users use the new `show()` and `stop()` functions:

```
...
from erhql.debug import show, stop

age = patients.age_on(index_date)
show(age)

dataset = create_dataset()
dataset.define_population(...)
stop()

dataset.age = age
```

`show(age)` prints the contents of the age variable; `stop()` means we stop loading the dataset definition at that point and evaluate and display the dataset as it is (i.e. in the above example, the dataset only has patient_id on it as age hasn't been added yet.

Both `show` and `stop` take optional `head` and `tail` kwargs, which display on the the first and last rows respectively. When passed to `stop()` they affect the rows shown on the final output dataset.

Example terminal output:
```
Debug line 14:
patient_id        | value
------------------+------------------
1                 | 1973
2                 | 1948
...               | ...
10                | 1979
Stopping at line 21
patient_id        | age               | year
------------------+-------------------+------------------
1                 | 49                | 1973
2                 | 74                | 1948
3                 | 19                | 2003
6                 | 28                | 1994
7                 | 69                | 1953
8                 | 30                | 1992
10                | 43                | 1979
```

The command can be passed an optional `--display-format` arg, which can be either "ascii" (the default, used for terminal output) or "html" (used for the vscode extension).

Example VS code output:
![Screenshot from 2024-11-12 10-41-42](https://github.com/user-attachments/assets/5f303027-f8dc-4048-9300-72b9b7ff3f1d)
