### PR TITLE
Update docs tests so ehrql in tutorial can be tested

### DIFF
--- a/docs/tutorial/building-a-dataset/index.md
+++ b/docs/tutorial/building-a-dataset/index.md
@@ -12,7 +12,7 @@ The diagnosis codelists ([proteinuria][1] and [micro-albuminuria][2]) are publis
 We have already seen how to determine whether a patient has a clinical event matching a code in a codelist.
 Medications are recorded in a similar way to clinical events, and can be queried using the same kinds of ehrQL.
 
-```py
+```ehrql
 from ehrql import codelist_from_csv, days, show
 from ehrql.tables.core import clinical_events, medications
 
@@ -72,7 +72,7 @@ Instead, we need to define a dataset.  As a reminder: a dataset is a new table c
 We then use `dataset = create_dataset()` to create a new dataset object, `dataset.define_population(...)` to define the population, and `dataset.column_name = ...` to define the columns:
 
 
-```py
+```ehrql
 from ehrql import create_dataset, codelist_from_csv, days, show
 from ehrql.tables.core import patients, practice_registrations, clinical_events, medications
 

--- a/docs/tutorial/more-complex-transformations/index.md
+++ b/docs/tutorial/more-complex-transformations/index.md
@@ -8,7 +8,7 @@ Again, we have some dummy data, which we can see with the `show()` function.
  Replace the code in `dataset_definition.py` with the following:
 
 
-```py
+```ehrql
 from ehrql import show
 from ehrql.tables.core import patients, practice_registrations, clinical_events, medications
 
@@ -27,7 +27,7 @@ Let's break this down.
 First, we'll create a boolean series indicating whether each registration started before the index date:
 
 
-```py
+```ehrql
 from ehrql import show
 from ehrql.tables.core import patients, practice_registrations, clinical_events, medications
 
@@ -43,7 +43,7 @@ Notice that we're showing the new boolean series alongside the `practice_registr
 
 We can then use this boolean series to filter `practice_registrations` to create a new event frame containing only the rows where the boolean series is `True`:
 
-```py
+```ehrql
 from ehrql import show
 from ehrql.tables.core import patients, practice_registrations, clinical_events, medications
 
@@ -54,7 +54,7 @@ show(practice_registrations.where(practice_registrations.start_date <= index_dat
 
 And now we can filter this event frame to create another new event frame containing only the rows where another boolean series is `False`:
 
-```py
+```ehrql
 from ehrql import show
 from ehrql.tables.core import patients, practice_registrations, clinical_events, medications
 
@@ -73,7 +73,7 @@ See [this StackOverflow question][2] for more about how Python parses long lines
 
 Finally we want to ask whether a row in this new event frame exists for each patient:
 
-```py
+```ehrql
 from ehrql import show
 from ehrql.tables.core import patients, practice_registrations, clinical_events, medications
 
@@ -91,7 +91,7 @@ Here, we have transformed an event frame into a patient series.
 
 We can give this new patient series a name, and we can combine it with other series:
 
-```py
+```ehrql
 from ehrql import show
 from ehrql.tables.core import patients, practice_registrations, clinical_events, medications
 
@@ -140,7 +140,7 @@ The codelist has already been downloaded into the tutorial Codespace, and is in 
 
 We can load the codelist from the CSV file, and use it to find just the events with a code in the codelist:
 
-```py
+```ehrql
 from ehrql import codelist_from_csv, show
 from ehrql.tables.core import patients, practice_registrations, clinical_events, medications
 
@@ -155,7 +155,7 @@ Note that for the sake of this tutorial, all diabetes diagnosis events have the 
 
 We can then ask which patients have a diabetes diagnosis code:
 
-```py
+```ehrql
 from ehrql import codelist_from_csv, show
 from ehrql.tables.core import patients, practice_registrations, clinical_events, medications
 
@@ -177,7 +177,7 @@ To find the patients with an unresolved diagnosis, we need to find the date of e
 
 We can find the latest event for each patient matching a codelists:
 
-```py
+```ehrql
 from ehrql import codelist_from_csv, show
 from ehrql.tables.core import patients, practice_registrations, clinical_events, medications
 
@@ -213,7 +213,7 @@ There are five cases we need to consider:
 A patient has an unresolved diagnosis in cases 2 and 4.
 In other words, we want the patients where `last_diagnosis_date` is not null, and where either `last_resolved_date` is null (case 2), or `last_resolved_date` is before `last_diagnosis_date` (case 4):
 
-```py
+```ehrql
 from ehrql import codelist_from_csv, show
 from ehrql.tables.core import patients, practice_registrations, clinical_events, medications
 
@@ -252,7 +252,7 @@ To recap, the register should contain all patients who, on 31st March 2024:
 
 Here's the full code:
 
-```py
+```ehrql
 from ehrql import codelist_from_csv, show
 from ehrql.tables.core import patients, practice_registrations, clinical_events, medications
 

--- a/docs/tutorial/simple-transformations/index.md
+++ b/docs/tutorial/simple-transformations/index.md
@@ -11,7 +11,7 @@ These are very common things to want to know, so ehrQL gives us some helper func
 
 Update `dataset_definition.py` so that it contains the following:
 
-```py
+```ehrql
 from ehrql import show
 from ehrql.tables.core import patients, practice_registrations, clinical_events, medications
 
@@ -29,7 +29,7 @@ Each of these columns is a patient series.
 The first series contains integers, and the second contains booleans.
 We will want to convert the first series to booleans, as we are not interested in the exact age of our patients, but whether they are at least 17 years old:
 
-```py
+```ehrql
 from ehrql import show
 from ehrql.tables.core import patients, practice_registrations, clinical_events, medications
 
@@ -44,7 +44,7 @@ show(
 We now have two boolean series, and it will be useful to give them names so that we can refer to them later:
 
 
-```py
+```ehrql
 from ehrql import show
 from ehrql.tables.core import patients, practice_registrations, clinical_events, medications
 
@@ -60,7 +60,7 @@ One thing we can do with boolean series is combine them with boolean operators.
 Here, we're asking whether each patient was both aged 17 or older and alive on the index date:
 
 
-```py
+```ehrql
 from ehrql import show
 from ehrql.tables.core import patients, practice_registrations, clinical_events, medications
 
@@ -84,7 +84,7 @@ You can see the definitions in [the ehrQL documentation][1].
 Here's code that does the same thing, without using helper functions:
 
 
-```py
+```ehrql
 from ehrql import show
 from ehrql.tables.core import patients, practice_registrations, clinical_events, medications
 

--- a/docs/tutorial/working-with-data-with-ehrql/index.md
+++ b/docs/tutorial/working-with-data-with-ehrql/index.md
@@ -19,7 +19,7 @@ Let's talk through the lines of code.
 
 These lines make some ehrQL functions and objects available for you to use:
 
-```py
+```ehrql
 from ehrql import show
 from ehrql.tables.core import patients, practice_registrations, clinical_events, medications
 ```

--- a/tests/docs/test_complete_examples.py
+++ b/tests/docs/test_complete_examples.py
@@ -13,6 +13,7 @@ import mkdocs.config
 import pytest
 
 import ehrql.main
+from ehrql.utils.string_utils import strip_indent
 
 
 def get_markdown_extension_configuration():
@@ -170,12 +171,17 @@ class EhrqlExample:
                 # Add imports and create_dataset/define_population at the beginning of the file
                 # to ensure it's available for the rest of the snippet. This results in a
                 # weird order of imports if the snippet already has imports, but it's still valid ehrql
-                self.source = (
-                    "from ehrql import create_dataset\n"
-                    "from ehrql.tables.core import patients\n"
-                    "dataset = create_dataset()\n"
-                    f"{population_definition}\n"
-                    f"{self.source}"
+                self.source = strip_indent(
+                    """
+                    from ehrql import create_dataset
+                    from ehrql.tables.core import patients
+                    dataset = create_dataset()
+                    {population_definition}
+                    {source}
+                    """
+                ).format(
+                    source=self.source,
+                    population_definition=population_definition,
                 )
                 return EhrqlExampleDefinitionType.DATASET
 

--- a/tests/docs/test_complete_examples.py
+++ b/tests/docs/test_complete_examples.py
@@ -112,8 +112,11 @@ class EhrqlExample:
     The origin of such an example may be a Markdown fence,
     or a standalone Python module.
 
-    Such examples to be tested should be complete examples,
-    not partial snippets of examples.
+    Such examples to be tested should be complete examples, with the exception of
+    the basic dataset boilerplate. If no create_dataset() call is found, we insert
+    the minumum code required to ensure the dataset is created, a valid population
+    defined and it can be evaluated. Note that this doesn't apply to measures definitions, which need to be
+    complete examples.
 
     An EhrqlExample itself is not validated as a correct ehrQL definition example at creation,
     but used as part of the tests to validate the ehrQL."""
@@ -148,11 +151,31 @@ class EhrqlExample:
                 self.source,
             )
         )
-        if len(definition_function_call_matches) != 1:
-            # Either no match,
-            # or we have both create_dataset() and create_measures().
-            # Both of these cases are invalid.
+        if len(definition_function_call_matches) > 1:
+            # we have both create_dataset() and create_measures().
             return None
+        if len(definition_function_call_matches) == 0:
+            # no create_dataset() or create_measures(); work out if it's a dataset definition
+            # file it is and add the relevant boilerplate
+            if "measure" in self.source:
+                # We're not currently handling incomplete measures examples
+                return None
+            else:
+                if "dataset.define_population" in self.source:
+                    population_definition = ""
+                else:
+                    population_definition = (
+                        "dataset.define_population(patients.exists_for_patient())"
+                    )
+                # Add imports and create_dataset/define_population at the beginning of the file
+                # to ensure it's available for the rest of the snippet. This results in a
+                # weird order of imports if the snippet already has imports, but it's still valid ehrql
+                self.source = (
+                    f"from ehrql import create_dataset\nfrom ehrql.tables.core import patients\n"
+                    f"dataset = create_dataset()\n{population_definition}\n"
+                    f"{self.source}"
+                )
+                return EhrqlExampleDefinitionType.DATASET
 
         (definition_function_call_string,) = definition_function_call_matches
         assert definition_function_call_string in definition_types

--- a/tests/docs/test_complete_examples.py
+++ b/tests/docs/test_complete_examples.py
@@ -171,8 +171,10 @@ class EhrqlExample:
                 # to ensure it's available for the rest of the snippet. This results in a
                 # weird order of imports if the snippet already has imports, but it's still valid ehrql
                 self.source = (
-                    f"from ehrql import create_dataset\nfrom ehrql.tables.core import patients\n"
-                    f"dataset = create_dataset()\n{population_definition}\n"
+                    "from ehrql import create_dataset\n"
+                    "from ehrql.tables.core import patients\n"
+                    "dataset = create_dataset()\n"
+                    f"{population_definition}\n"
                     f"{self.source}"
                 )
                 return EhrqlExampleDefinitionType.DATASET

--- a/tests/docs/test_run_generate_dataset_example.py
+++ b/tests/docs/test_run_generate_dataset_example.py
@@ -199,7 +199,7 @@ def test_run_ehrql_non_matching_example(tmp_path):
         fence_number=1,
         source=textwrap.dedent(
             """\
-            from ehrql import months
+            from ehrql import create_measures
             """
         ),
     )
@@ -208,3 +208,48 @@ def test_run_ehrql_non_matching_example(tmp_path):
     ) as exc_info:
         test_complete_examples.test_ehrql_example(tmp_path, example)
     assert type(exc_info.value) is test_complete_examples.EhrqlExampleTestError
+
+
+def test_run_ehrql_cannot_include_measures_and_dataset(tmp_path):
+    example = test_complete_examples.EhrqlExample(
+        path="test",
+        fence_number=1,
+        source=textwrap.dedent(
+            """\
+            from ehrql import create_measures, create_dataset
+            dataset = create_dataset()
+            measures = create_measures()
+            """
+        ),
+    )
+    with pytest.raises(
+        test_complete_examples.EhrqlExampleTestError,
+    ) as exc_info:
+        test_complete_examples.test_ehrql_example(tmp_path, example)
+    assert type(exc_info.value) is test_complete_examples.EhrqlExampleTestError
+
+
+def test_run_ehrql_partial_dataset_example(tmp_path):
+    example = test_complete_examples.EhrqlExample(
+        path="test",
+        fence_number=1,
+        source=textwrap.dedent(
+            """\
+            dataset.define_population(patients.exists_for_patient())
+            """
+        ),
+    )
+    test_complete_examples.test_ehrql_example(tmp_path, example)
+
+
+def test_run_ehrql_partial_dataset_example_no_population_defined(tmp_path):
+    example = test_complete_examples.EhrqlExample(
+        path="test",
+        fence_number=1,
+        source=textwrap.dedent(
+            """\
+            dataset.year = patients.date_of_birth.year
+            """
+        ),
+    )
+    test_complete_examples.test_ehrql_example(tmp_path, example)


### PR DESCRIPTION
Fixes #2245 
Adds the minimal dataset boilerplace (if it's missing) to create a dataset
and define a population so that an ehrql example can be validated. This
means that the tutorial examples, which mostly use the show() function,
don't need to include the dataset configuration and can still be tested
to ensure they're valid ehrql.

This does the minimal things to allow the tutorial ehrql to be tested without having to add extra code to the docs examples. It doesn't yet allow snippets where imports are missing (other than the `patients` table that's used for the very simplest population definition). It also doesn't do any magic boilerplating for measures definition.