### PR TITLE
Revert buggy in-memory engine change

### DIFF
--- a/ehrql/query_engines/in_memory_database.py
+++ b/ehrql/query_engines/in_memory_database.py
@@ -208,7 +208,7 @@ class EventTable:
     def pick_at_index(self, ix):
         return PatientTable(
             {
-                name: col.pick_at_index(ix, name == "patient_id")
+                name: col.pick_at_index(ix)
                 for name, col in self.name_to_col.items()
                 if name != "row_id"
             }
@@ -351,14 +351,19 @@ class EventColumn:
             {p: rows.sort(sort_index[p]) for p, rows in self.patient_to_rows.items()}
         )
 
-    def pick_at_index(self, ix, is_patient_id=False):
-        if is_patient_id:
-            # The patient_id column is special, and should always be a mapping
-            # from an id to itself.  Rows.pick_at_index will return None if a
-            # patient has no rows in the column.
-            return PatientColumn({p: p for p in self.patient_to_rows})
+    def pick_at_index(self, ix):
+        # It is arguable that for a patient with no rows (which would occur if
+        # this EventColumn was derived by filtering another EventColumn), the
+        # patient should be present in the new PatientColumn, with value None.
+        #
+        # However, we have decided to instead omit the patient from the new
+        # PatientColumn.
         return PatientColumn(
-            {p: rows.pick_at_index(ix) for p, rows in self.patient_to_rows.items()}
+            {
+                p: rows.pick_at_index(ix)
+                for p, rows in self.patient_to_rows.items()
+                if rows
+            }
         )
 
 
@@ -430,10 +435,7 @@ class Rows(UserDict):
     def pick_at_index(self, ix):
         """Return element at given position."""
 
-        try:
-            k = list(self)[ix]
-        except IndexError:
-            return None
+        k = list(self)[ix]
         return self[k]
 
 

--- a/tests/unit/query_engines/test_in_memory_database.py
+++ b/tests/unit/query_engines/test_in_memory_database.py
@@ -395,7 +395,6 @@ def test_event_table_filter_then_pick_at_index():
         --+-----+-----
         1 | 102 | 112
         2 | 203 | 211
-        3 |     |
         """,
     )
 

--- a/tests/unit/test_quiz.py
+++ b/tests/unit/test_quiz.py
@@ -12,6 +12,7 @@ from ehrql.tables.core import (
     clinical_events,
     medications,
     patients,
+    practice_registrations,
 )
 
 
@@ -157,6 +158,25 @@ def test_check_answer_dataset_column_has_missing_patients(engine):
         expected=dataset_smoketest(),
     )
     assert msg == "Incorrect `age` value for patient 1: expected 49, got 50 instead."
+
+
+@pytest.mark.parametrize(
+    "order, message",
+    [
+        ([0, 1], "Missing patient(s): 7."),
+        ([1, 0], "Found extra patient(s): 7."),
+    ],
+)
+def test_check_answer_patient_series_has_missing_or_extra_patients(
+    engine, order, message
+):
+    series = [
+        practice_registrations.for_patient_on("2013-12-01").practice_pseudo_id,
+        practice_registrations.for_patient_on("2014-01-01").practice_pseudo_id,
+    ]
+    answer, expected = (series[i] for i in order)
+    msg = quiz.check_answer(engine=engine, answer=answer, expected=expected)
+    assert msg == message
 
 
 def test_check_answer_patient_series_has_incorrect_value(engine):


### PR DESCRIPTION
This reverts the changes in #2247 which caused the in-memory engine to give incorrect results. As the in-memory engine is used for dummy data generation I don't think we can afford to live with this.

Fixing this would involve having some mechanism whereby a PatientFrame derived from an EventFrame by picking rows can distinguish patient_ids which are actually present in the frame from those which exist just in order to give less confusing results in the sandbox/debug context.

The bug was originally [discovered](https://github.com/opensafely-core/ehrql/actions/runs/12050788107/job/33600394222) by the overnight generative tests (thanks Hypothesis!).

Slack discussion:
https://bennettoxford.slack.com/archives/C069YDR4NCA/p1732729097689479