### PR TITLE
Allow users to do a quiz by filling in gaps in an incomplete file

### DIFF
--- a/docs/includes/generated_docs/cli.md
+++ b/docs/includes/generated_docs/cli.md
@@ -32,6 +32,20 @@ Start the ehrQL sandbox environment.
 </p>
 
 <div class="attr-heading">
+  <a href="#quiz"><tt>quiz</tt></a>
+</div>
+<p class="indent">
+Start the ehrQL quiz.
+</p>
+
+<div class="attr-heading">
+  <a href="#dump-quiz-file"><tt>dump-quiz-file</tt></a>
+</div>
+<p class="indent">
+Dump the file for answering the quiz to the current directory.
+</p>
+
+<div class="attr-heading">
   <a href="#dump-example-data"><tt>dump-example-data</tt></a>
 </div>
 <p class="indent">
@@ -397,6 +411,51 @@ Path to directory of data files (one per table), supported formats are:
 <div class="attr-heading" id="sandbox.help">
   <tt>-h, --help</tt>
   <a class="headerlink" href="#sandbox.help" title="Permanent link">🔗</a>
+</div>
+<div markdown="block" class="indent">
+show this help message and exit
+
+</div>
+
+
+<h2 id="quiz" data-toc-label="quiz" markdown>
+  quiz
+</h2>
+```
+ehrql quiz [QUIZ_FILE_PATH] [--help]
+```
+Start the ehrQL quiz.
+
+<div class="attr-heading" id="quiz.quiz_file_path">
+  <tt>QUIZ_FILE_PATH</tt>
+  <a class="headerlink" href="#quiz.quiz_file_path" title="Permanent link">🔗</a>
+</div>
+<div markdown="block" class="indent">
+Path to the quiz file. Default is `quiz_answers.py`.
+
+</div>
+
+<div class="attr-heading" id="quiz.help">
+  <tt>-h, --help</tt>
+  <a class="headerlink" href="#quiz.help" title="Permanent link">🔗</a>
+</div>
+<div markdown="block" class="indent">
+show this help message and exit
+
+</div>
+
+
+<h2 id="dump-quiz-file" data-toc-label="dump-quiz-file" markdown>
+  dump-quiz-file
+</h2>
+```
+ehrql dump-quiz-file [--help]
+```
+Dump the file for answering the quiz to the current directory.
+
+<div class="attr-heading" id="dump-quiz-file.help">
+  <tt>-h, --help</tt>
+  <a class="headerlink" href="#dump-quiz-file.help" title="Permanent link">🔗</a>
 </div>
 <div markdown="block" class="indent">
 show this help message and exit

--- a/ehrql/__main__.py
+++ b/ehrql/__main__.py
@@ -24,10 +24,12 @@ from .main import (
     debug_dataset_definition,
     dump_dataset_sql,
     dump_example_data,
+    dump_quiz_file,
     generate_dataset,
     generate_measures,
     graph_query,
     run_isolation_report,
+    run_quiz,
     run_sandbox,
     serialize_definition,
     test_connection,
@@ -155,6 +157,8 @@ def create_parser(user_args, environ):
     add_generate_dataset(subparsers, environ, user_args)
     add_generate_measures(subparsers, environ, user_args)
     add_run_sandbox(subparsers, environ, user_args)
+    add_run_quiz(subparsers, environ, user_args)
+    add_dump_quiz_file(subparsers, environ, user_args)
     add_dump_example_data(subparsers, environ, user_args)
     add_dump_dataset_sql(subparsers, environ, user_args)
     add_create_dummy_tables(subparsers, environ, user_args)
@@ -413,6 +417,35 @@ def add_debug_dataset_definition(subparsers, environ, user_args):
     )
 
     add_display_renderer_argument(parser, environ)
+
+
+def add_run_quiz(subparsers, environ, user_args):
+    parser = subparsers.add_parser(
+        "quiz",
+        help="Start the ehrQL quiz.",
+        formatter_class=RawTextHelpFormatter,
+    )
+    parser.set_defaults(function=run_quiz)
+    parser.add_argument(
+        "quiz_file_path",
+        nargs="?",
+        default="quiz_answers.py",
+        help=strip_indent(
+            """
+            Path to the quiz file. Default is `quiz_answers.py`.
+            """
+        ),
+        type=existing_python_file,
+    )
+
+
+def add_dump_quiz_file(subparsers, environ, user_args):
+    parser = subparsers.add_parser(
+        "dump-quiz-file",
+        help="Dump the file for answering the quiz to the current directory.",
+        formatter_class=RawTextHelpFormatter,
+    )
+    parser.set_defaults(function=dump_quiz_file)
 
 
 def add_assure(subparsers, environ, user_args):

--- a/ehrql/docs/cli.py
+++ b/ehrql/docs/cli.py
@@ -56,6 +56,13 @@ def get_argument(action):
             "usage_long": ", ".join(action.option_strings),
             "description": action.help,
         }
+    elif isinstance(action, argparse._StoreAction) and action.nargs == "?":
+        return {
+            "id": action.dest,
+            "usage_short": f"[{action.dest.upper()}]",
+            "usage_long": action.dest.upper(),
+            "description": action.help,
+        }
     elif isinstance(action, argparse._StoreAction) and not action.required:
         return {
             "id": action.option_strings[-1].lstrip("-"),

--- a/ehrql/main.py
+++ b/ehrql/main.py
@@ -7,7 +7,7 @@ from contextlib import nullcontext
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 
-from ehrql import assurance, sandbox
+from ehrql import assurance, quiz, sandbox
 from ehrql.dummy_data import DummyDataGenerator
 from ehrql.dummy_data_nextgen import DummyDataGenerator as NextGenDummyDataGenerator
 from ehrql.dummy_data_nextgen import (
@@ -355,6 +355,15 @@ def get_dummy_measures_data_class(dummy_data_config):
 
 def run_sandbox(dummy_tables_path, environ):
     sandbox.run(dummy_tables_path)
+
+
+def run_quiz(quiz_file_path):
+    sandbox.run_quiz(quiz_file_path)
+
+
+def dump_quiz_file():
+    dst_path = Path(os.getcwd()) / "quiz_answers.py"
+    quiz.write_quiz_file(dst_path)
 
 
 def assure(test_data_file, environ, user_args):

--- a/ehrql/quiz.py
+++ b/ehrql/quiz.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import Any
 
 from ehrql.query_engines.in_memory_database import (
@@ -266,3 +267,13 @@ def _check_table_then_columns_one_by_one(
         check_column,
         column_names=column_names,
     )
+
+
+def get_quiz_file_contents() -> str:
+    return "# Welcome to the ehrQL Quiz!"
+
+
+def write_quiz_file(file_path: str | Path) -> None:
+    contents = get_quiz_file_contents()
+    with open(file_path, "w") as f:
+        f.write(contents)

--- a/ehrql/sandbox.py
+++ b/ehrql/sandbox.py
@@ -1,6 +1,7 @@
 import code
 import readline
 import rlcompleter
+import subprocess
 import sys
 
 from ehrql.query_engines.sandbox import SandboxQueryEngine
@@ -35,3 +36,7 @@ def run(dummy_tables_path):
 def excepthook(type_, exc, tb):
     traceback = get_trimmed_traceback(exc, "<console>")
     sys.stderr.write(traceback)
+
+
+def run_quiz(quiz_file_path):  # pragma: no cover
+    subprocess.call(["python", str(quiz_file_path)])

--- a/tests/integration/test___main__.py
+++ b/tests/integration/test___main__.py
@@ -49,6 +49,24 @@ def test_dump_example_data(tmpdir):
     assert "patients.csv" in filenames
 
 
+def test_dump_quiz_file(tmpdir):
+    with contextlib.chdir(tmpdir):
+        main(["dump-quiz-file"])
+    filepath = tmpdir / "quiz_answers.py"
+    assert filepath.exists()
+    with open(filepath) as f:
+        content = f.read()
+        assert content.startswith("# Welcome to the ehrQL Quiz!")
+
+
+def test_run_quiz_with_default_file(mocker, tmpdir):
+    patched = mocker.patch("ehrql.sandbox.run_quiz")
+    with contextlib.chdir(tmpdir):
+        main(["dump-quiz-file"])
+        main(["quiz"])
+        patched.assert_called_once_with(Path("quiz_answers.py"))
+
+
 @pytest.mark.parametrize(
     "definition_type,definition_file",
     [

--- a/tests/unit/test___main__.py
+++ b/tests/unit/test___main__.py
@@ -139,7 +139,27 @@ def test_run_sandbox(mocker, tmp_path):
         str(dummy_data_path),
     ]
     main(argv)
-    patched.assert_called_once()
+    patched.assert_called_once_with(dummy_data_path)
+
+
+def test_run_quiz_with_file_path(mocker, tmp_path):
+    patched = mocker.patch("ehrql.sandbox.run_quiz")
+    file_path = tmp_path / "quiz_answers.py"
+    open(file_path, "w").close()
+    argv = [
+        "quiz",
+        str(file_path),
+    ]
+    main(argv)
+    patched.assert_called_once_with(file_path)
+
+
+def test_run_quiz_with_missing_file():
+    argv = [
+        "quiz",
+    ]
+    with pytest.raises(SystemExit):
+        main(argv)
 
 
 def test_existing_python_file_missing_file(capsys, tmp_path):

--- a/tests/unit/test_quiz.py
+++ b/tests/unit/test_quiz.py
@@ -5,7 +5,7 @@ import hypothesis.strategies as st
 import pytest
 from hypothesis import given
 
-from ehrql import quiz, weeks
+from ehrql import quiz, sandbox, weeks
 from ehrql.query_engines.sandbox import SandboxQueryEngine
 from ehrql.query_language import Dataset
 from ehrql.tables.core import (
@@ -61,6 +61,9 @@ def filtered_medications(
     return filtered
 
 
+# Tests for check_answer
+
+
 @pytest.mark.parametrize(
     "answer, expected, message",
     [
@@ -71,12 +74,12 @@ def filtered_medications(
         (patients, patients.date_of_birth, "Expected Series, got Table instead."),
     ],
 )
-def test_wrong_type_before_evaluation(answer, expected, message):
+def test_check_answer_wrong_type_before_evaluation(answer, expected, message):
     msg = quiz.check_answer(engine=None, answer=answer, expected=expected)
     assert msg == message
 
 
-def test_event_frame_not_converted_to_patient_frame(engine):
+def test_check_answer_event_frame_not_converted_to_patient_frame(engine):
     # Wrong type after evaluation
     msg = quiz.check_answer(
         engine=engine,
@@ -97,12 +100,12 @@ def test_event_frame_not_converted_to_patient_frame(engine):
         (medications.dmd_code, medications.dmd_code),
     ],
 )
-def test_same_syntax_correct(engine, answer, expected):
+def test_check_answer_same_syntax_correct(engine, answer, expected):
     msg = quiz.check_answer(engine=engine, answer=answer, expected=expected)
     assert msg == "Correct!"
 
 
-def test_empty_dataset(engine):
+def test_check_answer_empty_dataset(engine):
     msg = quiz.check_answer(
         engine=engine, answer=Dataset(), expected=dataset_smoketest()
     )
@@ -116,14 +119,14 @@ def test_empty_dataset(engine):
         ([1, 0], "Found extra column(s): year_of_birth."),
     ],
 )
-def test_dataset_has_missing_or_extra_column(engine, order, message):
+def test_check_answer_dataset_has_missing_or_extra_column(engine, order, message):
     datasets = [dataset_smoketest(), dataset_smoketest(year_of_birth_column=True)]
     answer, expected = (datasets[i] for i in order)
     msg = quiz.check_answer(engine=engine, answer=answer, expected=expected)
     assert msg == message
 
 
-def test_dataset_typo_in_column_name(engine):
+def test_check_answer_dataset_typo_in_column_name(engine):
     answer = dataset_smoketest(year_of_birth_column=False)
     answer.yeah_of_birth = patients.date_of_birth.year
     expected = dataset_smoketest(year_of_birth_column=True)
@@ -141,14 +144,14 @@ def test_dataset_typo_in_column_name(engine):
         ([1, 0], "Found extra patient(s): 4, 5, 9."),
     ],
 )
-def test_dataset_has_missing_or_extra_patients(engine, order, message):
+def test_check_answer_dataset_has_missing_or_extra_patients(engine, order, message):
     datasets = [dataset_smoketest(), dataset_smoketest(min_age=0, max_age=100)]
     answer, expected = (datasets[i] for i in order)
     msg = quiz.check_answer(engine=engine, answer=answer, expected=expected)
     assert msg == message
 
 
-def test_dataset_column_has_missing_patients(engine):
+def test_check_answer_dataset_column_has_missing_patients(engine):
     answer = dataset_smoketest()
     expected = dataset_smoketest()
     answer.num_medications = filtered_medications().count_for_patient()
@@ -157,7 +160,7 @@ def test_dataset_column_has_missing_patients(engine):
     assert msg == "Column `num_medications`:\nMissing patient(s): 1."
 
 
-def test_dataset_has_incorrect_value(engine):
+def test_check_answer_dataset_has_incorrect_value(engine):
     msg = quiz.check_answer(
         engine=engine,
         answer=dataset_smoketest(index_year=2023),
@@ -173,7 +176,9 @@ def test_dataset_has_incorrect_value(engine):
         ([1, 0], "Found extra patient(s): 7."),
     ],
 )
-def test_patient_series_has_missing_or_extra_patients(engine, order, message):
+def test_check_answer_patient_series_has_missing_or_extra_patients(
+    engine, order, message
+):
     series = [
         practice_registrations.for_patient_on("2013-12-01").practice_pseudo_id,
         practice_registrations.for_patient_on("2014-01-01").practice_pseudo_id,
@@ -183,7 +188,7 @@ def test_patient_series_has_missing_or_extra_patients(engine, order, message):
     assert msg == message
 
 
-def test_patient_series_has_incorrect_value(engine):
+def test_check_answer_patient_series_has_incorrect_value(engine):
     msg = quiz.check_answer(
         engine=engine,
         answer=patients.age_on("2023-12-31"),
@@ -199,7 +204,7 @@ def test_patient_series_has_incorrect_value(engine):
         ([0, 1], "Found extra row(s): 1, 3, 6, 9, 10, 13, 15, 17, 19, 20."),
     ],
 )
-def test_event_table_has_missing_or_extra_rows(engine, order, message):
+def test_check_answer_event_table_has_missing_or_extra_rows(engine, order, message):
     tables = [
         clinical_events,
         clinical_events.where(clinical_events.snomedct_code.is_in(["60621009"])),
@@ -216,7 +221,7 @@ def test_event_table_has_missing_or_extra_rows(engine, order, message):
         ([0, 1], "Found extra row(s): 5, 9."),
     ],
 )
-def test_event_series_has_missing_or_extra_rows(engine, order, message):
+def test_check_answer_event_series_has_missing_or_extra_rows(engine, order, message):
     series = [
         medications.dmd_code,
         medications.where(medications.date.is_on_or_before("2020-12-01")).dmd_code,
@@ -226,7 +231,7 @@ def test_event_series_has_missing_or_extra_rows(engine, order, message):
     assert msg == message
 
 
-def test_event_series_has_incorrect_value(engine):
+def test_check_answer_event_series_has_incorrect_value(engine):
     answer = medications.date
     expected = medications.dmd_code
     msg = quiz.check_answer(engine=engine, answer=answer, expected=expected)
@@ -236,7 +241,7 @@ def test_event_series_has_incorrect_value(engine):
     )
 
 
-def test_incorrect_event_selection_for_patient(engine):
+def test_check_answer_incorrect_event_selection_for_patient(engine):
     events = clinical_events.where(
         clinical_events.snomedct_code.is_in(["60621009"])
     ).sort_by(clinical_events.date)
@@ -249,7 +254,7 @@ def test_incorrect_event_selection_for_patient(engine):
     )
 
 
-def test_unidentified_error_shows_fallback_message(engine):
+def test_check_answer_unidentified_error_shows_fallback_message(engine):
     with patch("ehrql.quiz.check_patient_table_values", return_value=None):
         msg = quiz.check_answer(
             engine, dataset_smoketest(index_year=2024), dataset_smoketest()
@@ -271,7 +276,7 @@ def test_unidentified_error_shows_fallback_message(engine):
         year_of_birth_column=...,
     )
 )
-def test_dataset_is_either_correct_or_has_informative_error(dataset):
+def test_check_answer_dataset_is_either_correct_or_has_informative_error(dataset):
     engine = get_engine()
     msg = quiz.check_answer(engine, dataset, dataset_smoketest())
     assert not msg.startswith("Incorrect answer.\nExpected:")
@@ -286,7 +291,9 @@ def test_dataset_is_either_correct_or_has_informative_error(dataset):
         filter_dates=...,
     )
 )
-def test_filtered_medications_is_either_correct_or_has_informative_error(answer):
+def test_check_answer_filtered_medications_is_either_correct_or_has_informative_error(
+    answer,
+):
     engine = get_engine()
     msg = quiz.check_answer(
         engine,
@@ -294,3 +301,42 @@ def test_filtered_medications_is_either_correct_or_has_informative_error(answer)
         filtered_medications(),
     )
     assert not msg.startswith("Incorrect answer.\nExpected:")
+
+
+# Tests for functions running the quiz
+def test_get_questions():
+    questions = quiz.get_questions()
+    assert len(questions) == 2
+    assert questions[1].engine == questions[2].engine
+
+
+def test_get_questions_without_creating_engine():
+    questions = quiz.get_questions(create_engine=False)
+    assert len(questions) == 2
+    assert questions[1].engine is None
+
+
+def test_check():
+    question = quiz.Question("Create an Empty Dataset.")
+    question.expected = Dataset()
+    msg = question.check(Dataset())
+    assert msg == "Correct!"
+
+
+def test_write_quiz_file(tmpdir):
+    path = tmpdir / "quiz_answers.py"
+    quiz.write_quiz_file(path)
+    with open(path) as f:
+        contents = f.read()
+    assert contents.startswith("# Welcome to the ehrQL Quiz!")
+
+
+def test_run_quiz_with_default_file(capfd, tmpdir):
+    path = tmpdir / "quiz_answers.py"
+    quiz.write_quiz_file(path)
+
+    sandbox.run_quiz(path)
+    captured = capfd.readouterr()
+
+    assert "Expected Dataset, got ellipsis instead." in captured.out
+    assert "Expected Table, got ellipsis instead." in captured.out


### PR DESCRIPTION
 Addresses #2221. Context is provided in the ticket. 

- Allows a user to run the quiz in the codespace by `opensafely exec ehrql:v1 quiz`, provided that a `quiz_answers.py` file already exists. This can be done easily by adding it to the ehrQL tutorial template.
- Writing quiz questions is out of the scope for this PR. It should be noted that imports made for the user are currently hard-coded strings that needs to be adjusted with the questions. Unless it is possible to run ruff on the file upon generation, I found this to be the easiest, albeit non-ideal implementation.