### PR TITLE
Update behaviour of `show()` to just display ehrql objects

### DIFF
--- a/ehrql/debugger.py
+++ b/ehrql/debugger.py
@@ -83,8 +83,10 @@ def show(
             " - or call it with multiple columns/series:\n"
             "     show(patients.sex, patients.date_of_birth)\n"
             '     show(patients.sex == "male", patients.date_of_birth.is_before("2006-01-01"))\n\n'
-            "If passing in multiple arguments, they must all be 'of the same domain', meaning "
-            "you can't combine series from different tables."
+            "If passing in multiple arguments, they must either have:\n"
+            " - one row per patient (e.g. patients.sex, clinical_events.count_for_patient()), or\n"
+            " - multiple rows per patient AND be from the same table (e.g. clinical_events.date, "
+            "clinical_events.numeric_values)"
         )
 
 
@@ -200,8 +202,8 @@ def related_event_columns_to_records(columns):
 
 
 def is_ehrql_object(element):
-    isDataset = isinstance(element, Dataset)
-    isSeries = isinstance(element, BaseSeries)
-    isDateDifference = isinstance(element, DateDifference)
-    isFrame = isinstance(getattr(element, "_qm_node", None), qm.Frame)
-    return isDataset | isSeries | isDateDifference | isFrame
+    # Currently this is just if the thing is a Frame, BaseSeries, DateDifference
+    # or Dataset, and only used by the show() method. NB - show() doesn't work
+    # with Measures, so this doesn't check for them
+    is_frame = isinstance(getattr(element, "_qm_node", None), qm.Frame)
+    return is_frame | isinstance(element, BaseSeries | DateDifference | Dataset)

--- a/tests/fixtures/good_definition_files/debug_definition.py
+++ b/tests/fixtures/good_definition_files/debug_definition.py
@@ -4,7 +4,7 @@ from ehrql.tables.core import patients
 
 
 dataset = create_dataset()
+show(dataset)
 dataset.sex = patients.sex
-show("Hello")
 dataset.define_population(patients.date_of_birth.is_on_or_after("2000-01-01"))
 dataset.year_of_birth = patients.date_of_birth.year

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -249,7 +249,7 @@ def test_debug_show(tmp_path, capsys):
 
         dataset = create_dataset()
         year = patients.date_of_birth.year
-        show(6, label="Number")
+        show(dataset, label="Number")
         dataset.define_population(year>1980)
         """
     )
@@ -277,7 +277,8 @@ def test_debug_show(tmp_path, capsys):
     expected = textwrap.dedent(
         """\
         Show line 6: Number
-        6
+        patient_id
+        -----------------
         """
     ).strip()
     assert capsys.readouterr().err.strip() == expected

--- a/tests/unit/test_debugger.py
+++ b/tests/unit/test_debugger.py
@@ -386,7 +386,7 @@ def test_show_does_not_raise_error_for_series_from_same_domain(
 def test_show_not_run_outside_debug_context(capsys):
     expected_output = textwrap.dedent(
         """
-        Show line 364:
+        Show line 394:
          - show() ignored because we're not running in debug mode
         """
     ).strip()

--- a/tests/unit/test_debugger.py
+++ b/tests/unit/test_debugger.py
@@ -25,45 +25,35 @@ def test_show(capsys):
     expected_output = textwrap.dedent(
         """
         Show line 32:
-        'Hello'
+
         """
     ).strip()
 
     show("Hello")
     captured = capsys.readouterr()
-    assert captured.err.strip() == expected_output, captured.err
+    assert captured.err.strip().startswith(expected_output), captured.err
 
 
 def test_show_with_label(capsys):
     expected_output = textwrap.dedent(
         """
         Show line 45: Number
-        14
+
         """
     ).strip()
 
     show(14, label="Number")
     captured = capsys.readouterr()
-    assert captured.err.strip() == expected_output, captured.err
+    assert captured.err.strip().startswith(expected_output), captured.err
 
 
-def test_render_string():
-    assert render("Hello") == "'Hello'"
-
-
-def test_render_int_variable():
-    assert render(12) == "12"
-
-
-def test_render_multiple_variables():
-    expected_output = textwrap.dedent(
-        """
-        12
-        'Hello'
-        """
-    ).strip()
-
-    assert render(12, "Hello") == expected_output
+def test_show_fails_for_non_ehrql_object(dummy_tables_path):
+    with activate_debug_context(
+        dummy_tables_path=dummy_tables_path,
+        render_function=lambda value: value,
+    ):
+        with pytest.raises(TypeError):
+            show("Hello")
 
 
 def test_related_patient_columns_to_records_full_join():
@@ -353,3 +343,59 @@ def test_repr_related_date_difference_event_series(dummy_tables_path):
         {"patient_id": 1, "row_id": 2, "series_1": "18262 days", "series_2": "def"},
         {"patient_id": 2, "row_id": 3, "series_1": "9132 days", "series_2": "abc"},
     ]
+
+
+@pytest.mark.parametrize(
+    "example_input",
+    [
+        ((patients, patients.date_of_birth)),
+        ((patients.date_of_birth, events.date)),
+        ((patients.date_of_birth, {"some": "dict"}, patients.sex)),
+        ((init_dataset(), patients.date_of_birth, patients.sex)),
+    ],
+)
+def test_show_fails_for_mismatched_inputs(example_input):
+    with activate_debug_context(
+        dummy_tables_path=dummy_tables_path,
+        render_function=lambda value: value,
+    ):
+        with pytest.raises(TypeError):
+            assert show(*example_input)
+
+
+@pytest.mark.parametrize(
+    "example_input",
+    [
+        ((patients.date_of_birth, events.count_for_patient())),
+        ((patients.date_of_birth, patients.sex)),
+        ((events.date, events.code)),
+        ((patients.date_of_birth, patients.sex == "male")),
+        ((events.date, events.code == "123400")),
+    ],
+)
+def test_show_does_not_raise_error_for_series_from_same_domain(
+    dummy_tables_path, example_input
+):
+    with activate_debug_context(
+        dummy_tables_path=dummy_tables_path,
+        render_function=lambda value: value,
+    ):
+        show(example_input[0], *example_input[1:])
+
+
+def test_show_not_run_outside_debug_context(capsys):
+    expected_output = textwrap.dedent(
+        """
+        Show line 364:
+         - show() ignored because we're not running in debug mode
+        """
+    ).strip()
+
+    show(patients.date_of_birth, patients.sex)
+    captured = capsys.readouterr()
+    assert captured.err.strip() == expected_output, captured.err
+
+
+def test_render_multiple_without_repr_related_errors():
+    with pytest.raises(TypeError):
+        render("hello", "goodbye")

--- a/tests/unit/test_loaders.py
+++ b/tests/unit/test_loaders.py
@@ -122,8 +122,9 @@ def test_load_debug_dataset_definition(funcs, capsys):
     assert (
         capsys.readouterr().err.strip()
         == """
-Show line 8:
-'Hello'
+Show line 7:
+patient_id
+-----------------
 """.strip()
     )
     assert capsys.readouterr().out == ""


### PR DESCRIPTION
New `show` behaviour
- if not debug mode just display ignore message
- if debug mode and single ehrql object then display
- if debug mode and multiple series from same domain then display
- otherwise throw a helpful message