### PR TITLE
Remove all dependencies from core ehrql functionality

### DIFF
--- a/ehrql/sandbox.py
+++ b/ehrql/sandbox.py
@@ -1,6 +1,4 @@
 import code
-import readline
-import rlcompleter
 import sys
 
 from ehrql.debugger import activate_debug_context
@@ -17,7 +15,16 @@ def run(dummy_tables_path):
 
     # Set up namespace for tab-completion.
     namespace = {}
-    readline.set_completer(rlcompleter.Completer(namespace).complete)
+
+    # The readline library is not available in pyodide, it uses a different
+    # readline implementation that is enabled by default
+    try:
+        import readline
+        import rlcompleter
+
+        readline.set_completer(rlcompleter.Completer(namespace).complete)
+    except ImportError:
+        pass
 
     # Start running a Python REPL.
     with activate_debug_context(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 import os
 import subprocess
 import threading
+import venv
 from pathlib import Path
 
 import pytest
@@ -290,3 +291,12 @@ def study(tmp_path, containers, ehrql_image):
     # directories
     tmp_path.chmod(0o755)
     return Study(tmp_path, containers, ehrql_image)
+
+
+@pytest.fixture
+def venv_with_ehrql(tmp_path):
+    venv_path = tmp_path / "venv"
+    venv.create(venv_path, with_pip=True)
+    subprocess.run([venv_path / "bin/pip", "install", "-e", "."], check=True)
+    subprocess.run([venv_path / "bin/pip", "install", "pytest-cov"], check=True)
+    return venv_path

--- a/tests/integration/file_formats/test_arrow.py
+++ b/tests/integration/file_formats/test_arrow.py
@@ -1,3 +1,5 @@
+import subprocess
+
 import pyarrow.feather
 import pytest
 
@@ -59,3 +61,24 @@ def test_write_rows_arrow_raises_helpful_dictionary_errors(tmp_path):
         match="Invalid value 'D' for column 'category'\nAllowed are: 'A', 'B', 'C'",
     ):
         write_rows(filename, results, column_specs)
+
+
+def test_pyarrow_not_installed(venv_with_ehrql):
+    try:
+        subprocess.run(
+            [
+                venv_with_ehrql / "bin/python",
+                "-c",
+                "from pathlib import Path\n"
+                "from ehrql.file_formats import read_rows\n"
+                "read_rows(Path('file.arrow'), {})",
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        assert "Unsupported file type: .arrow" in exc.stderr
+        assert "You need to install pyarrow" in exc.stderr
+    else:
+        assert False, "Expected process error due to lack of pyarrow"

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -1,3 +1,4 @@
+import subprocess
 import textwrap
 from datetime import date
 
@@ -281,3 +282,29 @@ def test_debug_debug(tmp_path, capsys):
         """
     ).strip()
     assert capsys.readouterr().err.strip() == expected
+
+
+def test_sandbox_with_no_dependencies(venv_with_ehrql):
+    ps = subprocess.run(
+        [
+            venv_with_ehrql / "bin/python",
+            "-m",
+            "ehrql",
+            "sandbox",
+            "ehrql/example-data/",
+        ],
+        input=textwrap.dedent(
+            """\
+            from ehrql.tables.core import patients
+            patients
+            exit(0)
+            """
+        ),
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    # check it has loaded the patient table and repr'd it
+    assert "patient_id" in ps.stdout
+    assert "date_of_birth" in ps.stdout


### PR DESCRIPTION
This means we can run the sandbox w/o pyarrow, sqlalchemy, or the various graphviz dependencies installed.

Introduces a new fixture that installs ehrql in an isolated venv to test
the dependency-not-installed code paths work.


