### PR TITLE
Fix `additional_population_constraint` API

### DIFF
--- a/ehrql/dummy_data_nextgen/generator.py
+++ b/ehrql/dummy_data_nextgen/generator.py
@@ -99,7 +99,7 @@ class DummyDataGenerator:
         if self.configuration.additional_population_constraint is not None:
             variable_definitions["population"] = Function.And(
                 lhs=variable_definitions["population"],
-                rhs=self.configuration.additional_population_constraint._qm_node,
+                rhs=self.configuration.additional_population_constraint,
             )
         self.population_size = configuration.population_size
         self.batch_size = batch_size

--- a/ehrql/query_language.py
+++ b/ehrql/query_language.py
@@ -149,11 +149,17 @@ class Dataset:
         self.dummy_data_config.population_size = population_size
         self.dummy_data_config.legacy = legacy
         self.dummy_data_config.timeout = timeout
-        self.dummy_data_config.additional_population_constraint = (
-            additional_population_constraint._qm_node
-            if additional_population_constraint is not None
-            else None
-        )
+        if additional_population_constraint is not None:
+            validate_patient_series_type(
+                additional_population_constraint,
+                types=[bool],
+                context="additional population constraint",
+            )
+            self.dummy_data_config.additional_population_constraint = (
+                additional_population_constraint._qm_node
+            )
+        else:
+            self.dummy_data_config.additional_population_constraint = None
         if legacy and additional_population_constraint is not None:
             raise ValueError(
                 "Cannot provide an additional population constraint in legacy mode."

--- a/ehrql/query_language.py
+++ b/ehrql/query_language.py
@@ -48,7 +48,7 @@ class DummyDataConfig:
     population_size: int = 10
     legacy: bool = False
     timeout: int = 60
-    additional_population_constraint: "BoolPatientSeries | None" = None
+    additional_population_constraint: "qm.Series[bool] | None" = None
 
 
 class Dataset:
@@ -150,7 +150,9 @@ class Dataset:
         self.dummy_data_config.legacy = legacy
         self.dummy_data_config.timeout = timeout
         self.dummy_data_config.additional_population_constraint = (
-            additional_population_constraint
+            additional_population_constraint._qm_node
+            if additional_population_constraint is not None
+            else None
         )
         if legacy and additional_population_constraint is not None:
             raise ValueError(

--- a/tests/lib/fixtures.py
+++ b/tests/lib/fixtures.py
@@ -18,7 +18,10 @@ year = patients.date_of_birth.year
 dataset.define_population(year >= 1940)
 dataset.year = year
 
-dataset.configure_dummy_data(population_size=10)
+dataset.configure_dummy_data(
+    population_size=10,
+    additional_population_constraint=patients.date_of_death.is_null(),
+)
 """
 
 trivial_dataset_definition_legacy_dummy_data = """

--- a/tests/unit/dummy_data_nextgen/test_edge_cases_for_coverage.py
+++ b/tests/unit/dummy_data_nextgen/test_edge_cases_for_coverage.py
@@ -108,3 +108,11 @@ def test_errors_if_both_configuration_and_kwargs():
 
     with pytest.raises(ValueError):
         DummyDataGenerator.from_dataset(dataset, population_size=1000)
+
+
+def test_invalid_constraint_raises_error():
+    dataset = create_dataset()
+    with pytest.raises(TypeError):
+        dataset.configure_dummy_data(
+            additional_population_constraint=patients.sex,
+        )


### PR DESCRIPTION
This fixes an issue with #2278 where the dummy data config failed to pass through the serializer. As well as confirming the fix with an end-to-end test, we add an assertion which will force us to update the serializer test if we modify the signature of `configure_dummy_data`.

Slack thread:
https://bennettoxford.slack.com/archives/C069YDR4NCA/p1733837756311379