### PR TITLE
Reorganise examples page

### DIFF
--- a/docs/how-to/examples.md
+++ b/docs/how-to/examples.md
@@ -7,6 +7,10 @@ Or you can use the navigation bar at the top-right of this page,
 to see a list of the examples,
 and then jump to a specific example of interest.
 
+The examples are organised firstly by the table which they pull data from -
+for a more complete guide to the tables, refer to the
+[Table Schemas](https://docs.opensafely.org/ehrql/reference/schemas/) section of the
+ehrQL documentation.
 
 ## Understanding these examples
 

--- a/docs/how-to/examples.md
+++ b/docs/how-to/examples.md
@@ -321,6 +321,35 @@ dataset.region = registration.practice_nuts1_region_name
 dataset.define_population(patients.exists_for_patient())
 ```
 
+#### Excluding patients based on study dates
+
+The following example ensures that the dataset only includes patients registered at a
+single practice for the entire duration of the study, plus at least 3 months prior to the
+study start.
+
+```ehrql
+from ehrql import create_dataset, codelist_from_csv, months
+from ehrql.tables.tpp import patients, practice_registrations
+
+study_start_date = "2022-01-01"
+study_end_date = "2022-12-31"
+
+dataset = create_dataset()
+
+# find registrations that exist for the full study period, and at least 3 months
+# prior
+registrations = (
+    practice_registrations.where(
+        practice_registrations.start_date.is_on_or_before(study_start_date - months(3))
+    )
+    .except_where(
+        practice_registrations.end_date.is_on_or_before(study_end_date)
+    )
+)
+
+dataset.define_population(registrations.exists_for_patient())
+```
+
 ## Clinical Events
 
 ### Finding patient demographics
@@ -877,42 +906,3 @@ dataset.prescription_date = case(
 dataset.define_population(patients.exists_for_patient())
 ```
 
-#### Excluding patients based on study dates
-
-The following example ensures that the dataset only includes patients registered at a
-single practice for the entire duration of the study, plus at least 3 months prior to the
-study start.
-
-```ehrql
-from ehrql import create_dataset, codelist_from_csv, months
-from ehrql.tables.tpp import medications, patients, practice_registrations
-
-study_start_date = "2022-01-01"
-study_end_date = "2022-12-31"
-
-medication_codelist = codelist_from_csv("XXX", column="YYY")
-
-dataset = create_dataset()
-
-# First relevant prescription per patient
-first_prescription = (
-    medications.where(medications.dmd_code.is_in(medication_codelist))
-    .sort_by(medications.date)
-    .first_for_patient()
-)
-
-dataset.prescription_date = first_prescription.date
-
-# find registrations that exist for the full study period, and at least 3 months
-# prior
-registrations = (
-    practice_registrations.where(
-        practice_registrations.start_date.is_on_or_before(study_start_date - months(3))
-    )
-    .except_where(
-        practice_registrations.end_date.is_on_or_before(study_end_date)
-    )
-)
-
-dataset.define_population(registrations.exists_for_patient())
-```

--- a/docs/how-to/examples.md
+++ b/docs/how-to/examples.md
@@ -56,9 +56,35 @@ If you include an argument for `category_column`, the codelist returned will be 
 
 You can see an example of [how to access these categories within your dataset definition ](#finding-each-patients-ethnicity) below.
 
-## Finding patient demographics
+## Patients
 
-### Finding each patient's age
+### Finding patient demographics
+
+#### Finding each patient's sex
+
+```ehrql
+from ehrql import create_dataset
+from ehrql.tables.core import patients
+
+dataset = create_dataset()
+dataset.sex = patients.sex
+dataset.define_population(patients.exists_for_patient())
+```
+
+The possible values are "female", "male", "intersex", and "unknown".
+
+#### Finding each patient's date of birth
+
+```ehrql
+from ehrql import create_dataset
+from ehrql.tables.core import patients
+
+dataset = create_dataset()
+dataset.date_of_birth = patients.date_of_birth
+dataset.define_population(patients.exists_for_patient())
+```
+
+#### Finding each patient's age
 
 ```ehrql
 from ehrql import create_dataset
@@ -93,7 +119,7 @@ dataset.age = patients.age_on(index_date)
 dataset.define_population(patients.exists_for_patient())
 ```
 
-### Assigning each patient an age band
+#### Assigning each patient an age band
 
 ```ehrql
 from ehrql import create_dataset, case, when
@@ -112,18 +138,7 @@ dataset.age_band = case(
 dataset.define_population(patients.exists_for_patient())
 ```
 
-### Finding each patient's date of birth
-
-```ehrql
-from ehrql import create_dataset
-from ehrql.tables.core import patients
-
-dataset = create_dataset()
-dataset.date_of_birth = patients.date_of_birth
-dataset.define_population(patients.exists_for_patient())
-```
-
-### Finding each patient's date of death in their primary care record
+#### Finding each patient's date of death in their primary care record
 
 ```ehrql
 from ehrql import create_dataset
@@ -136,8 +151,11 @@ dataset.define_population(patients.exists_for_patient())
 
 :notepad_spiral: This value comes from the patient's EHR record. You can find more information about the accuracy of this value in the [reference schema](../reference/schemas/core.md#recording-of-death-in-primary-care).
 
+## ONS Deaths
 
-### Finding each patient's date, underlying_cause_of_death, and first noted additional medical condition noted on the death certificate from ONS records
+### Finding patient demographics
+
+#### Finding each patient's date, underlying_cause_of_death, and first noted additional medical condition noted on the death certificate from ONS records
 
 ```ehrql
 from ehrql import create_dataset
@@ -153,7 +171,7 @@ dataset.define_population(patients.exists_for_patient())
 :notepad_spiral: There are currently [multiple](https://github.com/opensafely-core/ehrql/blob/d29ff8ab2cebf3522258c408f8225b7a76f7b6f2/ehrql/tables/beta/core.py#L78-L92) cause of death fields. We aim to resolve these to a single feature in the future.
 
 
-### Finding patients with a particular cause of death
+#### Finding patients with a particular cause of death
 
 The `ons_deaths` table has multiple "cause of death" fields. Using the
 [`cause_of_death_is_in()`](../reference/schemas/core.md#ons_deaths.cause_of_death_is_in)
@@ -171,21 +189,143 @@ dataset.died_with_X = ons_deaths.cause_of_death_is_in(cause_of_death_X_codelist)
 dataset.define_population(patients.exists_for_patient())
 ```
 
+## Addresses
 
-### Finding each patient's sex
+### Finding attributes related to each patient's address as of a given date
+
+#### Finding each patient's IMD rank
 
 ```ehrql
 from ehrql import create_dataset
-from ehrql.tables.core import patients
+from ehrql.tables.tpp import addresses, patients
 
 dataset = create_dataset()
-dataset.sex = patients.sex
+dataset.imd = addresses.for_patient_on("2023-01-01").imd_rounded
 dataset.define_population(patients.exists_for_patient())
 ```
 
-The possible values are "female", "male", "intersex", and "unknown".
+The original IMD ranking is rounded to the nearest 100.
+The rounded IMD ranking ranges from 0 to 32,800.
 
-### Finding each patient's ethnicity
+See [this code comment](https://github.com/opensafely-core/ehrql/blob/d29ff8ab2cebf3522258c408f8225b7a76f7b6f2/ehrql/tables/beta/tpp.py#L117-L123) about how we choose one address if a patient has multiple registered addresses on the given date.
+
+#### Calculating each patient's IMD quintile and/or decile
+
+```ehrql
+from ehrql import create_dataset
+from ehrql.tables.tpp import addresses, patients
+
+dataset = create_dataset()
+
+patient_address = addresses.for_patient_on("2023-01-01")
+dataset.imd_quintile = patient_address.imd_quintile
+dataset.imd_decile = patient_address.imd_decile
+dataset.define_population(patients.exists_for_patient())
+```
+
+#### Finding each patient's rural/urban classification
+
+```ehrql
+from ehrql import create_dataset
+from ehrql.tables.tpp import addresses, patients
+
+dataset = create_dataset()
+dataset.rural_urban = addresses.for_patient_on("2023-01-01").rural_urban_classification
+dataset.define_population(patients.exists_for_patient())
+```
+
+The meaning of this value is as follows:
+
+* 1 - Urban major conurbation
+* 2 - Urban minor conurbation
+* 3 - Urban city and town
+* 4 - Urban city and town in a sparse setting
+* 5 - Rural town and fringe
+* 6 - Rural town and fringe in a sparse setting
+* 7 - Rural village and dispersed
+* 8 - Rural village and dispersed in a sparse setting
+
+#### Finding each patient's MSOA
+
+```ehrql
+from ehrql import create_dataset
+from ehrql.tables.tpp import addresses, patients
+
+dataset = create_dataset()
+dataset.msoa_code = addresses.for_patient_on("2023-01-01").msoa_code
+dataset.define_population(patients.exists_for_patient())
+```
+
+#### Finding multiple attributes of each patient's address
+
+```ehrql
+from ehrql import create_dataset
+from ehrql.tables.tpp import addresses, patients
+
+dataset = create_dataset()
+address = addresses.for_patient_on("2023-01-01")
+dataset.imd_rounded = address.imd_rounded
+dataset.rural_urban_classification = address.rural_urban_classification
+dataset.msoa_code = address.msoa_code
+dataset.define_population(patients.exists_for_patient())
+```
+
+## Practice Registrations
+
+### Finding attributes related to each patient's GP practice as of a given date
+
+#### Finding each patient's practice's pseudonymised identifier
+
+```ehrql
+from ehrql import create_dataset
+from ehrql.tables.tpp import practice_registrations, patients
+
+dataset = create_dataset()
+dataset.practice = practice_registrations.for_patient_on("2023-01-01").practice_pseudo_id
+dataset.define_population(patients.exists_for_patient())
+```
+
+#### Finding each patient's practice's STP
+
+```ehrql
+from ehrql import create_dataset
+from ehrql.tables.tpp import practice_registrations, patients
+
+dataset = create_dataset()
+dataset.stp = practice_registrations.for_patient_on("2023-01-01").practice_stp
+dataset.define_population(patients.exists_for_patient())
+```
+
+#### Finding each patient's practice's region
+
+```ehrql
+from ehrql import create_dataset
+from ehrql.tables.tpp import practice_registrations, patients
+
+dataset = create_dataset()
+dataset.region = practice_registrations.for_patient_on("2023-01-01").practice_nuts1_region_name
+dataset.define_population(patients.exists_for_patient())
+```
+
+#### Finding multiple attributes of each patient's practice
+
+```ehrql
+from ehrql import create_dataset
+from ehrql.tables.tpp import practice_registrations, patients
+
+dataset = create_dataset()
+registration = practice_registrations.for_patient_on("2023-01-01")
+dataset.practice = registration.practice_pseudo_id
+dataset.stp = registration.practice_stp
+dataset.region = registration.practice_nuts1_region_name
+dataset.define_population(patients.exists_for_patient())
+```
+
+## Clinical Events
+
+### Finding patient demographics
+
+#### Finding each patient's ethnicity
 
 Ethnicity can be defined using a codelist. There are a lot of individual codes that can used to indicate a patients' fine-grained ethnicity. To make analysis more manageable, ethnicity is therefore commonly grouped into higher level categories. Above, we described how you can [import codelists that have a category column](#some-examples-using-codelist_from_csv). You can use a codelist with a category column to map clinical event codes for ethnicity to higher level categories as in this example:
 
@@ -215,137 +355,9 @@ dataset.latest_ethnicity_group = dataset.latest_ethnicity_code.to_category(
 dataset.define_population(patients.exists_for_patient())
 ```
 
-## Finding attributes related to each patient's address as of a given date
+### Does each patient have an event matching some criteria?
 
-### Finding each patient's IMD rank
-
-```ehrql
-from ehrql import create_dataset
-from ehrql.tables.tpp import addresses, patients
-
-dataset = create_dataset()
-dataset.imd = addresses.for_patient_on("2023-01-01").imd_rounded
-dataset.define_population(patients.exists_for_patient())
-```
-
-The original IMD ranking is rounded to the nearest 100.
-The rounded IMD ranking ranges from 0 to 32,800.
-
-See [this code comment](https://github.com/opensafely-core/ehrql/blob/d29ff8ab2cebf3522258c408f8225b7a76f7b6f2/ehrql/tables/beta/tpp.py#L117-L123) about how we choose one address if a patient has multiple registered addresses on the given date.
-
-### Calculating each patient's IMD quintile and/or decile
-
-```ehrql
-from ehrql import create_dataset
-from ehrql.tables.tpp import addresses, patients
-
-dataset = create_dataset()
-
-patient_address = addresses.for_patient_on("2023-01-01")
-dataset.imd_quintile = patient_address.imd_quintile
-dataset.imd_decile = patient_address.imd_decile
-dataset.define_population(patients.exists_for_patient())
-```
-
-### Finding each patient's rural/urban classification
-
-```ehrql
-from ehrql import create_dataset
-from ehrql.tables.tpp import addresses, patients
-
-dataset = create_dataset()
-dataset.rural_urban = addresses.for_patient_on("2023-01-01").rural_urban_classification
-dataset.define_population(patients.exists_for_patient())
-```
-
-The meaning of this value is as follows:
-
-* 1 - Urban major conurbation
-* 2 - Urban minor conurbation
-* 3 - Urban city and town
-* 4 - Urban city and town in a sparse setting
-* 5 - Rural town and fringe
-* 6 - Rural town and fringe in a sparse setting
-* 7 - Rural village and dispersed
-* 8 - Rural village and dispersed in a sparse setting
-
-### Finding each patient's MSOA
-
-```ehrql
-from ehrql import create_dataset
-from ehrql.tables.tpp import addresses, patients
-
-dataset = create_dataset()
-dataset.msoa_code = addresses.for_patient_on("2023-01-01").msoa_code
-dataset.define_population(patients.exists_for_patient())
-```
-
-### Finding multiple attributes of each patient's address
-
-```ehrql
-from ehrql import create_dataset
-from ehrql.tables.tpp import addresses, patients
-
-dataset = create_dataset()
-address = addresses.for_patient_on("2023-01-01")
-dataset.imd_rounded = address.imd_rounded
-dataset.rural_urban_classification = address.rural_urban_classification
-dataset.msoa_code = address.msoa_code
-dataset.define_population(patients.exists_for_patient())
-```
-
-## Finding attributes related to each patient's GP practice as of a given date
-
-### Finding each patient's practice's pseudonymised identifier
-
-```ehrql
-from ehrql import create_dataset
-from ehrql.tables.tpp import practice_registrations, patients
-
-dataset = create_dataset()
-dataset.practice = practice_registrations.for_patient_on("2023-01-01").practice_pseudo_id
-dataset.define_population(patients.exists_for_patient())
-```
-
-### Finding each patient's practice's STP
-
-```ehrql
-from ehrql import create_dataset
-from ehrql.tables.tpp import practice_registrations, patients
-
-dataset = create_dataset()
-dataset.stp = practice_registrations.for_patient_on("2023-01-01").practice_stp
-dataset.define_population(patients.exists_for_patient())
-```
-
-### Finding each patient's practice's region
-
-```ehrql
-from ehrql import create_dataset
-from ehrql.tables.tpp import practice_registrations, patients
-
-dataset = create_dataset()
-dataset.region = practice_registrations.for_patient_on("2023-01-01").practice_nuts1_region_name
-dataset.define_population(patients.exists_for_patient())
-```
-
-### Finding multiple attributes of each patient's practice
-
-```ehrql
-from ehrql import create_dataset
-from ehrql.tables.tpp import practice_registrations, patients
-
-dataset = create_dataset()
-registration = practice_registrations.for_patient_on("2023-01-01")
-dataset.practice = registration.practice_pseudo_id
-dataset.stp = registration.practice_stp
-dataset.region = registration.practice_nuts1_region_name
-dataset.define_population(patients.exists_for_patient())
-```
-
-## Does each patient have an event matching some criteria?
-
-### Does each patient have a clinical event matching a code in a codelist?
+#### Does each patient have a clinical event matching a code in a codelist?
 
 ```ehrql
 from ehrql import create_dataset, codelist_from_csv
@@ -360,7 +372,7 @@ dataset.has_had_asthma_diagnosis = clinical_events.where(
 dataset.define_population(patients.exists_for_patient())
 ```
 
-### Does each patient have a clinical event matching a code in a codelist in a time period?
+#### Does each patient have a clinical event matching a code in a codelist in a time period?
 
 ```ehrql
 from ehrql import create_dataset, codelist_from_csv
@@ -377,63 +389,12 @@ dataset.has_recent_asthma_diagnosis = clinical_events.where(
 dataset.define_population(patients.exists_for_patient())
 ```
 
-### Does each patient have a medication event matching some criteria?
-
-```ehrql
-from ehrql import create_dataset, codelist_from_csv
-from ehrql.tables.core import medications, patients
-
-statin_medications = codelist_from_csv("XXX", column="YYY")
-
-dataset = create_dataset()
-dataset.has_recent_statin_prescription = medications.where(
-        medications.dmd_code.is_in(statin_medications)
-).where(
-        medications.date.is_on_or_between("2022-07-01", "2023-01-01")
-).exists_for_patient()
-dataset.define_population(patients.exists_for_patient())
-```
-
-### Does each patient have a hospitalisation event matching some criteria?
-
-```ehrql
-from ehrql import create_dataset, codelist_from_csv
-from ehrql.tables.tpp import apcs, patients
-
-cardiac_diagnosis_codes = codelist_from_csv("XXX", column="YYY")
-
-dataset = create_dataset()
-dataset.has_recent_cardiac_admission = apcs.where(
-        apcs.primary_diagnosis.is_in(cardiac_diagnosis_codes)
-).where(
-        apcs.admission_date.is_on_or_between("2022-07-01", "2023-01-01")
-).exists_for_patient()
-dataset.define_population(patients.exists_for_patient())
-```
-
-## How many events does each patient have matching some criteria?
-
-```ehrql
-from ehrql import create_dataset, codelist_from_csv
-from ehrql.tables.core import medications, patients
-
-statin_medications = codelist_from_csv("XXX", column="YYY")
-
-dataset = create_dataset()
-dataset.number_of_statin_prescriptions_in_last_year = medications.where(
-        medications.dmd_code.is_in(statin_medications)
-).where(
-        medications.date.is_on_or_between("2022-01-01", "2023-01-01")
-).count_for_patient()
-dataset.define_population(patients.exists_for_patient())
-```
-
-## What is the first/last event matching some criteria?
+### What is the first/last event matching some criteria?
 
 The `first_for_patient()` and `last_for_patient()` methods can only be used on a sorted frame.
 Frames can be sorted by calling the `sort_by()` method with the column to sort the frame by.
 
-### What is the earliest/latest clinical event matching some criteria?
+#### What is the earliest/latest clinical event matching some criteria?
 
 ```ehrql
 from ehrql import create_dataset, codelist_from_csv
@@ -469,43 +430,7 @@ dataset.last_asthma_diagnosis_date = clinical_events.where(
 dataset.define_population(patients.exists_for_patient())
 ```
 
-### What is the earliest/latest medication event matching some criteria?
-
-```ehrql
-from ehrql import create_dataset, codelist_from_csv
-from ehrql.tables.core import medications, patients
-
-statin_medications = codelist_from_csv("XXX", column="YYY")
-
-dataset = create_dataset()
-dataset.first_statin_prescription_date = medications.where(
-        medications.dmd_code.is_in(statin_medications)
-).where(
-        medications.date.is_on_or_after("2022-07-01")
-).sort_by(
-        medications.date
-).first_for_patient().date
-dataset.define_population(patients.exists_for_patient())
-```
-
-```ehrql
-from ehrql import create_dataset, codelist_from_csv
-from ehrql.tables.core import medications, patients
-
-statin_medications = codelist_from_csv("XXX", column="YYY")
-
-dataset = create_dataset()
-dataset.last_statin_prescription_date = medications.where(
-        medications.dmd_code.is_in(statin_medications)
-).where(
-        medications.date.is_on_or_after("2022-07-01")
-).sort_by(
-        medications.date
-).last_for_patient().date
-dataset.define_population(patients.exists_for_patient())
-```
-
-### What is the clinical event, matching some criteria, with the least/greatest value?
+#### What is the clinical event, matching some criteria, with the least/greatest value?
 
 ```ehrql
 from ehrql import create_dataset, codelist_from_csv
@@ -552,9 +477,9 @@ dataset.value_of_last_max_hba1c_observed = latest_max_hba1c_event.numeric_value
 dataset.define_population(patients.exists_for_patient())
 ```
 
-## Getting properties of an event matching some criteria
+### Getting properties of an event matching some criteria
 
-### What is the code of the first/last clinical event matching some criteria?
+#### What is the code of the first/last clinical event matching some criteria?
 
 ```ehrql
 from ehrql import create_dataset, codelist_from_csv
@@ -573,7 +498,7 @@ dataset.first_asthma_diagnosis_code = clinical_events.where(
 dataset.define_population(patients.exists_for_patient())
 ```
 
-### What is the date of the first/last clinical event matching some criteria?
+#### What is the date of the first/last clinical event matching some criteria?
 
 ```ehrql
 from ehrql import create_dataset, codelist_from_csv
@@ -592,7 +517,7 @@ dataset.first_asthma_diagnosis_date = clinical_events.where(
 dataset.define_population(patients.exists_for_patient())
 ```
 
-### What is the code and date of the first/last clinical event matching some criteria?
+#### What is the code and date of the first/last clinical event matching some criteria?
 
 ```ehrql
 from ehrql import create_dataset, codelist_from_csv
@@ -613,9 +538,272 @@ dataset.first_asthma_diagnosis_date = first_asthma_diagnosis.date
 dataset.define_population(patients.exists_for_patient())
 ```
 
-## Finding events occuring close in time to another event
+### Performing arithmetic on numeric values of clinical events
 
-### Finding the code of the first medication after the first clinical event matching some criteria
+#### Finding the mean observed value of clinical events matching some criteria
+
+```ehrql
+from ehrql import create_dataset, codelist_from_csv
+from ehrql.tables.core import clinical_events, patients
+
+hba1c_codelist = codelist_from_csv("XXX", column="YYY")
+
+dataset = create_dataset()
+dataset.mean_hba1c = clinical_events.where(
+        clinical_events.snomedct_code.is_in(hba1c_codelist)
+).where(
+        clinical_events.date.is_on_or_after("2022-07-01")
+).numeric_value.mean_for_patient()
+dataset.define_population(patients.exists_for_patient())
+```
+
+### Finding events within a date range
+
+#### Finding events within a fixed date range
+
+```ehrql
+from ehrql import create_dataset, codelist_from_csv
+from ehrql.tables.core import clinical_events, patients
+
+asthma_codelist = codelist_from_csv("XXX", column="YYY")
+
+dataset = create_dataset()
+dataset.has_recent_asthma_diagnosis = clinical_events.where(
+        clinical_events.snomedct_code.is_in(asthma_codelist)
+).where(
+        clinical_events.date.is_on_or_between("2022-07-01", "2023-01-01")
+).exists_for_patient()
+dataset.define_population(patients.exists_for_patient())
+```
+
+#### Finding events within a date range plus a constant
+
+```ehrql
+from ehrql import create_dataset, codelist_from_csv, weeks
+from ehrql.tables.core import clinical_events, patients
+
+asthma_codelist = codelist_from_csv("XXX", column="YYY")
+
+index_date = "2022-07-01"
+
+dataset = create_dataset()
+dataset.has_recent_asthma_diagnosis = clinical_events.where(
+        clinical_events.snomedct_code.is_in(asthma_codelist)
+).where(
+        clinical_events.date.is_on_or_between(index_date, index_date + weeks(2))
+).exists_for_patient()
+dataset.define_population(patients.exists_for_patient())
+```
+
+#### Finding events within a dynamic date range
+
+```ehrql
+from ehrql import create_dataset, codelist_from_csv, months
+from ehrql.tables.core import clinical_events, patients
+
+diabetes_codelist = codelist_from_csv("XXX", column="YYY")
+hba1c_codelist = codelist_from_csv("XXX", column="YYY")
+
+dataset = create_dataset()
+first_diabetes_code_date = clinical_events.where(
+        clinical_events.snomedct_code.is_in(diabetes_codelist)
+).sort_by(
+        clinical_events.date
+).first_for_patient().date
+
+dataset.count_of_hba1c_tests_6mo_post_first_diabetes_code = clinical_events.where(
+        clinical_events.snomedct_code.is_in(hba1c_codelist)
+).where(
+        clinical_events.date.is_on_or_between(first_diabetes_code_date, first_diabetes_code_date + months(6))
+).count_for_patient()
+dataset.define_population(patients.exists_for_patient())
+```
+
+#### Excluding events which have happened in the future
+
+Data quality issues with many sources may result in events apparently happening in future dates (e.g. 9999-01-01), it is useful to filter these from your analysis.
+
+```ehrql
+from datetime import date
+from ehrql import create_dataset, codelist_from_csv
+from ehrql.tables.core import clinical_events, patients
+
+asthma_codelist = codelist_from_csv("XXX", column="YYY")
+
+dataset = create_dataset()
+dataset.has_recent_asthma_diagnosis = clinical_events.where(
+        clinical_events.snomedct_code.is_in(asthma_codelist)
+).where(
+        clinical_events.date > "2022-07-01"
+).where(
+        clinical_events.date < date.today()
+).exists_for_patient()
+dataset.define_population(patients.exists_for_patient())
+```
+
+### Extracting parts of dates and date differences
+
+#### Finding the year an event occurred
+
+```ehrql
+from datetime import date
+from ehrql import create_dataset, codelist_from_csv
+from ehrql.tables.core import clinical_events, patients
+
+asthma_codelist = codelist_from_csv("XXX", column="YYY")
+
+dataset = create_dataset()
+dataset.year_of_first = clinical_events.where(
+        clinical_events.snomedct_code.is_in(asthma_codelist)
+).sort_by(
+        clinical_events.date
+).first_for_patient().date.year
+dataset.define_population(patients.exists_for_patient())
+```
+
+#### Finding the number of weeks between two events
+
+```ehrql
+from ehrql import create_dataset, codelist_from_csv
+from ehrql.tables.core import clinical_events, patients
+
+asthma_codelist = codelist_from_csv("XXX", column="YYY")
+asthma_review_codelist = codelist_from_csv("XXX", column="YYY")
+
+dataset = create_dataset()
+first_asthma_diagnosis_date = clinical_events.where(
+        clinical_events.snomedct_code.is_in(asthma_codelist)
+).sort_by(clinical_events.date).first_for_patient().date
+
+first_asthma_review_date = clinical_events.where(
+        clinical_events.snomedct_code.is_in(asthma_review_codelist)
+).where(
+        clinical_events.date.is_on_or_after(first_asthma_diagnosis_date)
+).sort_by(clinical_events.date).first_for_patient().date
+
+dataset.weeks_between_diagnosis_and_review = (first_asthma_review_date - first_asthma_diagnosis_date).weeks
+dataset.define_population(patients.exists_for_patient())
+```
+
+## Admitted Patient Care Spells (APCS)
+
+### Does each patient have an event matching some criteria?
+
+#### Does each patient have a hospitalisation event matching some criteria?
+
+```ehrql
+from ehrql import create_dataset, codelist_from_csv
+from ehrql.tables.tpp import apcs, patients
+
+cardiac_diagnosis_codes = codelist_from_csv("XXX", column="YYY")
+
+dataset = create_dataset()
+dataset.has_recent_cardiac_admission = apcs.where(
+        apcs.primary_diagnosis.is_in(cardiac_diagnosis_codes)
+).where(
+        apcs.admission_date.is_on_or_between("2022-07-01", "2023-01-01")
+).exists_for_patient()
+dataset.define_population(patients.exists_for_patient())
+```
+
+## Medications
+
+### Does each patient have an event matching some criteria?
+
+#### Does each patient have a medication event matching some criteria?
+
+```ehrql
+from ehrql import create_dataset, codelist_from_csv
+from ehrql.tables.core import medications, patients
+
+statin_medications = codelist_from_csv("XXX", column="YYY")
+
+dataset = create_dataset()
+dataset.has_recent_statin_prescription = medications.where(
+        medications.dmd_code.is_in(statin_medications)
+).where(
+        medications.date.is_on_or_between("2022-07-01", "2023-01-01")
+).exists_for_patient()
+dataset.define_population(patients.exists_for_patient())
+```
+
+#### How many events does each patient have matching some criteria?
+
+```ehrql
+from ehrql import create_dataset, codelist_from_csv
+from ehrql.tables.core import medications, patients
+
+statin_medications = codelist_from_csv("XXX", column="YYY")
+
+dataset = create_dataset()
+dataset.number_of_statin_prescriptions_in_last_year = medications.where(
+        medications.dmd_code.is_in(statin_medications)
+).where(
+        medications.date.is_on_or_between("2022-01-01", "2023-01-01")
+).count_for_patient()
+dataset.define_population(patients.exists_for_patient())
+```
+
+#### What is the earliest/latest medication event matching some criteria?
+
+```ehrql
+from ehrql import create_dataset, codelist_from_csv
+from ehrql.tables.core import medications, patients
+
+statin_medications = codelist_from_csv("XXX", column="YYY")
+
+dataset = create_dataset()
+dataset.first_statin_prescription_date = medications.where(
+        medications.dmd_code.is_in(statin_medications)
+).where(
+        medications.date.is_on_or_after("2022-07-01")
+).sort_by(
+        medications.date
+).first_for_patient().date
+dataset.define_population(patients.exists_for_patient())
+```
+
+```ehrql
+from ehrql import create_dataset, codelist_from_csv
+from ehrql.tables.core import medications, patients
+
+statin_medications = codelist_from_csv("XXX", column="YYY")
+
+dataset = create_dataset()
+dataset.last_statin_prescription_date = medications.where(
+        medications.dmd_code.is_in(statin_medications)
+).where(
+        medications.date.is_on_or_after("2022-07-01")
+).sort_by(
+        medications.date
+).last_for_patient().date
+dataset.define_population(patients.exists_for_patient())
+```
+
+### Extracting parts of dates and date differences
+
+#### Finding prescriptions made in particular months of the year
+
+```ehrql
+from ehrql import create_dataset, codelist_from_csv
+from ehrql.tables.core import medications, patients
+
+amoxicillin_codelist = codelist_from_csv("XXX", column="YYY")
+
+winter_months = [10,11,12,1,2,3]
+
+dataset = create_dataset()
+dataset.winter_amoxicillin_count = medications.where(
+        medications.dmd_code.is_in(amoxicillin_codelist)
+).where(
+        medications.date.month.is_in(winter_months)
+).count_for_patient()
+dataset.define_population(patients.exists_for_patient())
+```
+
+### Finding events occuring close in time to another event
+
+#### Finding the code of the first medication after the first clinical event matching some criteria
 
 ```ehrql
 from ehrql import create_dataset, codelist_from_csv, weeks
@@ -641,178 +829,11 @@ dataset.count_ics_prescriptions_2wks_post_diagnosis = medications.where(
 dataset.define_population(patients.exists_for_patient())
 ```
 
-## Performing arithmetic on numeric values of clinical events
-
-### Finding the mean observed value of clinical events matching some criteria
-
-```ehrql
-from ehrql import create_dataset, codelist_from_csv
-from ehrql.tables.core import clinical_events, patients
-
-hba1c_codelist = codelist_from_csv("XXX", column="YYY")
-
-dataset = create_dataset()
-dataset.mean_hba1c = clinical_events.where(
-        clinical_events.snomedct_code.is_in(hba1c_codelist)
-).where(
-        clinical_events.date.is_on_or_after("2022-07-01")
-).numeric_value.mean_for_patient()
-dataset.define_population(patients.exists_for_patient())
-```
-
-## Finding events within a date range
-
-### Finding events within a fixed date range
-
-```ehrql
-from ehrql import create_dataset, codelist_from_csv
-from ehrql.tables.core import clinical_events, patients
-
-asthma_codelist = codelist_from_csv("XXX", column="YYY")
-
-dataset = create_dataset()
-dataset.has_recent_asthma_diagnosis = clinical_events.where(
-        clinical_events.snomedct_code.is_in(asthma_codelist)
-).where(
-        clinical_events.date.is_on_or_between("2022-07-01", "2023-01-01")
-).exists_for_patient()
-dataset.define_population(patients.exists_for_patient())
-```
-
-### Finding events within a date range plus a constant
-
-```ehrql
-from ehrql import create_dataset, codelist_from_csv, weeks
-from ehrql.tables.core import clinical_events, patients
-
-asthma_codelist = codelist_from_csv("XXX", column="YYY")
-
-index_date = "2022-07-01"
-
-dataset = create_dataset()
-dataset.has_recent_asthma_diagnosis = clinical_events.where(
-        clinical_events.snomedct_code.is_in(asthma_codelist)
-).where(
-        clinical_events.date.is_on_or_between(index_date, index_date + weeks(2))
-).exists_for_patient()
-dataset.define_population(patients.exists_for_patient())
-```
-
-### Finding events within a dynamic date range
-
-```ehrql
-from ehrql import create_dataset, codelist_from_csv, months
-from ehrql.tables.core import clinical_events, patients
-
-diabetes_codelist = codelist_from_csv("XXX", column="YYY")
-hba1c_codelist = codelist_from_csv("XXX", column="YYY")
-
-dataset = create_dataset()
-first_diabetes_code_date = clinical_events.where(
-        clinical_events.snomedct_code.is_in(diabetes_codelist)
-).sort_by(
-        clinical_events.date
-).first_for_patient().date
-
-dataset.count_of_hba1c_tests_6mo_post_first_diabetes_code = clinical_events.where(
-        clinical_events.snomedct_code.is_in(hba1c_codelist)
-).where(
-        clinical_events.date.is_on_or_between(first_diabetes_code_date, first_diabetes_code_date + months(6))
-).count_for_patient()
-dataset.define_population(patients.exists_for_patient())
-```
-
-### Excluding events which have happened in the future
-
-Data quality issues with many sources may result in events apparently happening in future dates (e.g. 9999-01-01), it is useful to filter these from your analysis.
-
-```ehrql
-from datetime import date
-from ehrql import create_dataset, codelist_from_csv
-from ehrql.tables.core import clinical_events, patients
-
-asthma_codelist = codelist_from_csv("XXX", column="YYY")
-
-dataset = create_dataset()
-dataset.has_recent_asthma_diagnosis = clinical_events.where(
-        clinical_events.snomedct_code.is_in(asthma_codelist)
-).where(
-        clinical_events.date > "2022-07-01"
-).where(
-        clinical_events.date < date.today()
-).exists_for_patient()
-dataset.define_population(patients.exists_for_patient())
-```
-
-## Extracting parts of dates and date differences
-
-### Finding the year an event occurred
-
-```ehrql
-from datetime import date
-from ehrql import create_dataset, codelist_from_csv
-from ehrql.tables.core import clinical_events, patients
-
-asthma_codelist = codelist_from_csv("XXX", column="YYY")
-
-dataset = create_dataset()
-dataset.year_of_first = clinical_events.where(
-        clinical_events.snomedct_code.is_in(asthma_codelist)
-).sort_by(
-        clinical_events.date
-).first_for_patient().date.year
-dataset.define_population(patients.exists_for_patient())
-```
-
-### Finding prescriptions made in particular months of the year
-
-```ehrql
-from ehrql import create_dataset, codelist_from_csv
-from ehrql.tables.core import medications, patients
-
-amoxicillin_codelist = codelist_from_csv("XXX", column="YYY")
-
-winter_months = [10,11,12,1,2,3]
-
-dataset = create_dataset()
-dataset.winter_amoxicillin_count = medications.where(
-        medications.dmd_code.is_in(amoxicillin_codelist)
-).where(
-        medications.date.month.is_in(winter_months)
-).count_for_patient()
-dataset.define_population(patients.exists_for_patient())
-```
-
-### Finding the number of weeks between two events
-
-```ehrql
-from ehrql import create_dataset, codelist_from_csv
-from ehrql.tables.core import clinical_events, patients
-
-asthma_codelist = codelist_from_csv("XXX", column="YYY")
-asthma_review_codelist = codelist_from_csv("XXX", column="YYY")
-
-dataset = create_dataset()
-first_asthma_diagnosis_date = clinical_events.where(
-        clinical_events.snomedct_code.is_in(asthma_codelist)
-).sort_by(clinical_events.date).first_for_patient().date
-
-first_asthma_review_date = clinical_events.where(
-        clinical_events.snomedct_code.is_in(asthma_review_codelist)
-).where(
-        clinical_events.date.is_on_or_after(first_asthma_diagnosis_date)
-).sort_by(clinical_events.date).first_for_patient().date
-
-dataset.weeks_between_diagnosis_and_review = (first_asthma_review_date - first_asthma_diagnosis_date).weeks
-dataset.define_population(patients.exists_for_patient())
-```
-
-
-## Excluding medications for patients who have transferred between practices
+### Excluding medications for patients who have transferred between practices
 
 Note that in these examples, the periods defined are illustrative only.
 
-### Excluding patients based on prescription date
+#### Excluding patients based on prescription date
 
 ```ehrql
 from ehrql import case, create_dataset, codelist_from_csv, when, weeks
@@ -856,7 +877,7 @@ dataset.prescription_date = case(
 dataset.define_population(patients.exists_for_patient())
 ```
 
-### Excluding patients based on study dates
+#### Excluding patients based on study dates
 
 The following example ensures that the dataset only includes patients registered at a
 single practice for the entire duration of the study, plus at least 3 months prior to the

--- a/docs/how-to/examples.md
+++ b/docs/how-to/examples.md
@@ -62,6 +62,8 @@ You can see an example of [how to access these categories within your dataset de
 
 ## Patients
 
+Examples for the [patients table](../../reference/schemas/core/#patients).
+
 ### Finding patient demographics
 
 #### Finding each patient's sex
@@ -157,6 +159,8 @@ dataset.define_population(patients.exists_for_patient())
 
 ## ONS Deaths
 
+Examples for the [ons_deaths table](../../reference/schemas/core/#ons_deaths).
+
 ### Finding patient demographics
 
 #### Finding each patient's date, underlying_cause_of_death, and first noted additional medical condition noted on the death certificate from ONS records
@@ -194,6 +198,8 @@ dataset.define_population(patients.exists_for_patient())
 ```
 
 ## Addresses
+
+Examples for the [TPP addresses table](../../reference/schemas/tpp/#addresses).
 
 ### Finding attributes related to each patient's address as of a given date
 
@@ -276,6 +282,8 @@ dataset.define_population(patients.exists_for_patient())
 
 ## Practice Registrations
 
+Examples for the [practice_registrations table](../../reference/schemas/core/#practice_registrations).
+
 ### Finding attributes related to each patient's GP practice as of a given date
 
 #### Finding each patient's practice's pseudonymised identifier
@@ -355,6 +363,8 @@ dataset.define_population(registrations.exists_for_patient())
 ```
 
 ## Clinical Events
+
+Examples for the [clinical_events table](../../reference/schemas/core/#clinical_events).
 
 ### Finding patient demographics
 
@@ -720,6 +730,8 @@ dataset.define_population(patients.exists_for_patient())
 
 ## Admitted Patient Care Spells (APCS)
 
+Examples for the [TPP apcs table](../../reference/schemas/tpp/#apcs).
+
 ### Does each patient have an event matching some criteria?
 
 #### Does each patient have a hospitalisation event matching some criteria?
@@ -740,6 +752,8 @@ dataset.define_population(patients.exists_for_patient())
 ```
 
 ## Medications
+
+Examples for the [medications table](../../reference/schemas/core/#medications).
 
 ### Does each patient have an event matching some criteria?
 

--- a/docs/includes/generated_docs/schemas/core.md
+++ b/docs/includes/generated_docs/schemas/core.md
@@ -25,8 +25,6 @@ Note that event codes do not change in this table. If an event code in the codin
 system becomes inactive, the event will still be coded to the inactive code.
 As such, codelists should include all relevant inactive codes.
 
-### Example usage
-
 [Example ehrQL usage of clinical_events](../../../how-to/examples/#clinical-events)
 <div markdown="block" class="definition-list-wrapper">
   <div class="title">Columns</div>
@@ -101,8 +99,6 @@ interest, you may simply want to ensure that all included patients were register
 at a single practice for a minimum time prior to the study period, and were
 registered at the same practice for the duration of the study period.
 
-### Example usage
-
 Examples of using ehrQL to calculation such periods can be found in the documentation
 on how to
 [use ehrQL to answer specific questions using the medications table](../../../how-to/examples/#clinical-events)
@@ -167,8 +163,6 @@ The `ehrql.tables.raw.core.ons_deaths` table contains all registered deaths.
     like autopsies and inquests delaying reporting on cause of death. This is
     evident in the [OpenSAFELY historical database coverage
     report](https://reports.opensafely.org/reports/opensafely-tpp-database-history/#ons_deaths)
-
-### Example usage
 
 [Example ehrQL usage of ons_deaths](../../../how-to/examples/#ons-deaths)
 <div markdown="block" class="definition-list-wrapper">
@@ -461,8 +455,6 @@ recording in primary care in:
 By contrast, cause of death is often not accurate in the primary care record so we
 don't make it available to query here.
 
-### Example usage
-
 [Example ehrQL usage of patients](../../../how-to/examples/#patients)
 <div markdown="block" class="definition-list-wrapper">
   <div class="title">Columns</div>
@@ -587,8 +579,6 @@ return patients.date_of_death.is_not_null() & patients.date_of_death.is_before(d
 ## practice_registrations
 
 Each record corresponds to a patient's registration with a practice.
-
-### Example usage
 
 [Example ehrQL usage of practice_registrations](../../../how-to/examples/#practice-registrations)
 <div markdown="block" class="definition-list-wrapper">

--- a/docs/includes/generated_docs/schemas/core.md
+++ b/docs/includes/generated_docs/schemas/core.md
@@ -24,6 +24,10 @@ Each record corresponds to a single clinical or consultation event for a patient
 Note that event codes do not change in this table. If an event code in the coding
 system becomes inactive, the event will still be coded to the inactive code.
 As such, codelists should include all relevant inactive codes.
+
+### Example usage
+
+[Example ehrQL usage of clinical_events](../../../how-to/examples/#clinical-events)
 <div markdown="block" class="definition-list-wrapper">
   <div class="title">Columns</div>
   <dl markdown="block">
@@ -97,9 +101,11 @@ interest, you may simply want to ensure that all included patients were register
 at a single practice for a minimum time prior to the study period, and were
 registered at the same practice for the duration of the study period.
 
+### Example usage
+
 Examples of using ehrQL to calculation such periods can be found in the documentation
 on how to
-[use ehrQL to answer specific questions](../../how-to/examples.md#excluding-medications-for-patients-who-have-transferred-between-practices).
+[use ehrQL to answer specific questions using the medications table](../../../how-to/examples/#clinical-events)
 <div markdown="block" class="definition-list-wrapper">
   <div class="title">Columns</div>
   <dl markdown="block">
@@ -161,6 +167,10 @@ The `ehrql.tables.raw.core.ons_deaths` table contains all registered deaths.
     like autopsies and inquests delaying reporting on cause of death. This is
     evident in the [OpenSAFELY historical database coverage
     report](https://reports.opensafely.org/reports/opensafely-tpp-database-history/#ons_deaths)
+
+### Example usage
+
+[Example ehrQL usage of ons_deaths](../../../how-to/examples/#ons-deaths)
 <div markdown="block" class="definition-list-wrapper">
   <div class="title">Columns</div>
   <dl markdown="block">
@@ -450,6 +460,10 @@ recording in primary care in:
 
 By contrast, cause of death is often not accurate in the primary care record so we
 don't make it available to query here.
+
+### Example usage
+
+[Example ehrQL usage of patients](../../../how-to/examples/#patients)
 <div markdown="block" class="definition-list-wrapper">
   <div class="title">Columns</div>
   <dl markdown="block">
@@ -573,6 +587,10 @@ return patients.date_of_death.is_not_null() & patients.date_of_death.is_before(d
 ## practice_registrations
 
 Each record corresponds to a patient's registration with a practice.
+
+### Example usage
+
+[Example ehrQL usage of practice_registrations](../../../how-to/examples/#practice-registrations)
 <div markdown="block" class="definition-list-wrapper">
   <div class="title">Columns</div>
   <dl markdown="block">

--- a/docs/includes/generated_docs/schemas/emis.md
+++ b/docs/includes/generated_docs/schemas/emis.md
@@ -26,8 +26,6 @@ Note that event codes do not change in this table. If an event code in the codin
 system becomes inactive, the event will still be coded to the inactive code.
 As such, codelists should include all relevant inactive codes.
 
-### Example usage
-
 [Example ehrQL usage of clinical_events](../../../how-to/examples/#clinical-events)
 <div markdown="block" class="definition-list-wrapper">
   <div class="title">Columns</div>
@@ -102,8 +100,6 @@ interest, you may simply want to ensure that all included patients were register
 at a single practice for a minimum time prior to the study period, and were
 registered at the same practice for the duration of the study period.
 
-### Example usage
-
 Examples of using ehrQL to calculation such periods can be found in the documentation
 on how to
 [use ehrQL to answer specific questions using the medications table](../../../how-to/examples/#clinical-events)
@@ -168,8 +164,6 @@ The `ehrql.tables.raw.core.ons_deaths` table contains all registered deaths.
     like autopsies and inquests delaying reporting on cause of death. This is
     evident in the [OpenSAFELY historical database coverage
     report](https://reports.opensafely.org/reports/opensafely-tpp-database-history/#ons_deaths)
-
-### Example usage
 
 [Example ehrQL usage of ons_deaths](../../../how-to/examples/#ons-deaths)
 <div markdown="block" class="definition-list-wrapper">
@@ -620,11 +614,7 @@ return patients.registration_start_date.is_on_or_before(start_date) & (
 
 Each record corresponds to a patient's registration with a practice.
 
-### Example usage
-
 [Example ehrQL usage of practice_registrations](../../../how-to/examples/#practice-registrations)
-
-### EMIS specific information
 
 !!! warning
     At present, the EMIS database contains only the patient's current practice

--- a/docs/includes/generated_docs/schemas/emis.md
+++ b/docs/includes/generated_docs/schemas/emis.md
@@ -25,6 +25,10 @@ Each record corresponds to a single clinical or consultation event for a patient
 Note that event codes do not change in this table. If an event code in the coding
 system becomes inactive, the event will still be coded to the inactive code.
 As such, codelists should include all relevant inactive codes.
+
+### Example usage
+
+[Example ehrQL usage of clinical_events](../../../how-to/examples/#clinical-events)
 <div markdown="block" class="definition-list-wrapper">
   <div class="title">Columns</div>
   <dl markdown="block">
@@ -98,9 +102,11 @@ interest, you may simply want to ensure that all included patients were register
 at a single practice for a minimum time prior to the study period, and were
 registered at the same practice for the duration of the study period.
 
+### Example usage
+
 Examples of using ehrQL to calculation such periods can be found in the documentation
 on how to
-[use ehrQL to answer specific questions](../../how-to/examples.md#excluding-medications-for-patients-who-have-transferred-between-practices).
+[use ehrQL to answer specific questions using the medications table](../../../how-to/examples/#clinical-events)
 <div markdown="block" class="definition-list-wrapper">
   <div class="title">Columns</div>
   <dl markdown="block">
@@ -162,6 +168,10 @@ The `ehrql.tables.raw.core.ons_deaths` table contains all registered deaths.
     like autopsies and inquests delaying reporting on cause of death. This is
     evident in the [OpenSAFELY historical database coverage
     report](https://reports.opensafely.org/reports/opensafely-tpp-database-history/#ons_deaths)
+
+### Example usage
+
+[Example ehrQL usage of ons_deaths](../../../how-to/examples/#ons-deaths)
 <div markdown="block" class="definition-list-wrapper">
   <div class="title">Columns</div>
   <dl markdown="block">
@@ -609,6 +619,12 @@ return patients.registration_start_date.is_on_or_before(start_date) & (
 ## practice_registrations
 
 Each record corresponds to a patient's registration with a practice.
+
+### Example usage
+
+[Example ehrQL usage of practice_registrations](../../../how-to/examples/#practice-registrations)
+
+### EMIS specific information
 
 !!! warning
     At present, the EMIS database contains only the patient's current practice

--- a/docs/includes/generated_docs/schemas/tpp.md
+++ b/docs/includes/generated_docs/schemas/tpp.md
@@ -51,8 +51,6 @@ from which other larger geographic representations can be derived
 
 [addresses_ukgeographies]: https://www.ons.gov.uk/methodology/geography/ukgeographies
 
-### Example usage
-
 [Example ehrQL usage of addresses](../../../how-to/examples/#addresses)
 <div markdown="block" class="definition-list-wrapper">
   <div class="title">Columns</div>
@@ -366,8 +364,6 @@ and the [GitHub issue discussing more of the background context][apcs_context_is
 
 [apcs_data_source_docs]: https://docs.opensafely.org/data-sources/apc/
 [apcs_context_issue]: https://github.com/opensafely-core/cohort-extractor/issues/186
-
-### Example usage
 
 [Example ehrQL usage of apcs](../../../how-to/examples/#admitted-patient-care-spells-apcs)
 <div markdown="block" class="definition-list-wrapper">
@@ -1764,8 +1760,6 @@ interest, you may simply want to ensure that all included patients were register
 at a single practice for a minimum time prior to the study period, and were
 registered at the same practice for the duration of the study period.
 
-### Example usage
-
 Examples of using ehrQL to calculation such periods can be found in the documentation
 on how to
 [use ehrQL to answer specific questions using the medications table](../../../how-to/examples/#clinical-events)
@@ -1876,8 +1870,6 @@ The `ehrql.tables.raw.core.ons_deaths` table contains all registered deaths.
     like autopsies and inquests delaying reporting on cause of death. This is
     evident in the [OpenSAFELY historical database coverage
     report](https://reports.opensafely.org/reports/opensafely-tpp-database-history/#ons_deaths)
-
-### Example usage
 
 [Example ehrQL usage of ons_deaths](../../../how-to/examples/#ons-deaths)
 
@@ -2732,8 +2724,6 @@ recording in primary care in:
 By contrast, cause of death is often not accurate in the primary care record so we
 don't make it available to query here.
 
-### Example usage
-
 [Example ehrQL usage of patients](../../../how-to/examples/#patients)
 <div markdown="block" class="definition-list-wrapper">
   <div class="title">Columns</div>
@@ -2858,8 +2848,6 @@ return patients.date_of_death.is_not_null() & patients.date_of_death.is_before(d
 ## practice_registrations
 
 Each record corresponds to a patient's registration with a practice.
-
-### Example usage
 
 [Example ehrQL usage of practice_registrations](../../../how-to/examples/#practice-registrations)
 

--- a/docs/includes/generated_docs/schemas/tpp.md
+++ b/docs/includes/generated_docs/schemas/tpp.md
@@ -50,6 +50,10 @@ from which other larger geographic representations can be derived
 (see various [ONS publications][addresses_ukgeographies] for more detail).
 
 [addresses_ukgeographies]: https://www.ons.gov.uk/methodology/geography/ukgeographies
+
+### Example usage
+
+[Example ehrQL usage of addresses](../../../how-to/examples/#addresses)
 <div markdown="block" class="definition-list-wrapper">
   <div class="title">Columns</div>
   <dl markdown="block">
@@ -362,6 +366,10 @@ and the [GitHub issue discussing more of the background context][apcs_context_is
 
 [apcs_data_source_docs]: https://docs.opensafely.org/data-sources/apc/
 [apcs_context_issue]: https://github.com/opensafely-core/cohort-extractor/issues/186
+
+### Example usage
+
+[Example ehrQL usage of apcs](../../../how-to/examples/#admitted-patient-care-spells-apcs)
 <div markdown="block" class="definition-list-wrapper">
   <div class="title">Columns</div>
   <dl markdown="block">
@@ -1756,9 +1764,11 @@ interest, you may simply want to ensure that all included patients were register
 at a single practice for a minimum time prior to the study period, and were
 registered at the same practice for the duration of the study period.
 
+### Example usage
+
 Examples of using ehrQL to calculation such periods can be found in the documentation
 on how to
-[use ehrQL to answer specific questions](../../how-to/examples.md#excluding-medications-for-patients-who-have-transferred-between-practices).
+[use ehrQL to answer specific questions using the medications table](../../../how-to/examples/#clinical-events)
 <div markdown="block" class="definition-list-wrapper">
   <div class="title">Columns</div>
   <dl markdown="block">
@@ -1866,6 +1876,12 @@ The `ehrql.tables.raw.core.ons_deaths` table contains all registered deaths.
     like autopsies and inquests delaying reporting on cause of death. This is
     evident in the [OpenSAFELY historical database coverage
     report](https://reports.opensafely.org/reports/opensafely-tpp-database-history/#ons_deaths)
+
+### Example usage
+
+[Example ehrQL usage of ons_deaths](../../../how-to/examples/#ons-deaths)
+
+### TPP specific information
 
 !!! tip
     Note that this version of the table, which includes a place of death field, is
@@ -2715,6 +2731,10 @@ recording in primary care in:
 
 By contrast, cause of death is often not accurate in the primary care record so we
 don't make it available to query here.
+
+### Example usage
+
+[Example ehrQL usage of patients](../../../how-to/examples/#patients)
 <div markdown="block" class="definition-list-wrapper">
   <div class="title">Columns</div>
   <dl markdown="block">
@@ -2838,6 +2858,12 @@ return patients.date_of_death.is_not_null() & patients.date_of_death.is_before(d
 ## practice_registrations
 
 Each record corresponds to a patient's registration with a practice.
+
+### Example usage
+
+[Example ehrQL usage of practice_registrations](../../../how-to/examples/#practice-registrations)
+
+### TPP specific information
 
 See the [TPP backend information](../backends.md#patients-included-in-the-tpp-backend)
 for details of which patients are included.

--- a/ehrql/tables/core.py
+++ b/ehrql/tables/core.py
@@ -67,6 +67,10 @@ class patients(PatientFrame):
 
     By contrast, cause of death is often not accurate in the primary care record so we
     don't make it available to query here.
+
+    ### Example usage
+
+    [Example ehrQL usage of patients](../../../how-to/examples/#patients)
     """
 
     date_of_birth = Series(
@@ -126,6 +130,10 @@ class patients(PatientFrame):
 class practice_registrations(EventFrame):
     """
     Each record corresponds to a patient's registration with a practice.
+
+    ### Example usage
+
+    [Example ehrQL usage of practice_registrations](../../../how-to/examples/#practice-registrations)
     """
 
     start_date = Series(
@@ -215,6 +223,10 @@ class ons_deaths(PatientFrame):
         like autopsies and inquests delaying reporting on cause of death. This is
         evident in the [OpenSAFELY historical database coverage
         report](https://reports.opensafely.org/reports/opensafely-tpp-database-history/#ons_deaths)
+
+    ### Example usage
+
+    [Example ehrQL usage of ons_deaths](../../../how-to/examples/#ons-deaths)
     """
 
     date = Series(
@@ -312,6 +324,9 @@ class clinical_events(EventFrame):
     system becomes inactive, the event will still be coded to the inactive code.
     As such, codelists should include all relevant inactive codes.
 
+    ### Example usage
+
+    [Example ehrQL usage of clinical_events](../../../how-to/examples/#clinical-events)
     """
 
     date = Series(datetime.date)
@@ -349,9 +364,11 @@ class medications(EventFrame):
     at a single practice for a minimum time prior to the study period, and were
     registered at the same practice for the duration of the study period.
 
+    ### Example usage
+
     Examples of using ehrQL to calculation such periods can be found in the documentation
     on how to
-    [use ehrQL to answer specific questions](../../how-to/examples.md#excluding-medications-for-patients-who-have-transferred-between-practices).
+    [use ehrQL to answer specific questions using the medications table](../../../how-to/examples/#clinical-events)
     """
 
     date = Series(datetime.date)

--- a/ehrql/tables/core.py
+++ b/ehrql/tables/core.py
@@ -68,8 +68,6 @@ class patients(PatientFrame):
     By contrast, cause of death is often not accurate in the primary care record so we
     don't make it available to query here.
 
-    ### Example usage
-
     [Example ehrQL usage of patients](../../../how-to/examples/#patients)
     """
 
@@ -130,8 +128,6 @@ class patients(PatientFrame):
 class practice_registrations(EventFrame):
     """
     Each record corresponds to a patient's registration with a practice.
-
-    ### Example usage
 
     [Example ehrQL usage of practice_registrations](../../../how-to/examples/#practice-registrations)
     """
@@ -223,8 +219,6 @@ class ons_deaths(PatientFrame):
         like autopsies and inquests delaying reporting on cause of death. This is
         evident in the [OpenSAFELY historical database coverage
         report](https://reports.opensafely.org/reports/opensafely-tpp-database-history/#ons_deaths)
-
-    ### Example usage
 
     [Example ehrQL usage of ons_deaths](../../../how-to/examples/#ons-deaths)
     """
@@ -324,8 +318,6 @@ class clinical_events(EventFrame):
     system becomes inactive, the event will still be coded to the inactive code.
     As such, codelists should include all relevant inactive codes.
 
-    ### Example usage
-
     [Example ehrQL usage of clinical_events](../../../how-to/examples/#clinical-events)
     """
 
@@ -363,8 +355,6 @@ class medications(EventFrame):
     interest, you may simply want to ensure that all included patients were registered
     at a single practice for a minimum time prior to the study period, and were
     registered at the same practice for the duration of the study period.
-
-    ### Example usage
 
     Examples of using ehrQL to calculation such periods can be found in the documentation
     on how to

--- a/ehrql/tables/emis.py
+++ b/ehrql/tables/emis.py
@@ -136,11 +136,7 @@ class practice_registrations(ehrql.tables.core.practice_registrations.__class__)
     """
     Each record corresponds to a patient's registration with a practice.
 
-    ### Example usage
-
     [Example ehrQL usage of practice_registrations](../../../how-to/examples/#practice-registrations)
-
-    ### EMIS specific information
 
     !!! warning
         At present, the EMIS database contains only the patient's current practice

--- a/ehrql/tables/emis.py
+++ b/ehrql/tables/emis.py
@@ -136,6 +136,12 @@ class practice_registrations(ehrql.tables.core.practice_registrations.__class__)
     """
     Each record corresponds to a patient's registration with a practice.
 
+    ### Example usage
+
+    [Example ehrQL usage of practice_registrations](../../../how-to/examples/#practice-registrations)
+
+    ### EMIS specific information
+
     !!! warning
         At present, the EMIS database contains only the patient's current practice
         registration and does not include their full registration history.

--- a/ehrql/tables/tpp.py
+++ b/ehrql/tables/tpp.py
@@ -62,6 +62,10 @@ class addresses(EventFrame):
     (see various [ONS publications][addresses_ukgeographies] for more detail).
 
     [addresses_ukgeographies]: https://www.ons.gov.uk/methodology/geography/ukgeographies
+
+    ### Example usage
+
+    [Example ehrQL usage of addresses](../../../how-to/examples/#addresses)
     """
 
     address_id = Series(
@@ -252,6 +256,10 @@ class apcs(EventFrame):
 
     [apcs_data_source_docs]: https://docs.opensafely.org/data-sources/apc/
     [apcs_context_issue]: https://github.com/opensafely-core/cohort-extractor/issues/186
+
+    ### Example usage
+
+    [Example ehrQL usage of apcs](../../../how-to/examples/#admitted-patient-care-spells-apcs)
     """
 
     apcs_ident = Series(
@@ -955,9 +963,11 @@ class medications(ehrql.tables.core.medications.__class__):
     at a single practice for a minimum time prior to the study period, and were
     registered at the same practice for the duration of the study period.
 
+    ### Example usage
+
     Examples of using ehrQL to calculation such periods can be found in the documentation
     on how to
-    [use ehrQL to answer specific questions](../../how-to/examples.md#excluding-medications-for-patients-who-have-transferred-between-practices).
+    [use ehrQL to answer specific questions using the medications table](../../../how-to/examples/#clinical-events)
     """
 
     consultation_id = Series(
@@ -1018,6 +1028,12 @@ class ons_deaths(ehrql.tables.core.ons_deaths.__class__):
         like autopsies and inquests delaying reporting on cause of death. This is
         evident in the [OpenSAFELY historical database coverage
         report](https://reports.opensafely.org/reports/opensafely-tpp-database-history/#ons_deaths)
+
+    ### Example usage
+
+    [Example ehrQL usage of ons_deaths](../../../how-to/examples/#ons-deaths)
+
+    ### TPP specific information
 
     !!! tip
         Note that this version of the table, which includes a place of death field, is
@@ -1373,6 +1389,12 @@ class parents(PatientFrame):
 class practice_registrations(ehrql.tables.core.practice_registrations.__class__):
     """
     Each record corresponds to a patient's registration with a practice.
+
+    ### Example usage
+
+    [Example ehrQL usage of practice_registrations](../../../how-to/examples/#practice-registrations)
+
+    ### TPP specific information
 
     See the [TPP backend information](../backends.md#patients-included-in-the-tpp-backend)
     for details of which patients are included.

--- a/ehrql/tables/tpp.py
+++ b/ehrql/tables/tpp.py
@@ -63,8 +63,6 @@ class addresses(EventFrame):
 
     [addresses_ukgeographies]: https://www.ons.gov.uk/methodology/geography/ukgeographies
 
-    ### Example usage
-
     [Example ehrQL usage of addresses](../../../how-to/examples/#addresses)
     """
 
@@ -256,8 +254,6 @@ class apcs(EventFrame):
 
     [apcs_data_source_docs]: https://docs.opensafely.org/data-sources/apc/
     [apcs_context_issue]: https://github.com/opensafely-core/cohort-extractor/issues/186
-
-    ### Example usage
 
     [Example ehrQL usage of apcs](../../../how-to/examples/#admitted-patient-care-spells-apcs)
     """
@@ -963,8 +959,6 @@ class medications(ehrql.tables.core.medications.__class__):
     at a single practice for a minimum time prior to the study period, and were
     registered at the same practice for the duration of the study period.
 
-    ### Example usage
-
     Examples of using ehrQL to calculation such periods can be found in the documentation
     on how to
     [use ehrQL to answer specific questions using the medications table](../../../how-to/examples/#clinical-events)
@@ -1028,8 +1022,6 @@ class ons_deaths(ehrql.tables.core.ons_deaths.__class__):
         like autopsies and inquests delaying reporting on cause of death. This is
         evident in the [OpenSAFELY historical database coverage
         report](https://reports.opensafely.org/reports/opensafely-tpp-database-history/#ons_deaths)
-
-    ### Example usage
 
     [Example ehrQL usage of ons_deaths](../../../how-to/examples/#ons-deaths)
 
@@ -1389,8 +1381,6 @@ class parents(PatientFrame):
 class practice_registrations(ehrql.tables.core.practice_registrations.__class__):
     """
     Each record corresponds to a patient's registration with a practice.
-
-    ### Example usage
 
     [Example ehrQL usage of practice_registrations](../../../how-to/examples/#practice-registrations)
 


### PR DESCRIPTION
Examples page is now organised by primary table of interest
<img width="720" alt="Screenshot 2024-12-12 at 14 37 40" src="https://github.com/user-attachments/assets/a08d22be-db47-488d-ac2c-504e8e0da57f" />

Reference docs for the table now link to the relevant section of the examples page

<img width="719" alt="Screenshot 2024-12-12 at 14 37 59" src="https://github.com/user-attachments/assets/ef69e24e-a342-4b23-b339-85c1bf5d341d" />

This is done manually, if we produce many more examples in the future we could build some tooling to automate (but I'm not convinced that's worth doing right now).

Fixes https://github.com/opensafely-core/ehrql/issues/2210
