### PR TITLE
Move `compile` function to a method on `Dataset`

### DIFF
--- a/ehrql/loaders.py
+++ b/ehrql/loaders.py
@@ -9,7 +9,7 @@ import textwrap
 import ehrql
 from ehrql.debugger import activate_debug_context
 from ehrql.measures import Measures
-from ehrql.query_language import Dataset, compile, modify_exception
+from ehrql.query_language import Dataset, modify_exception
 from ehrql.renderers import DISPLAY_RENDERERS
 from ehrql.serializer import deserialize
 from ehrql.utils.traceback_utils import get_trimmed_traceback
@@ -282,7 +282,7 @@ def get_variable_definitions_from_module(module):
         raise DefinitionError(
             "A population has not been defined; define one with define_population()"
         )
-    return compile(dataset)
+    return dataset._compile()
 
 
 def load_measure_definitions_unsafe(definition_file, user_args, **kwargs):

--- a/ehrql/query_engines/sandbox.py
+++ b/ehrql/query_engines/sandbox.py
@@ -2,14 +2,14 @@ from functools import reduce
 
 from ehrql.query_engines.in_memory_database import apply_function
 from ehrql.query_engines.local_file import LocalFileQueryEngine
-from ehrql.query_language import Dataset, DateDifference, compile
+from ehrql.query_language import Dataset, DateDifference
 from ehrql.query_model.introspection import get_table_nodes
 from ehrql.query_model.nodes import AggregateByPatient, Function
 
 
 class SandboxQueryEngine(LocalFileQueryEngine):
     def evaluate_dataset(self, dataset_definition):
-        variable_definitions = compile(dataset_definition)
+        variable_definitions = dataset_definition._compile()
         if not variable_definitions:
             return EmptyDataset()
         table_nodes = get_table_nodes(*variable_definitions.values())

--- a/ehrql/query_language.py
+++ b/ehrql/query_language.py
@@ -157,6 +157,9 @@ class Dataset:
             return self.variables[name]
         raise AttributeError(f"Variable '{name}' has not been defined")
 
+    def _compile(self):
+        return {k: v._qm_node for k, v in self.variables.items()}
+
 
 def create_dataset():
     """
@@ -176,10 +179,6 @@ def create_dataset():
     ```
     """
     return Dataset()
-
-
-def compile(dataset):  # noqa A003
-    return {k: v._qm_node for k, v in dataset.variables.items()}
 
 
 # BASIC SERIES TYPES

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,6 @@ from ehrql.query_engines.in_memory import InMemoryQueryEngine
 from ehrql.query_engines.mssql import MSSQLQueryEngine
 from ehrql.query_engines.sqlite import SQLiteQueryEngine
 from ehrql.query_engines.trino import TrinoQueryEngine
-from ehrql.query_language import compile
 from tests.lib.orm_utils import make_orm_models
 
 from .lib.databases import (
@@ -196,7 +195,7 @@ class QueryEngineFixture:
         return self.query_engine_class(dsn, **engine_kwargs)
 
     def extract(self, dataset, **engine_kwargs):
-        variable_definitions = compile(dataset)
+        variable_definitions = dataset._compile()
         return self.extract_qm(variable_definitions, **engine_kwargs)
 
     def extract_qm(self, variable_definitions, **engine_kwargs):
@@ -207,7 +206,7 @@ class QueryEngineFixture:
         return [row._asdict() for row in sorted(results)]
 
     def dump_dataset_sql(self, dataset, **engine_kwargs):
-        variable_definitions = compile(dataset)
+        variable_definitions = dataset._compile()
         query_engine = self.query_engine(dsn=None, **engine_kwargs)
         return get_sql_strings(query_engine, variable_definitions)
 

--- a/tests/integration/backends/test_emis.py
+++ b/tests/integration/backends/test_emis.py
@@ -7,7 +7,6 @@ from trino import exceptions as trino_exceptions
 from ehrql import create_dataset
 from ehrql.backends.emis import EMISBackend
 from ehrql.query_engines.base_sql import get_setup_and_cleanup_queries
-from ehrql.query_language import compile
 from ehrql.tables import PatientFrame, Series, emis, table_from_rows
 from ehrql.tables.raw import emis as emis_raw
 from ehrql.utils.sqlalchemy_query_utils import CreateTableAs, GeneratedTable
@@ -606,7 +605,7 @@ def test_inline_table_includes_organisation_hash(trino_database):
         backend=backend,
     )
 
-    variables = compile(dataset)
+    variables = dataset._compile()
 
     results_query = query_engine.get_query(variables)
     inline_tables = [
@@ -662,7 +661,7 @@ def test_temp_table_includes_organisation_hash(trino_database):
         backend=backend,
     )
 
-    variables = compile(dataset)
+    variables = dataset._compile()
     results_query = query_engine.get_query(variables)
     temp_tables = [
         ch

--- a/tests/integration/backends/test_tpp.py
+++ b/tests/integration/backends/test_tpp.py
@@ -8,7 +8,6 @@ from pymssql import exceptions as pymssql_exceptions
 from ehrql import create_dataset
 from ehrql.backends.tpp import TPPBackend
 from ehrql.query_engines.mssql_dialect import SelectStarInto
-from ehrql.query_language import compile
 from ehrql.tables import tpp
 from ehrql.tables.raw import tpp as tpp_raw
 from tests.lib.tpp_schema import (
@@ -3125,6 +3124,6 @@ def test_t1oo_patients_excluded_as_specified(mssql_database, suffix, expected):
         mssql_database.host_url() + suffix,
         backend=backend,
     )
-    results = query_engine.get_results(compile(dataset))
+    results = query_engine.get_results(dataset._compile())
 
     assert list(results) == expected

--- a/tests/integration/query_engines/test_local_file.py
+++ b/tests/integration/query_engines/test_local_file.py
@@ -2,7 +2,6 @@ from pathlib import Path
 
 from ehrql import Dataset
 from ehrql.query_engines.local_file import LocalFileQueryEngine
-from ehrql.query_language import compile
 from ehrql.tables import EventFrame, PatientFrame, Series, table
 
 
@@ -31,7 +30,7 @@ def test_local_file_query_engine():
     ).count_for_patient()
 
     dataset.define_population(patients.exists_for_patient())
-    variable_definitions = compile(dataset)
+    variable_definitions = dataset._compile()
 
     query_engine = LocalFileQueryEngine(FIXTURES)
     results = query_engine.get_results(variable_definitions)

--- a/tests/unit/dummy_data/test_generator.py
+++ b/tests/unit/dummy_data/test_generator.py
@@ -7,7 +7,7 @@ import pytest
 from ehrql import Dataset
 from ehrql.dummy_data.generator import DummyDataGenerator, DummyPatientGenerator
 from ehrql.dummy_data.query_info import ColumnInfo, TableInfo
-from ehrql.query_language import compile, table_from_rows
+from ehrql.query_language import table_from_rows
 from ehrql.tables import Constraint, EventFrame, PatientFrame, Series, table
 
 
@@ -70,7 +70,7 @@ def test_dummy_data_generator():
     dataset.date = last_event.date
 
     # Generate some results
-    variable_definitions = compile(dataset)
+    variable_definitions = dataset._compile()
     generator = DummyDataGenerator(variable_definitions)
     generator.population_size = 7
     generator.batch_size = 4
@@ -97,7 +97,7 @@ def test_dummy_data_generator_timeout_with_some_results(patched_time):
     dataset = Dataset()
     dataset.define_population(patients.exists_for_patient())
 
-    variable_definitions = compile(dataset)
+    variable_definitions = dataset._compile()
     generator = DummyDataGenerator(variable_definitions)
     generator.population_size = 100
     generator.batch_size = 3
@@ -120,7 +120,7 @@ def test_dummy_data_generator_timeout_with_no_results(patched_time):
     dataset = Dataset()
     dataset.define_population(patients.sex != patients.sex)
 
-    variable_definitions = compile(dataset)
+    variable_definitions = dataset._compile()
     generator = DummyDataGenerator(variable_definitions)
     generator.timeout = 10
 
@@ -180,7 +180,7 @@ def test_dummy_data_generator_with_inline_patient_table(
         )
 
     # Generate some results
-    variable_definitions = compile(dataset)
+    variable_definitions = dataset._compile()
     generator = DummyDataGenerator(variable_definitions)
     # We're asking for more results than we can possibly get (because there are only 6
     # patients in the inline table). We expect the attempt to timeout and just return 6
@@ -277,7 +277,7 @@ def test_get_random_int_with_range(dummy_patient_generator):
 def dummy_patient_generator():
     dataset = Dataset()
     dataset.define_population(patients.exists_for_patient())
-    variable_definitions = compile(dataset)
+    variable_definitions = dataset._compile()
     generator = DummyPatientGenerator(
         variable_definitions,
         random_seed="abc",

--- a/tests/unit/dummy_data/test_query_info.py
+++ b/tests/unit/dummy_data/test_query_info.py
@@ -3,7 +3,6 @@ import datetime
 from ehrql import Dataset, days
 from ehrql.codes import CTV3Code
 from ehrql.dummy_data.query_info import ColumnInfo, QueryInfo, TableInfo
-from ehrql.query_language import compile
 from ehrql.tables import (
     Constraint,
     EventFrame,
@@ -42,7 +41,7 @@ def test_query_info_from_variable_definitions():
         events.code == CTV3Code("abc00")
     ).exists_for_patient()
 
-    variable_definitions = compile(dataset)
+    variable_definitions = dataset._compile()
     query_info = QueryInfo.from_variable_definitions(variable_definitions)
 
     assert query_info == QueryInfo(
@@ -99,7 +98,7 @@ def test_query_info_records_values():
         | test_table.value.contains("d")
     )
 
-    variable_definitions = compile(dataset)
+    variable_definitions = dataset._compile()
     query_info = QueryInfo.from_variable_definitions(variable_definitions)
     column_info = query_info.tables["test_table"].columns["value"]
 
@@ -127,7 +126,7 @@ def test_query_info_ignores_inline_patient_tables():
         | inline_table.value.contains("d")
     )
 
-    variable_definitions = compile(dataset)
+    variable_definitions = dataset._compile()
     query_info = QueryInfo.from_variable_definitions(variable_definitions)
 
     assert query_info == QueryInfo(
@@ -150,7 +149,7 @@ def test_query_info_ignores_complex_comparisons():
     dataset.q1 = patients.date_of_birth.year.is_in([2000, 2010, 2020])
     dataset.q2 = patients.date_of_birth + days(100) == "2021-10-20"
     dataset.q3 = patients.date_of_birth == "2022-10-05"
-    variable_definitions = compile(dataset)
+    variable_definitions = dataset._compile()
 
     query_info = QueryInfo.from_variable_definitions(variable_definitions)
     column_info = query_info.tables["patients"].columns["date_of_birth"]

--- a/tests/unit/dummy_data_nextgen/test_generator.py
+++ b/tests/unit/dummy_data_nextgen/test_generator.py
@@ -7,7 +7,7 @@ import pytest
 from ehrql import Dataset
 from ehrql.dummy_data_nextgen.generator import DummyDataGenerator, DummyPatientGenerator
 from ehrql.dummy_data_nextgen.query_info import ColumnInfo, TableInfo
-from ehrql.query_language import compile, table_from_rows
+from ehrql.query_language import table_from_rows
 from ehrql.tables import Constraint, EventFrame, PatientFrame, Series, table
 
 
@@ -76,7 +76,7 @@ def test_dummy_data_generator():
     # Generate some results
     target_size = 7
 
-    variable_definitions = compile(dataset)
+    variable_definitions = dataset._compile()
     generator = DummyDataGenerator(variable_definitions, population_size=target_size)
     generator.batch_size = 4
     results = list(generator.get_results())
@@ -106,7 +106,7 @@ def test_dummy_data_generator_timeout_with_some_results(patched_time):
     dataset = Dataset()
     dataset.define_population(patients.exists_for_patient())
 
-    variable_definitions = compile(dataset)
+    variable_definitions = dataset._compile()
     generator = DummyDataGenerator(variable_definitions)
     generator.population_size = 100
     generator.batch_size = 3
@@ -132,7 +132,7 @@ def test_dummy_data_generator_timeout_with_no_results(patched_time):
         & (patients.date_of_death.day == 2)
     )
 
-    variable_definitions = compile(dataset)
+    variable_definitions = dataset._compile()
     generator = DummyDataGenerator(variable_definitions)
     generator.timeout = 10
 
@@ -192,7 +192,7 @@ def test_dummy_data_generator_with_inline_patient_table(
         )
 
     # Generate some results
-    variable_definitions = compile(dataset)
+    variable_definitions = dataset._compile()
     generator = DummyDataGenerator(variable_definitions)
     # We're asking for more results than we can possibly get (because there are only 6
     # patients in the inline table). We expect the attempt to timeout and just return 6
@@ -336,7 +336,7 @@ def test_cannot_generate_data_outside_of_a_seed_block(dummy_patient_generator):
 def dummy_patient_generator():
     dataset = Dataset()
     dataset.define_population(patients.exists_for_patient())
-    variable_definitions = compile(dataset)
+    variable_definitions = dataset._compile()
     generator = DummyPatientGenerator(
         variable_definitions,
         random_seed="abc",

--- a/tests/unit/dummy_data_nextgen/test_query_info.py
+++ b/tests/unit/dummy_data_nextgen/test_query_info.py
@@ -3,7 +3,6 @@ import datetime
 from ehrql import Dataset, days
 from ehrql.codes import CTV3Code
 from ehrql.dummy_data_nextgen.query_info import ColumnInfo, QueryInfo, TableInfo
-from ehrql.query_language import compile
 from ehrql.tables import (
     Constraint,
     EventFrame,
@@ -42,7 +41,7 @@ def test_query_info_from_variable_definitions():
         events.code == CTV3Code("abc00")
     ).exists_for_patient()
 
-    variable_definitions = compile(dataset)
+    variable_definitions = dataset._compile()
     query_info = QueryInfo.from_variable_definitions(variable_definitions)
 
     assert query_info == QueryInfo(
@@ -99,7 +98,7 @@ def test_query_info_records_values():
         | test_table.value.contains("d")
     )
 
-    variable_definitions = compile(dataset)
+    variable_definitions = dataset._compile()
     query_info = QueryInfo.from_variable_definitions(variable_definitions)
     column_info = query_info.tables["test_table"].columns["value"]
 
@@ -123,7 +122,7 @@ def test_query_info_ignores_inline_patient_tables():
         | inline_table.value.contains("d")
     )
 
-    variable_definitions = compile(dataset)
+    variable_definitions = dataset._compile()
     query_info = QueryInfo.from_variable_definitions(variable_definitions)
 
     assert query_info == QueryInfo(
@@ -146,7 +145,7 @@ def test_query_info_ignores_complex_comparisons():
     dataset.q1 = patients.date_of_birth.year.is_in([2000, 2010, 2020])
     dataset.q2 = patients.date_of_birth + days(100) == "2021-10-20"
     dataset.q3 = patients.date_of_birth == "2022-10-05"
-    variable_definitions = compile(dataset)
+    variable_definitions = dataset._compile()
 
     query_info = QueryInfo.from_variable_definitions(variable_definitions)
     column_info = query_info.tables["patients"].columns["date_of_birth"]

--- a/tests/unit/dummy_data_nextgen/test_specific_datasets.py
+++ b/tests/unit/dummy_data_nextgen/test_specific_datasets.py
@@ -15,7 +15,6 @@ from ehrql.query_language import (
     EventFrame,
     PatientFrame,
     Series,
-    compile,
     table,
     table_from_rows,
 )
@@ -73,7 +72,7 @@ def test_queries_with_exact_one_shot_generation(patched_time, query):
 
     target_size = 1000
 
-    variable_definitions = compile(dataset)
+    variable_definitions = dataset._compile()
     generator = DummyDataGenerator(variable_definitions, population_size=target_size)
     generator.batch_size = target_size
     generator.timeout = 10
@@ -105,7 +104,7 @@ def test_queries_with_exact_two_shot_generation(patched_time, query):
 
     target_size = 1000
 
-    variable_definitions = compile(dataset)
+    variable_definitions = dataset._compile()
     generator = DummyDataGenerator(variable_definitions, population_size=target_size)
     generator.batch_size = target_size
     generator.timeout = 10
@@ -174,7 +173,7 @@ def test_combined_age_range_in_one_shot(patched_time, query, target_size):
 
     dataset.define_population(query)
 
-    variable_definitions = compile(dataset)
+    variable_definitions = dataset._compile()
     generator = DummyDataGenerator(variable_definitions, population_size=target_size)
     generator.batch_size = target_size
     generator.timeout = 10
@@ -257,7 +256,7 @@ def test_queries_not_yet_well_handled(patched_time, query):
     dataset.define_population(patients.exists_for_patient() & query)
 
     target_size = 1000
-    variable_definitions = compile(dataset)
+    variable_definitions = dataset._compile()
 
     generator = DummyDataGenerator(variable_definitions, population_size=target_size)
     generator.batch_size = target_size
@@ -287,7 +286,7 @@ def test_inline_table_query(patched_time):
     dataset.i = p.i
 
     target_size = 1000
-    variable_definitions = compile(dataset)
+    variable_definitions = dataset._compile()
 
     generator = DummyDataGenerator(variable_definitions, population_size=target_size)
     generator.batch_size = target_size
@@ -320,7 +319,7 @@ def test_will_raise_if_all_data_is_impossible(patched_time, query):
 
     dataset.define_population(query)
     target_size = 1000
-    variable_definitions = compile(dataset)
+    variable_definitions = dataset._compile()
 
     generator = DummyDataGenerator(variable_definitions, population_size=target_size)
     generator.timeout = 1
@@ -345,7 +344,7 @@ def test_generates_events_starting_from_birthdate():
 
     target_size = 1000
     dataset.configure_dummy_data(population_size=target_size)
-    variable_definitions = compile(dataset)
+    variable_definitions = dataset._compile()
 
     generator = DummyDataGenerator(variable_definitions, population_size=target_size)
 
@@ -366,7 +365,7 @@ def test_distribution_of_booleans():
 
     target_size = 1000
 
-    variable_definitions = compile(dataset)
+    variable_definitions = dataset._compile()
     generator = DummyDataGenerator(variable_definitions, population_size=target_size)
     generator.batch_size = target_size
 
@@ -399,7 +398,7 @@ def test_can_generate_patients_with_one_but_not_both_conditions():
 
     target_size = 1000
     dataset.configure_dummy_data(population_size=target_size)
-    variable_definitions = compile(dataset)
+    variable_definitions = dataset._compile()
 
     generator = DummyDataGenerator(variable_definitions, population_size=target_size)
 

--- a/tests/unit/query_model/test_graphs.py
+++ b/tests/unit/query_model/test_graphs.py
@@ -1,5 +1,4 @@
 from ehrql import Dataset
-from ehrql.query_language import compile
 from ehrql.query_model.graphs import build_graph
 from ehrql.tables.tpp import patients
 
@@ -11,4 +10,4 @@ def test_build_graph():
     dataset.year = year
 
     # We just want to check that nothing blows up
-    build_graph(compile(dataset))
+    build_graph(dataset._compile())

--- a/tests/unit/test_assurance.py
+++ b/tests/unit/test_assurance.py
@@ -10,7 +10,6 @@ from ehrql.assurance import (
     validate,
 )
 from ehrql.codes import SNOMEDCTCode
-from ehrql.query_language import compile
 from ehrql.tables import Constraint, EventFrame, PatientFrame, Series, table
 
 
@@ -181,7 +180,7 @@ expected_valid_and_invalid_data_validation_results = {
 
 def test_valid_data_validate():
     assert (
-        validate(compile(dataset), valid_test_data)
+        validate(dataset._compile(), valid_test_data)
         == expected_valid_data_validation_results
     )
 
@@ -202,7 +201,7 @@ Validate results: Found errors with 3 patient(s)
 
 def test_invalid_data_validate():
     assert (
-        validate(compile(dataset), invalid_test_data)
+        validate(dataset._compile(), invalid_test_data)
         == expected_invalid_data_validation_results
     )
 
@@ -224,7 +223,7 @@ Validate results: All OK!
 
 def test_valid_and_invalid_data_validate():
     assert (
-        validate(compile(dataset), valid_and_invalid_test_data)
+        validate(dataset._compile(), valid_and_invalid_test_data)
         == expected_valid_and_invalid_data_validation_results
     )
 

--- a/tests/unit/test_query_language.py
+++ b/tests/unit/test_query_language.py
@@ -29,7 +29,6 @@ from ehrql.query_language import (
     StrEventSeries,
     StrPatientSeries,
     case,
-    compile,
     create_dataset,
     days,
     modify_exception,
@@ -102,7 +101,7 @@ def test_dataset():
     assert dataset.year_of_birth is year_of_birth
     assert dataset.dummy_data_config.population_size == 123
 
-    assert compile(dataset) == {
+    assert dataset._compile() == {
         "year_of_birth": Function.YearFromDate(
             source=SelectColumn(
                 name="date_of_birth",
@@ -155,7 +154,7 @@ def test_dataset_preserves_variable_order():
     dataset.baz = patients.date_of_birth.year + 100
     dataset.bar = patients.date_of_birth.year - 100
 
-    variables = list(compile(dataset).keys())
+    variables = list(dataset._compile().keys())
     assert variables == ["population", "foo", "baz", "bar"]
 
 
@@ -170,7 +169,7 @@ def test_dataset_accepts_valid_variable_names(name):
 def test_add_column():
     dataset = Dataset()
     dataset.add_column("foo", patients.i)
-    variables = list(compile(dataset).keys())
+    variables = list(dataset._compile().keys())
     assert variables == ["foo"]
 
 


### PR DESCRIPTION
The proximate cause for doing this is that newer versions of `ruff check` are stricter about shadowing the `compile()` builtin and we would need to add an exception everywhere we import it, not just where we define it.

However, I've wanted to change this for a while as:
 * shadowing the `compile` builtin is a bit ick;
 * having `Dataset` know how to compile itself seems nicer than having to import a dedicated function for the purpose.

This does mean that we have a method which is private from the _user_ point of view (and so starts with an underscore) but public from the codebase point of view. Possibly this is the reason it was a function in the first place. But I think we can live with this minor awkwardness.