### PR TITLE
Allow providing additional constraints in your dummy data definition

### DIFF
--- a/docs/includes/generated_docs/language__dataset.md
+++ b/docs/includes/generated_docs/language__dataset.md
@@ -61,7 +61,7 @@ over a dictionary. For more details see the guide on
 </div>
 
 <div class="attr-heading" id="Dataset.configure_dummy_data">
-  <tt><strong>configure_dummy_data</strong>(<em>population_size=10</em>, <em>legacy=False</em>, <em>timeout=60</em>)</tt>
+  <tt><strong>configure_dummy_data</strong>(<em>population_size=10</em>, <em>legacy=False</em>, <em>timeout=60</em>, <em>additional_population_constraint=None</em>)</tt>
   <a class="headerlink" href="#Dataset.configure_dummy_data" title="Permanent link">🔗</a>
 </div>
 <div markdown="block" class="indent">
@@ -78,6 +78,19 @@ Use legacy dummy data.
 
 _timeout_<br>
 Maximum time in seconds to spend generating dummy data.
+
+_additional_population_constraint_<br>
+An additional ehrQL query that can be used to constrain the population that will
+be selected for dummy data. This is incompatible with legacy mode.
+
+For example, if you wanted to ensure that two dates appear in a particular order in your
+dummy data, you could add ``additional_population_constraint = dataset.first_date <
+dataset.second_date``.
+
+You can also combine constraints with ``&`` as normal in ehrQL.
+e.g. ``additional_population_constraint = patients.sex.is_in(['male', 'female']) & (
+patients.age_on(some_date) < 80)`` would give you dummy data consisting of only men
+and women who were under the age of 80 on some particular date.
 
 ```py
 dataset.configure_dummy_data(population_size=10000)

--- a/ehrql/dummy_data_nextgen/measures.py
+++ b/ehrql/dummy_data_nextgen/measures.py
@@ -1,4 +1,5 @@
 import dataclasses
+from dataclasses import replace
 from functools import reduce
 
 from ehrql.dummy_data_nextgen import DummyDataGenerator
@@ -19,8 +20,10 @@ class DummyMeasuresDataGenerator:
         combined = CombinedMeasureComponents.from_measures(measures)
         self.generator = DummyDataGenerator(
             get_dataset_variables(combined),
-            population_size=get_population_size(dummy_data_config, combined),
-            timeout=dummy_data_config.timeout,
+            configuration=replace(
+                dummy_data_config,
+                population_size=get_population_size(dummy_data_config, combined),
+            ),
             **kwargs,
         )
 

--- a/ehrql/query_language.py
+++ b/ehrql/query_language.py
@@ -47,6 +47,7 @@ class DummyDataConfig:
     population_size: int = 10
     legacy: bool = False
     timeout: int = 60
+    additional_population_constraint: "BoolPatientSeries | None" = None
 
 
 class Dataset:
@@ -110,6 +111,7 @@ class Dataset:
         population_size=DummyDataConfig.population_size,
         legacy=DummyDataConfig.legacy,
         timeout=DummyDataConfig.timeout,
+        additional_population_constraint=None,
     ):
         """
         Configure the dummy data to be generated.
@@ -126,6 +128,19 @@ class Dataset:
         _timeout_<br>
         Maximum time in seconds to spend generating dummy data.
 
+        _additional_population_constraint_<br>
+        An additional ehrQL query that can be used to constrain the population that will
+        be selected for dummy data. This is incompatible with legacy mode.
+
+        For example, if you wanted to ensure that two dates appear in a particular order in your
+        dummy data, you could add ``additional_population_constraint = dataset.first_date <
+        dataset.second_date``.
+
+        You can also combine constraints with ``&`` as normal in ehrQL.
+        e.g. ``additional_population_constraint = patients.sex.is_in(['male', 'female']) & (
+        patients.age_on(some_date) < 80)`` would give you dummy data consisting of only men
+        and women who were under the age of 80 on some particular date.
+
         ```py
         dataset.configure_dummy_data(population_size=10000)
         ```
@@ -133,6 +148,13 @@ class Dataset:
         self.dummy_data_config.population_size = population_size
         self.dummy_data_config.legacy = legacy
         self.dummy_data_config.timeout = timeout
+        self.dummy_data_config.additional_population_constraint = (
+            additional_population_constraint
+        )
+        if legacy and additional_population_constraint is not None:
+            raise ValueError(
+                "Cannot provide an additional population constraint in legacy mode."
+            )
 
     def __setattr__(self, name, value):
         if name == "population":


### PR DESCRIPTION
This is more or less the simplest possible API improvement I could think of that will allow for users cleaning up a lot of oddities in the dummy data provided. Whenever something that should be impossible occurs in your dummy data but you don't want to make it part of the main population definition, this lets you add it to the population definition for the dummy data only. So e.g. if you have a `diagnosis_date` and `treatment_date` field, you could add the constraint `dataset.diagnosis_date < dataset.treatment_date` to the dummy data without having to overly restrict your population of interest in the real dataset.