### PR TITLE
Protect standard out when loading ehrql dataset

### DIFF
--- a/ehrql/loaders.py
+++ b/ehrql/loaders.py
@@ -337,6 +337,11 @@ def load_module(module_path, user_args=()):
     # generally looks as it would had you run: `python script.py some args --here`
     original_sys_argv = sys.argv.copy()
     sys.argv = [str(module_path), *user_args]
+    # Force any user generated output (prints etc) to stderr so it doe not get
+    # mixed up with anything we might want to output ourselves
+    original_sys_stdout = sys.stdout
+    sys.stdout = sys.stderr
+
     try:
         spec.loader.exec_module(module)
         return module
@@ -348,3 +353,4 @@ def load_module(module_path, user_args=()):
     finally:
         sys.path = original_sys_path
         sys.argv = original_sys_argv
+        sys.stdout = original_sys_stdout

--- a/tests/fixtures/good_definition_files/dataset_definition_with_print.py
+++ b/tests/fixtures/good_definition_files/dataset_definition_with_print.py
@@ -1,0 +1,10 @@
+# noqa: INP001
+from ehrql import create_dataset
+from ehrql.tables.core import patients
+
+
+dataset = create_dataset()
+dataset.year_of_birth = patients.date_of_birth.year
+dataset.sex = patients.sex
+dataset.define_population(patients.date_of_birth.is_on_or_after("2000-01-01"))
+print("user stdout")

--- a/tests/unit/test_loaders.py
+++ b/tests/unit/test_loaders.py
@@ -80,6 +80,16 @@ def test_load_dataset_definition(funcs, capsys):
     assert capsys.readouterr().err == ""
 
 
+def test_load_dataset_definition_with_print(funcs, capsys):
+    filename = FIXTURES_GOOD / "dataset_definition_with_print.py"
+    variables, dummy_data_config = funcs.load_dataset_definition(filename)
+    assert isinstance(variables, dict)
+    assert isinstance(dummy_data_config, DummyDataConfig)
+    out, err = capsys.readouterr()
+    assert "user stdout" not in out
+    assert "user stdout" in err
+
+
 def test_load_measure_definitions(funcs, capsys):
     filename = FIXTURES_GOOD / "measure_definitions.py"
     (


### PR DESCRIPTION
Users may reasonably use print() statment in their dataset. Currently,
because we use stdout to output the serialization from the isolated
subprocess, this will break that process.

So, we force any use of sys.stdout within the dataset definition to use
stderr instead, to avoid that happening.

Lots of detailed discussion on this in this slack thread

https://bennettoxford.slack.com/archives/C069YDR4NCA/p1733228945599029
