### PR TITLE
Modify references to the old tutorial in the rest of the docs

### DIFF
--- a/docs/explanation/backend-tables.md
+++ b/docs/explanation/backend-tables.md
@@ -69,22 +69,18 @@ the names of the table schemas, tables and columns
 have been provided for you.
 
 For example,
-in the [writing a dataset definition](../tutorial/writing-a-dataset-definition/index.md) section of the tutorial,
-we used the interactive ehrQL sandbox with the following statement to start with:
+in the initial [dataset definition](../tutorial/setting-up/index.md) of the tutorial,
+we had the following line:
 
 ```python
->>> from ehrql.tables.core import patients, medications
+from ehrql.tables.core import patients, practice_registrations, clinical_events, medications
 ```
 
 * `core` is the *table schema*
-* `patients` and `medications` are the *table names*
+* `patients`, `practice_registrations`, `clinical_events` and `medications` are the *table names*
 
-We also accessed *table columns*
-such as the `date_of_birth` column on the `patients` table:
-
-```python
->>> patients.date_of_birth
-```
+We also used the `show()` command to display the `patients` table and saw that the *table columns*
+available were `date_of_birth`, `sex` and `date_of_death`.
 
 Use the [table schema reference](../reference/schemas.md)
 to look up which schemas and columns are available.

--- a/docs/explanation/backend-tables.md
+++ b/docs/explanation/backend-tables.md
@@ -69,7 +69,7 @@ the names of the table schemas, tables and columns
 have been provided for you.
 
 For example,
-in the initial [dataset definition](../tutorial/setting-up/index.md) of the tutorial,
+in the initial [dataset definition](../tutorial/working-with-data-with-ehrql/index.md) of the tutorial,
 we had the following line:
 
 ```python

--- a/docs/explanation/running-ehrql.md
+++ b/docs/explanation/running-ehrql.md
@@ -331,14 +331,14 @@ actions:
     run: ehrql:v1 generate-dataset dataset_definition.py --dummy-tables example-data --output output/dataset.csv.gz
     outputs:
       highly_sensitive:
-        cohort: output/dataset.csv.gz
+        dataset: output/dataset.csv.gz
 
   summarise_dataset:
     run: python:latest summarise_dataset.py
     needs: [generate_dataset]
     outputs:
      moderately_sensitive:
-        cohort: output/summary.txt
+        dataset: output/summary.txt
 ```
 
 :notepad_spiral: Users already familiar with the [OpenSAFELY research template](https://github.com/opensafely/research-template) may notice that the research template already includes a basic `project.yaml` file that can be edited.

--- a/docs/how-to/assign-multiple-columns.md
+++ b/docs/how-to/assign-multiple-columns.md
@@ -7,7 +7,7 @@ This guide first shows you how to use `dataset.add_column` to assign one new col
 
 ## Assign one column to the dataset
 
-As mentioned in the tutorial on "[Writing a more complex dataset definition](../tutorial/writing-a-more-complex-dataset-definition/index.md#assign-variables-to-the-dataset)",
+As mentioned in the tutorial on "[Building a dataset](../tutorial/building-a-dataset/#datasets)",
 we can assign a variable to the dataset by adding a dot and the name of the variable to the dataset,
 followed by an equals sign and the definition of the variable.
 In the following example, the name of the variable is `my_variable`

--- a/docs/how-to/dummy-data.md
+++ b/docs/how-to/dummy-data.md
@@ -46,7 +46,7 @@ You can provide a dummy dataset file in the following formats.
 :warning: Your dummy dataset file must have the relevant file extension shown in the table
 above.
 
-For example, take this dataset definition from the homepage:
+For example, take this dataset definition:
 
 ```ehrql
 from ehrql import create_dataset

--- a/docs/how-to/dummy-data.md
+++ b/docs/how-to/dummy-data.md
@@ -46,7 +46,7 @@ You can provide a dummy dataset file in the following formats.
 :warning: Your dummy dataset file must have the relevant file extension shown in the table
 above.
 
-For example, take this dataset definition from the tutorial:
+For example, take this dataset definition from the homepage:
 
 ```ehrql
 from ehrql import create_dataset

--- a/docs/how-to/examples.md
+++ b/docs/how-to/examples.md
@@ -563,7 +563,7 @@ from ehrql.tables.core import clinical_events, patients
 asthma_codelist = codelist_from_csv("XXX", column="YYY")
 
 dataset = create_dataset()
-dataset.first_asthma_diagnosis_date = clinical_events.where(
+dataset.first_asthma_diagnosis_code = clinical_events.where(
         clinical_events.snomedct_code.is_in(asthma_codelist)
 ).where(
         clinical_events.date.is_on_or_after("2022-07-01")


### PR DESCRIPTION
Related to #2269 
Some of the text in the docs still refer to the old tutorial. 

This PR tries up update those, along with a couple of minor corrections found along the way.
