### PR TITLE
Added a `.hint()` method to allow hints in the quiz

### DIFF
--- a/ehrql/quiz.py
+++ b/ehrql/quiz.py
@@ -1,3 +1,4 @@
+import inspect
 import sys
 from pathlib import Path
 from typing import Any
@@ -307,7 +308,7 @@ class Question:
         self.engine = engine
         self.attempted = False
         self.correct = False
-        self._hint = "Unfortunately we don't have a hint for this question."
+        self._hint = ""
 
     def check(self, answer: Any = ...) -> str:
         if answer is not ...:
@@ -321,8 +322,19 @@ class Question:
         print(message, file=sys.stderr)
 
     def hint(self):
-        message = f"Hint for question {self.index}\n{self._hint}\n"
-        print(message, file=sys.stderr)
+        message_lines = [f"Hint for question {self.index}:"]
+
+        if len(self._hint) > 0:
+            message_lines.append(self._hint)
+
+        message_lines.append(
+            inspect.cleandoc("""
+            Remember that you can use show() to take a look at your
+            output. So instead of calling questions[].check(..your answer..), you
+            can call show(..your answer..) to see if you're on the right track
+        """)
+        )
+        print("\n\n".join(message_lines), file=sys.stderr)
 
     @staticmethod
     def get_engine() -> SandboxQueryEngine:

--- a/ehrql/quiz.py
+++ b/ehrql/quiz.py
@@ -1,4 +1,3 @@
-import inspect
 import sys
 from pathlib import Path
 from typing import Any
@@ -328,11 +327,12 @@ class Question:
             message_lines.append(self._hint)
 
         message_lines.append(
-            inspect.cleandoc("""
-            Remember that you can use show() to take a look at your
-            output. So instead of calling questions[].check(..your answer..), you
-            can call show(..your answer..) to see if you're on the right track
-        """)
+            "Remember that you can use show() to take a look at your "
+            "output. So instead of calling\n\n"
+            f"questions[{self.index}].check(..your answer..)\n\n"
+            "you can call\n\n"
+            "show(..your answer..)\n\n"
+            "to see if you're on the right track.\n"
         )
         print("\n\n".join(message_lines), file=sys.stderr)
 

--- a/ehrql/quiz.py
+++ b/ehrql/quiz.py
@@ -307,6 +307,7 @@ class Question:
         self.engine = engine
         self.attempted = False
         self.correct = False
+        self._hint = "Unfortunately we don't have a hint for this question."
 
     def check(self, answer: Any = ...) -> str:
         if answer is not ...:
@@ -317,6 +318,10 @@ class Question:
         else:
             message = "Skipped."
         message = f"Question {self.index}\n{message}\n"
+        print(message, file=sys.stderr)
+
+    def hint(self):
+        message = f"Hint for question {self.index}\n{self._hint}\n"
         print(message, file=sys.stderr)
 
     @staticmethod

--- a/tests/unit/test_quiz.py
+++ b/tests/unit/test_quiz.py
@@ -346,7 +346,17 @@ def test_set_dummy_tables_path_in_debug_context():
 
 def test_hint(capfd):
     hint = "This is a\nhint"
-    question = quiz.Question("Create an Empty Dataset.", 0)
+    question = quiz.Question("", 0)
     question._hint = hint
     question.hint()
     assert capfd.readouterr().err.rstrip().startswith(f"Hint for question 0:\n\n{hint}")
+
+
+def test_empty_hint(capfd):
+    question = quiz.Question("", 0)
+    question.hint()
+    # If the hint is not provided there is a default hint message that currently starts
+    # with "Remember".
+    assert (
+        capfd.readouterr().err.rstrip().startswith("Hint for question 0:\n\nRemember")
+    )

--- a/tests/unit/test_quiz.py
+++ b/tests/unit/test_quiz.py
@@ -342,3 +342,11 @@ def test_set_dummy_tables_path_in_debug_context():
         assert debugger.DEBUG_QUERY_ENGINE.dsn.name == "bar"
     # This should be unset outside of the context manager
     assert debugger.DEBUG_QUERY_ENGINE is None
+
+
+def test_hint(capfd):
+    hint = "This is a\nhint"
+    question = quiz.Question("Create an Empty Dataset.", 0)
+    question._hint = hint
+    question.hint()
+    assert capfd.readouterr().err.rstrip().startswith(f"Hint for question 0:\n\n{hint}")


### PR DESCRIPTION
I've made a default hint which reminds people about `show()`. I realise this method is currently still called `debug()` but I doubt this will affect anyone before the debug->show change is also made.