### PR TITLE
Dummy data configuration tweaks

### DIFF
--- a/ehrql/dummy_data/generator.py
+++ b/ehrql/dummy_data/generator.py
@@ -110,6 +110,10 @@ class DummyDataGenerator:
                     f"Failed to find {self.population_size} matching patients within "
                     f"{self.timeout} seconds — giving up"
                 )
+                log.info(
+                    f"Use e.g. `dataset.configure_dummy_data(timeout={self.timeout * 2})` "
+                    f"to try for longer"
+                )
                 return data
 
     def get_patient_id_batches(self):

--- a/ehrql/dummy_data_nextgen/generator.py
+++ b/ehrql/dummy_data_nextgen/generator.py
@@ -110,6 +110,10 @@ class DummyDataGenerator:
                     f"Failed to find {self.population_size} matching patients within "
                     f"{self.timeout} seconds — giving up"
                 )
+                log.info(
+                    f"Use e.g. `dataset.configure_dummy_data(timeout={self.timeout * 2})` "
+                    f"to try for longer"
+                )
                 return data
 
     def get_patient_id_batches(self):


### PR DESCRIPTION
This is a follow-on PR from #2258 to incorporate some review comments which were postponed in the interests of fixing a problem for a user.

On hitting a timeout we now add a prompt showing how to configure a large timeout:
```
[warning] Failed to find 10000 matching patients within 120 seconds — giving up
[info   ] Use e.g. `dataset.configure_dummy_data(timeout=240)` to try for longer
```

We also add a crude end-to-end test to confirm that we're correctly threading the dummy data config all the way through the system.
 