### PR TITLE
Add a proper query model type for datasets

### DIFF
--- a/ehrql/assurance.py
+++ b/ehrql/assurance.py
@@ -10,7 +10,7 @@ UNEXPECTED_NOT_IN_POPULATION = "unexpected-not-in-population"
 UNEXPECTED_OUTPUT_VALUE = "unexpected-output-value"
 
 
-def validate(variable_definitions, test_data):
+def validate(dataset, test_data):
     """Validates that the given test data
     (1) meet the constraints in the tables and
     (2) produce the given expected output.
@@ -23,7 +23,7 @@ def validate(variable_definitions, test_data):
     """
 
     # Create objects to insert into database
-    table_nodes = get_table_nodes(*variable_definitions.values())
+    table_nodes = get_table_nodes(dataset)
 
     constraint_validation_errors = {}
     input_data = {table: [] for table in table_nodes}
@@ -50,8 +50,7 @@ def validate(variable_definitions, test_data):
     # Query the database
     engine = InMemoryQueryEngine(database)
     query_results = {
-        row.patient_id: row._asdict()
-        for row in engine.get_results(variable_definitions)
+        row.patient_id: row._asdict() for row in engine.get_results(dataset)
     }
 
     # Validate results of query

--- a/ehrql/backends/base.py
+++ b/ehrql/backends/base.py
@@ -3,6 +3,7 @@ import re
 import sqlalchemy
 
 from ehrql.query_language import get_tables_from_namespace
+from ehrql.query_model import nodes as qm
 
 
 class ValidationError(Exception): ...
@@ -22,11 +23,11 @@ class BaseBackend:
         """
         return dsn
 
-    def modify_query_variables(self, variables: dict) -> dict:
+    def modify_dataset(self, dataset: qm.Dataset) -> qm.Dataset:
         """
-        This hook gives backends the option to modify queries before they are run
+        This hook gives backends the option to modify the dataset before running it
         """
-        return variables
+        return dataset
 
     def modify_inline_table_args(self, columns, rows):
         """

--- a/ehrql/dummy_data/measures.py
+++ b/ehrql/dummy_data/measures.py
@@ -10,7 +10,7 @@ from ehrql.measures.calculate import (
 )
 from ehrql.query_engines.in_memory import InMemoryQueryEngine
 from ehrql.query_engines.in_memory_database import InMemoryDatabase
-from ehrql.query_model.nodes import Function
+from ehrql.query_model.nodes import Dataset, Function
 
 
 class DummyMeasuresDataGenerator:
@@ -18,7 +18,7 @@ class DummyMeasuresDataGenerator:
         self.measures = measures
         combined = CombinedMeasureComponents.from_measures(measures)
         self.generator = DummyDataGenerator(
-            get_dataset_variables(combined),
+            get_dataset(combined),
             population_size=get_population_size(dummy_data_config, combined),
             timeout=dummy_data_config.timeout,
             **kwargs,
@@ -55,27 +55,26 @@ class CombinedMeasureComponents:
         )
 
 
-def get_dataset_variables(combined):
+def get_dataset(combined):
     """
-    Return a dict of dataset definition variables suitable for passing to the dummy data
-    generator which should produce dummy data of the right shape to use for calculating
-    measures
+    Return a query model dataset suitable for passing to the dummy data generator which
+    should produce dummy data of the right shape to use for calculating measures
     """
-    variable_placeholders = {
+    dataset_placeholders = Dataset(
         # Use the union of all denominators as the population
-        "population": reduce(Function.Or, combined.denominators),
-        **{
+        population=reduce(Function.Or, combined.denominators),
+        variables={
             f"column_{i}": column
             for i, column in enumerate([*combined.numerators, *combined.groups])
         },
-    }
+    )
 
     # Use the maximum range over all intervals as a date range
     min_interval_start = min(interval[0] for interval in combined.intervals)
     max_interval_end = max(interval[1] for interval in combined.intervals)
 
     return substitute_interval_parameters(
-        variable_placeholders, (min_interval_start, max_interval_end)
+        dataset_placeholders, (min_interval_start, max_interval_end)
     )
 
 

--- a/ehrql/dummy_data/query_info.py
+++ b/ehrql/dummy_data/query_info.py
@@ -5,6 +5,7 @@ from functools import cached_property
 from ehrql.query_model.introspection import all_unique_nodes, get_table_nodes
 from ehrql.query_model.nodes import (
     Column,
+    Dataset,
     Function,
     InlinePatientTable,
     SelectColumn,
@@ -98,6 +99,7 @@ class QueryInfo:
 
     @classmethod
     def from_dataset(cls, dataset):
+        assert isinstance(dataset, Dataset)
         all_nodes = all_unique_nodes(dataset)
         by_type = get_nodes_by_type(all_nodes)
 

--- a/ehrql/dummy_data/query_info.py
+++ b/ehrql/dummy_data/query_info.py
@@ -97,8 +97,8 @@ class QueryInfo:
     other_table_names: list[str]
 
     @classmethod
-    def from_variable_definitions(cls, variable_definitions):
-        all_nodes = all_unique_nodes(*variable_definitions.values())
+    def from_dataset(cls, dataset):
+        all_nodes = all_unique_nodes(dataset)
         by_type = get_nodes_by_type(all_nodes)
 
         tables = {
@@ -155,7 +155,7 @@ class QueryInfo:
         # Record which tables are used in determining population membership and which
         # are not
         population_table_names = {
-            node.name for node in get_table_nodes(variable_definitions["population"])
+            node.name for node in get_table_nodes(dataset.population)
         }
 
         other_table_names = tables.keys() - population_table_names

--- a/ehrql/dummy_data_nextgen/query_info.py
+++ b/ehrql/dummy_data_nextgen/query_info.py
@@ -113,6 +113,7 @@ class QueryInfo:
 
     @classmethod
     def from_dataset(cls, dataset):
+        assert isinstance(dataset, Dataset)
         all_nodes = all_unique_nodes(dataset)
         by_type = get_nodes_by_type(all_nodes)
 

--- a/ehrql/measures/calculate.py
+++ b/ehrql/measures/calculate.py
@@ -213,7 +213,8 @@ def series_as_int(series):
             {
                 Function.EQ(series, Value(True)): Value(1),
                 Function.EQ(series, Value(False)): Value(0),
-            }
+            },
+            default=None,
         )
     else:
         assert False

--- a/ehrql/query_engines/base_sql.py
+++ b/ehrql/query_engines/base_sql.py
@@ -91,16 +91,7 @@ class BaseSQLQueryEngine(BaseQueryEngine):
         needed to create these tables and clean them up can be retrieved by calling
         `get_setup_and_cleanup_queries` on the query object.
         """
-        # Temporarily continue to accept dicts of variable definitions so we don't need
-        # to change everything in one go
-        if isinstance(dataset, dict):
-            dataset = Dataset(
-                population=dataset["population"],
-                variables={k: v for k, v in dataset.items() if k != "population"},
-            )
-        else:
-            assert isinstance(dataset, Dataset)
-
+        assert isinstance(dataset, Dataset)
         dataset = self.backend.modify_dataset(dataset)
         dataset = apply_transforms(dataset)
 

--- a/ehrql/query_engines/base_sql.py
+++ b/ehrql/query_engines/base_sql.py
@@ -15,6 +15,7 @@ from ehrql.backends.base import DefaultSQLBackend
 from ehrql.query_model.nodes import (
     AggregateByPatient,
     Case,
+    Dataset,
     Filter,
     Function,
     InlinePatientTable,
@@ -82,20 +83,30 @@ class BaseSQLQueryEngine(BaseQueryEngine):
         self.counter += 1
         return self.counter
 
-    def get_query(self, variable_definitions):
+    def get_query(self, dataset):
         """
-        Return the SQL query to fetch the results for `variable_definitions`
+        Return the SQL query to fetch the results for `dataset`
 
         Note that this query might make use of intermediate tables. The SQL queries
         needed to create these tables and clean them up can be retrieved by calling
         `get_setup_and_cleanup_queries` on the query object.
         """
-        variable_definitions = self.backend.modify_query_variables(variable_definitions)
-        variable_definitions = apply_transforms(variable_definitions)
+        # Temporarily continue to accept dicts of variable definitions so we don't need
+        # to change everything in one go
+        if isinstance(dataset, dict):
+            dataset = Dataset(
+                population=dataset["population"],
+                variables={k: v for k, v in dataset.items() if k != "population"},
+            )
+        else:
+            assert isinstance(dataset, Dataset)
+
+        dataset = self.backend.modify_dataset(dataset)
+        dataset = apply_transforms(dataset)
 
         # Generate a table containing the IDs all of patients matching the population
         # definition
-        population_expression = self.get_predicate(variable_definitions["population"])
+        population_expression = self.get_predicate(dataset.population)
         select_patient_id = self.select_patient_id_for_population(population_expression)
         population_query = select_patient_id.where(population_expression)
         population_query = apply_patient_joins(population_query)
@@ -106,8 +117,7 @@ class BaseSQLQueryEngine(BaseQueryEngine):
 
         variable_expressions = {
             name: self.get_expr(definition)
-            for name, definition in variable_definitions.items()
-            if name != "population"
+            for name, definition in dataset.variables.items()
         }
         query = sqlalchemy.select(population_table.c.patient_id)
         query = query.add_columns(

--- a/ehrql/query_engines/in_memory.py
+++ b/ehrql/query_engines/in_memory.py
@@ -35,15 +35,7 @@ class InMemoryQueryEngine(BaseQueryEngine):
             yield Row(**record)
 
     def get_results_as_table(self, dataset):
-        # Temporarily continue to accept dicts of variable definitions so we don't need
-        # to change everything in one go
-        if isinstance(dataset, dict):
-            dataset = qm.Dataset(
-                population=dataset["population"],
-                variables={k: v for k, v in dataset.items() if k != "population"},
-            )
-        else:
-            assert isinstance(dataset, qm.Dataset)
+        assert isinstance(dataset, qm.Dataset)
 
         self.cache = {}
 

--- a/ehrql/query_engines/local_file.py
+++ b/ehrql/query_engines/local_file.py
@@ -14,14 +14,14 @@ class LocalFileQueryEngine(InMemoryQueryEngine):
 
     database = None
 
-    def get_results(self, variable_definitions):
-        # Given the variables supplied determine the tables used and load the associated
+    def get_results(self, dataset):
+        # Given the dataset supplied determine the tables used and load the associated
         # data into the database
         self.populate_database(
-            get_table_nodes(*variable_definitions.values()),
+            get_table_nodes(dataset),
         )
         # Run the query as normal
-        return super().get_results(variable_definitions)
+        return super().get_results(dataset)
 
     def populate_database(self, table_nodes, allow_missing_columns=True):
         table_specs = {

--- a/ehrql/query_model/graphs.py
+++ b/ehrql/query_model/graphs.py
@@ -10,14 +10,15 @@ import pydot
 from ehrql.query_model import nodes
 
 
-def graph_to_svg(variable_definitions, output_path):  # pragma: no cover
-    graph = build_graph(variable_definitions)
+def graph_to_svg(dataset, output_path):  # pragma: no cover
+    graph = build_graph(dataset)
     graph.write_svg(output_path)
 
 
-def build_graph(variable_definitions):
+def build_graph(dataset):
     G = nx.DiGraph()
-    for name, node in variable_definitions.items():
+    columns = [("population", dataset.population), *dataset.variables.items()]
+    for name, node in columns:
         G.add_node(name)
         G.add_node(get_id(node), label=get_label(node))
         G.add_edge(name, get_id(node))
@@ -29,7 +30,7 @@ def build_graph(variable_definitions):
     # Ensure that all variables line up at the top of the graph
     P = nx.nx_pydot.to_pydot(G)
     cluster = pydot.Cluster(rank="min", style="invis")
-    for name in variable_definitions:
+    for name, _ in columns:
         cluster.add_node(pydot.Node(get_id(name)))
     P.add_subgraph(cluster)
 

--- a/ehrql/query_model/nodes.py
+++ b/ehrql/query_model/nodes.py
@@ -621,7 +621,7 @@ def get_domain_for_filter(node):
 # Operations of these types are guaranteed to produce output in the patient domain
 @get_domain.register(OneRowPerPatientFrame)
 @get_domain.register(OneRowPerPatientSeries)
-def get_domains_for_one_row_per_patient_operations(node):
+def get_domain_for_one_row_per_patient_operations(node):
     return Domain.PATIENT
 
 

--- a/ehrql/query_model/nodes.py
+++ b/ehrql/query_model/nodes.py
@@ -443,7 +443,7 @@ class Function:
 
 class Case(Series[T]):
     cases: Mapping[Series[bool], Series[T] | None]
-    default: Series[T] | None = None
+    default: Series[T] | None
 
     def __hash__(self):
         # `cases` is a dict and so not naturally hashable, but we treat it as immutable.

--- a/ehrql/query_model/population_validation.py
+++ b/ehrql/query_model/population_validation.py
@@ -1,6 +1,7 @@
 from ehrql.query_engines.in_memory import InMemoryQueryEngine
 from ehrql.query_engines.in_memory_database import EventTable, PatientTable
 from ehrql.query_model.nodes import (
+    Dataset,
     Series,
     ValidationError,
     get_series_type,
@@ -94,7 +95,7 @@ class EmptyQueryEngine(InMemoryQueryEngine):
         return {1}
 
     def series_evaluates_true(self, series):
-        results = self.get_results({"population": series})
+        results = self.get_results(Dataset(population=series, variables={}))
         return bool(list(results))
 
     def visit_SelectTable(self, node):

--- a/ehrql/query_model/transforms.py
+++ b/ehrql/query_model/transforms.py
@@ -40,12 +40,12 @@ class PickOneRowPerPatientWithColumns(PickOneRowPerPatient):
     selected_columns: Set[Series[Any]]
 
 
-def apply_transforms(variables):
+def apply_transforms(root_node):
     # Note that we're currently sharing `rewriter`, `nodes` and `reverse_index` across
     # transforms. While we only have one this is obviously fine! It _might_ be OK as we
     # add more depending on whether they're commutative but we should be careful here
     # and might decide we want to restructure things to keep the transforms independent.
-    nodes = all_unique_nodes(*variables.values())
+    nodes = all_unique_nodes(root_node)
     reverse_index = build_reverse_index(nodes)
 
     transforms = [
@@ -56,7 +56,7 @@ def apply_transforms(variables):
     for type_, transform in transforms:
         apply_transform(rewriter, type_, transform, nodes, reverse_index)
 
-    return rewriter.rewrite(variables)
+    return rewriter.rewrite(root_node)
 
 
 def apply_transform(rewriter, type_, transform, nodes, reverse_index):
@@ -188,10 +188,10 @@ def build_reverse_index(nodes):
     return reverse_index
 
 
-def substitute_parameters(variable_definitions, **parameter_values):
+def substitute_parameters(node, **parameter_values):
     rewriter = QueryGraphRewriter()
     for name, value in parameter_values.items():
         value_type = type(value)
         parameter = Parameter(name, value_type)
         rewriter.replace(parameter, Value(value))
-    return rewriter.rewrite(variable_definitions)
+    return rewriter.rewrite(node)

--- a/tests/generative/test_query_model.py
+++ b/tests/generative/test_query_model.py
@@ -15,6 +15,7 @@ from ehrql.query_model.introspection import all_unique_nodes
 from ehrql.query_model.nodes import (
     AggregateByPatient,
     Column,
+    Dataset,
     Function,
     Parameter,
     SelectColumn,
@@ -372,6 +373,9 @@ def test_variable_strategy_is_comprehensive():
         # Parameters don't themselves form part of valid queries: they are placeholders
         # which must all be replaced with Values before the query can be executed.
         Parameter,
+        # This is a structure which we put the generated operations into, but don't
+        # expect to generate itself
+        Dataset,
     }
     all_operations = set(get_all_operations())
     unexpected_missing = all_operations - known_missing_operations - operations_seen

--- a/tests/generative/test_query_model.py
+++ b/tests/generative/test_query_model.py
@@ -177,10 +177,10 @@ def test_query_model(
 
 
 def run_test(query_engines, data, population, variable, recorder):
-    instances, variables = setup_test(data, population, variable)
+    instances, dataset = setup_test(data, population, variable)
 
     all_results = {
-        name: run_with(engine, instances, variables)
+        name: run_with(engine, instances, dataset)
         for name, engine in query_engines.items()
     }
 
@@ -213,7 +213,7 @@ def run_test(query_engines, data, population, variable, recorder):
     first_results = results.pop(first_name)
     # If the results contain floats then we want only approximate equality to account
     # for rounding differences
-    if any(get_series_type(v) is float for v in variables.values()):
+    if any(get_series_type(v) is float for v in dataset.variables.values()):
         first_results = [pytest.approx(row, rel=1e-5) for row in first_results]
 
     for other_name, other_results in results.items():
@@ -224,11 +224,11 @@ def run_test(query_engines, data, population, variable, recorder):
 
 def setup_test(data, population, variable):
     instances = instantiate(data)
-    variables = {
-        "population": population,
-        "v": variable,
-    }
-    return instances, variables
+    dataset = Dataset(
+        population=population,
+        variables={"v": variable},
+    )
+    return instances, dataset
 
 
 def instantiate(data):
@@ -280,7 +280,7 @@ def run_dummy_data_test_without_error_handling(population, variable, next_gen=Fa
     dummy = dummy_data_nextgen if next_gen else dummy_data
 
     dummy_data_generator = dummy.DummyDataGenerator(
-        {"population": population, "v": variable},
+        Dataset(population=population, variables={"v": variable}),
         population_size=1,
         # We need a batch size bigger than one otherwise by chance (or, more strictly,
         # by deterministic combination of query and fixed random seed) we can end up
@@ -300,7 +300,7 @@ def run_dummy_data_test_without_error_handling(population, variable, next_gen=Fa
     # Using a simplified population definition which should always have matching patients
     # we can confirm that we generate at least some data
     dummy_data_generator = dummy.DummyDataGenerator(
-        {"population": all_patients_query, "v": variable},
+        Dataset(population=all_patients_query, variables={"v": variable}),
         population_size=1,
         batch_size=1,
         timeout=-1,

--- a/tests/integration/query_engines/test_mssql.py
+++ b/tests/integration/query_engines/test_mssql.py
@@ -9,6 +9,7 @@ from sqlalchemy.sql import Select
 from ehrql.query_model.nodes import (
     AggregateByPatient,
     Column,
+    Dataset,
     SelectColumn,
     SelectPatientTable,
     TableSchema,
@@ -18,9 +19,9 @@ from ehrql.query_model.nodes import (
 def test_get_results_with_retries(mssql_engine):
     # Define a simple query and load some test data
     patient_table = SelectPatientTable("patients", TableSchema(i=Column(int)))
-    variable_definitions = dict(
+    dataset = Dataset(
         population=AggregateByPatient.Exists(patient_table),
-        i=SelectColumn(patient_table, "i"),
+        variables={"i": SelectColumn(patient_table, "i")},
     )
     mssql_engine.populate(
         {
@@ -39,7 +40,7 @@ def test_get_results_with_retries(mssql_engine):
             None,
         ]
 
-        results = mssql_engine.extract_qm(variable_definitions)
+        results = mssql_engine.extract_qm(dataset)
 
         assert results == [
             {"patient_id": 1, "i": 10},

--- a/tests/integration/query_engines/test_trino_dialect.py
+++ b/tests/integration/query_engines/test_trino_dialect.py
@@ -1,6 +1,7 @@
 from ehrql.query_model.nodes import (
     AggregateByPatient,
     Column,
+    Dataset,
     Function,
     InlinePatientTable,
     SelectColumn,
@@ -20,10 +21,10 @@ def test_float_precision(trino_engine):
     f1 = SelectColumn(t, "f1")
     f2 = SelectColumn(t, "f2")
 
-    variables = {
-        "population": AggregateByPatient.Exists(t),
-        "v": Function.Subtract(f1, Function.Add(f1, f2)),
-    }
+    dataset = Dataset(
+        population=AggregateByPatient.Exists(t),
+        variables={"v": Function.Subtract(f1, Function.Add(f1, f2))},
+    )
 
-    results = trino_engine.extract_qm(variables)
+    results = trino_engine.extract_qm(dataset)
     assert results[0]["v"] == v1 - (v1 + v2)

--- a/tests/integration/query_model/test_transforms.py
+++ b/tests/integration/query_model/test_transforms.py
@@ -1,5 +1,6 @@
 from ehrql.query_model.nodes import (
     AggregateByPatient,
+    Dataset,
     PickOneRowPerPatient,
     Position,
     SelectColumn,
@@ -45,8 +46,9 @@ def test_sort_booleans_null_first(engine):
         "b",
     )
     population = AggregateByPatient.Exists(events)
+    dataset = Dataset(population=population, variables={"v": variable})
 
-    assert engine.extract_qm(dict(v=variable, population=population)) == [
+    assert engine.extract_qm(dataset) == [
         dict(patient_id=0, v=True),  # True sorts after False
         dict(patient_id=1, v=True),  # True sorts after NULL
         dict(patient_id=2, v=False),  # False sorts after NULL

--- a/tests/lib/gentest_example_simplify.py
+++ b/tests/lib/gentest_example_simplify.py
@@ -172,14 +172,12 @@ class QueryModelRepr:
     def repr_node(self, value):
         args = []
         kwargs = {}
-        for field in dataclasses.fields(value):
-            if field.default is dataclasses.MISSING:
-                assert (
-                    not kwargs
-                ), "Required fields must come before all optional fields"
-                args.append(getattr(value, field.name))
-            else:
-                kwargs[field.name] = getattr(value, field.name)
+        fields = dataclasses.fields(value)
+        # Single argument nodes use positional arguments for brevity
+        if len(fields) == 1:
+            args = [getattr(value, fields[0].name)]
+        else:
+            kwargs = {field.name: getattr(value, field.name) for field in fields}
         return self.repr_init(value, args, kwargs)
 
     @repr_value.register(list)

--- a/tests/lib/test_gentest_example_simplify.py
+++ b/tests/lib/test_gentest_example_simplify.py
@@ -29,7 +29,8 @@ def test_gentest_example_simplify():
                 Value(True): Function.MaximumOf(
                     (SelectColumn(SelectPatientTable("p0", schema), "i1"),),
                 )
-            }
+            },
+            default=None,
         ),
         Value(frozenset({1, 2, 3})),
     )

--- a/tests/unit/dummy_data/test_query_info.py
+++ b/tests/unit/dummy_data/test_query_info.py
@@ -32,7 +32,7 @@ class events(EventFrame):
     code = Series(CTV3Code)
 
 
-def test_query_info_from_variable_definitions():
+def test_query_info_from_dataset():
     dataset = Dataset()
     dataset.define_population(events.exists_for_patient())
     dataset.date_of_birth = patients.date_of_birth
@@ -41,8 +41,7 @@ def test_query_info_from_variable_definitions():
         events.code == CTV3Code("abc00")
     ).exists_for_patient()
 
-    variable_definitions = dataset._compile()
-    query_info = QueryInfo.from_variable_definitions(variable_definitions)
+    query_info = QueryInfo.from_dataset(dataset._compile())
 
     assert query_info == QueryInfo(
         tables={
@@ -98,8 +97,7 @@ def test_query_info_records_values():
         | test_table.value.contains("d")
     )
 
-    variable_definitions = dataset._compile()
-    query_info = QueryInfo.from_variable_definitions(variable_definitions)
+    query_info = QueryInfo.from_dataset(dataset._compile())
     column_info = query_info.tables["test_table"].columns["value"]
 
     assert column_info == ColumnInfo(
@@ -126,8 +124,7 @@ def test_query_info_ignores_inline_patient_tables():
         | inline_table.value.contains("d")
     )
 
-    variable_definitions = dataset._compile()
-    query_info = QueryInfo.from_variable_definitions(variable_definitions)
+    query_info = QueryInfo.from_dataset(dataset._compile())
 
     assert query_info == QueryInfo(
         tables={
@@ -149,9 +146,8 @@ def test_query_info_ignores_complex_comparisons():
     dataset.q1 = patients.date_of_birth.year.is_in([2000, 2010, 2020])
     dataset.q2 = patients.date_of_birth + days(100) == "2021-10-20"
     dataset.q3 = patients.date_of_birth == "2022-10-05"
-    variable_definitions = dataset._compile()
 
-    query_info = QueryInfo.from_variable_definitions(variable_definitions)
+    query_info = QueryInfo.from_dataset(dataset._compile())
     column_info = query_info.tables["patients"].columns["date_of_birth"]
 
     assert column_info.values_used == [datetime.date(2022, 10, 5)]

--- a/tests/unit/dummy_data_nextgen/test_edge_cases_for_coverage.py
+++ b/tests/unit/dummy_data_nextgen/test_edge_cases_for_coverage.py
@@ -10,6 +10,7 @@ from ehrql.query_language import (
 )
 from ehrql.query_model.nodes import (
     Case,
+    Dataset,
     Function,
     SelectColumn,
     SelectPatientTable,
@@ -59,20 +60,22 @@ def test_minimum_of_values_is_value():
 
 
 def test_some_nonsense():
-    QueryInfo.from_variable_definitions(
-        {
-            "population": Function.LT(
+    QueryInfo.from_dataset(
+        Dataset(
+            population=Function.LT(
                 lhs=Case(
                     cases={SelectColumn(source=p0, name="b1"): None},
                     default=Value(value=date(2010, 1, 1)),
                 ),
                 rhs=Value(value=date(2010, 1, 1)),
             ),
-            "v": SelectColumn(
-                source=p0,
-                name="i1",
-            ),
-        }
+            variables={
+                "v": SelectColumn(
+                    source=p0,
+                    name="i1",
+                ),
+            },
+        )
     )
 
 

--- a/tests/unit/dummy_data_nextgen/test_query_info.py
+++ b/tests/unit/dummy_data_nextgen/test_query_info.py
@@ -32,7 +32,7 @@ class events(EventFrame):
     code = Series(CTV3Code)
 
 
-def test_query_info_from_variable_definitions():
+def test_query_info_from_dataset():
     dataset = Dataset()
     dataset.define_population(events.exists_for_patient())
     dataset.date_of_birth = patients.date_of_birth
@@ -41,8 +41,7 @@ def test_query_info_from_variable_definitions():
         events.code == CTV3Code("abc00")
     ).exists_for_patient()
 
-    variable_definitions = dataset._compile()
-    query_info = QueryInfo.from_variable_definitions(variable_definitions)
+    query_info = QueryInfo.from_dataset(dataset._compile())
 
     assert query_info == QueryInfo(
         tables={
@@ -98,8 +97,7 @@ def test_query_info_records_values():
         | test_table.value.contains("d")
     )
 
-    variable_definitions = dataset._compile()
-    query_info = QueryInfo.from_variable_definitions(variable_definitions)
+    query_info = QueryInfo.from_dataset(dataset._compile())
     column_info = query_info.tables["test_table"].columns["value"]
 
     assert column_info._values_used == {"a", "b", "c", "d"}
@@ -122,8 +120,7 @@ def test_query_info_ignores_inline_patient_tables():
         | inline_table.value.contains("d")
     )
 
-    variable_definitions = dataset._compile()
-    query_info = QueryInfo.from_variable_definitions(variable_definitions)
+    query_info = QueryInfo.from_dataset(dataset._compile())
 
     assert query_info == QueryInfo(
         tables={
@@ -145,9 +142,8 @@ def test_query_info_ignores_complex_comparisons():
     dataset.q1 = patients.date_of_birth.year.is_in([2000, 2010, 2020])
     dataset.q2 = patients.date_of_birth + days(100) == "2021-10-20"
     dataset.q3 = patients.date_of_birth == "2022-10-05"
-    variable_definitions = dataset._compile()
 
-    query_info = QueryInfo.from_variable_definitions(variable_definitions)
+    query_info = QueryInfo.from_dataset(dataset._compile())
     column_info = query_info.tables["patients"].columns["date_of_birth"]
 
     assert column_info.values_used == [datetime.date(2022, 10, 5)]

--- a/tests/unit/query_model/test_column_specs.py
+++ b/tests/unit/query_model/test_column_specs.py
@@ -88,6 +88,7 @@ def test_get_categories_for_case_with_static_values():
             Function.LT(event_name, Value("lmn")): Value("med"),
             Function.GE(event_name, Value("lmn")): Value("high"),
         },
+        default=None,
     )
     assert get_categories(name_bucket) == ("low", "med", "high")
 

--- a/tests/unit/query_model/test_column_specs.py
+++ b/tests/unit/query_model/test_column_specs.py
@@ -12,6 +12,7 @@ from ehrql.query_model.nodes import (
     Case,
     Column,
     Constraint,
+    Dataset,
     Function,
     SelectColumn,
     SelectPatientTable,
@@ -37,13 +38,15 @@ def test_get_column_specs():
             ),
         ),
     )
-    variables = dict(
+    dataset = Dataset(
         population=AggregateByPatient.Exists(patients),
-        dob=SelectColumn(patients, "date_of_birth"),
-        code=SelectColumn(patients, "code"),
-        category=SelectColumn(patients, "category"),
+        variables=dict(
+            dob=SelectColumn(patients, "date_of_birth"),
+            code=SelectColumn(patients, "code"),
+            category=SelectColumn(patients, "category"),
+        ),
     )
-    column_specs = get_column_specs(variables)
+    column_specs = get_column_specs(dataset)
     assert column_specs == {
         "patient_id": ColumnSpec(type=int, nullable=False, categories=None),
         "dob": ColumnSpec(type=datetime.date, nullable=True, categories=None),

--- a/tests/unit/query_model/test_nodes.py
+++ b/tests/unit/query_model/test_nodes.py
@@ -10,6 +10,7 @@ from ehrql.query_model.nodes import (
     AggregateByPatient,
     Case,
     Column,
+    Dataset,
     DomainMismatchError,
     Filter,
     Frame,
@@ -350,6 +351,33 @@ def test_cannot_aggregate_a_one_row_per_patient_series():
     first_date = SelectColumn(first_event, "date")
     with pytest.raises(DomainMismatchError):
         AggregateByPatient.Max(first_date)
+
+
+def test_can_construct_dataset():
+    events = SelectTable("events", EVENTS_SCHEMA)
+    dates = SelectColumn(events, "date")
+    assert Dataset(
+        population=AggregateByPatient.Exists(events),
+        variables={"max_date": AggregateByPatient.Max(dates)},
+    )
+
+
+def test_can_construct_dataset_with_no_variables():
+    events = SelectTable("events", EVENTS_SCHEMA)
+    assert Dataset(
+        population=AggregateByPatient.Exists(events),
+        variables={},
+    )
+
+
+def test_cannot_use_event_series_in_a_dataset():
+    events = SelectTable("events", EVENTS_SCHEMA)
+    dates = SelectColumn(events, "date")
+    with pytest.raises(DomainMismatchError):
+        Dataset(
+            population=AggregateByPatient.Exists(events),
+            variables={"date": dates},
+        )
 
 
 def test_domain_get_node():

--- a/tests/unit/query_model/test_population_validation.py
+++ b/tests/unit/query_model/test_population_validation.py
@@ -178,16 +178,6 @@ cases = [
         ),
     ),
     (
-        False,
-        Case(
-            {
-                Function.EQ(patients_value, Value(1)): Value("foo"),
-                Function.EQ(patients_value, Value(2)): Value("bar"),
-            },
-            default=None,
-        ),
-    ),
-    (
         True,
         Function.StringContains(Value("foobar"), Value("oba")),
     ),

--- a/tests/unit/test_loaders.py
+++ b/tests/unit/test_loaders.py
@@ -10,6 +10,7 @@ from ehrql import loaders
 from ehrql.loaders import DefinitionError
 from ehrql.measures.measures import DisclosureControlConfig
 from ehrql.query_language import DummyDataConfig
+from ehrql.query_model.nodes import Dataset
 
 
 FIXTURES_GOOD = Path(__file__).parents[1] / "fixtures" / "good_definition_files"
@@ -73,8 +74,8 @@ def funcs(request):
 
 def test_load_dataset_definition(funcs, capsys):
     filename = FIXTURES_GOOD / "dataset_definition.py"
-    variables, dummy_data_config = funcs.load_dataset_definition(filename)
-    assert isinstance(variables, dict)
+    dataset, dummy_data_config = funcs.load_dataset_definition(filename)
+    assert isinstance(dataset, Dataset)
     assert isinstance(dummy_data_config, DummyDataConfig)
     # Check the subprocess doesn't emit warnings
     assert capsys.readouterr().err == ""
@@ -82,8 +83,8 @@ def test_load_dataset_definition(funcs, capsys):
 
 def test_load_dataset_definition_with_print(funcs, capsys):
     filename = FIXTURES_GOOD / "dataset_definition_with_print.py"
-    variables, dummy_data_config = funcs.load_dataset_definition(filename)
-    assert isinstance(variables, dict)
+    dataset, dummy_data_config = funcs.load_dataset_definition(filename)
+    assert isinstance(dataset, Dataset)
     assert isinstance(dummy_data_config, DummyDataConfig)
     out, err = capsys.readouterr()
     assert "user stdout" not in out
@@ -106,8 +107,8 @@ def test_load_measure_definitions(funcs, capsys):
 
 def test_load_test_definition(funcs, capsys):
     filename = FIXTURES_GOOD / "assurance.py"
-    variables, test_data = funcs.load_test_definition(filename)
-    assert isinstance(variables, dict)
+    dataset, test_data = funcs.load_test_definition(filename)
+    assert isinstance(dataset, Dataset)
     assert isinstance(test_data, dict)
     # Check the subprocess doesn't emit warnings
     assert capsys.readouterr().err == ""


### PR DESCRIPTION
This replaces the "dict with implicitly special population key" that we used to use here. This was always a bit of a nasty corner of the code; but the specific motivation for doing this now is that we're going to want to make this a richer type which can contain not just patient variables but optionally collections of event variables as well. We can't model this with plain dicts.

The changes here are pretty much mechanical, and entirely driven by failing tests, but not quite amenable to just doing by regex replacement.