### PR TITLE
Better error message for `MultiCodeString` `is_in()` and `is_not_in()`

### DIFF
--- a/docs/includes/generated_docs/language__series.md
+++ b/docs/includes/generated_docs/language__series.md
@@ -2307,9 +2307,8 @@ Note that `other` must be of the same type as this series.
   <a class="headerlink" href="#MultiCodeStringPatientSeries.is_in" title="Permanent link">🔗</a>
 </div>
 <div markdown="block" class="indent">
-Return a boolean series which is True for each value in this series which is
-contained in `other`, where `other` can be any of the standard "container"
-types (tuple, list, set, frozenset, or dict) or another event series.
+This operation is not allowed. To check for the presence of any codes in
+a codelist, please use the `contains_any_of(codelist)` method instead.
 </div>
 
 <div class="attr-heading" id="MultiCodeStringPatientSeries.is_not_in">
@@ -2317,7 +2316,10 @@ types (tuple, list, set, frozenset, or dict) or another event series.
   <a class="headerlink" href="#MultiCodeStringPatientSeries.is_not_in" title="Permanent link">🔗</a>
 </div>
 <div markdown="block" class="indent">
-Return the inverse of `is_in()` above.
+This operation is not allowed. To check for the absence of all codes in a codelist,
+from a column called `column`, please use `~column.contains_any_of(codelist)`.
+NB the `contains_any_of(codelist)` will provide any records that contain any of the
+codes, which is then negated with the `~` operator.
 </div>
 
 <div class="attr-heading" id="MultiCodeStringPatientSeries.map_values">
@@ -2425,9 +2427,8 @@ Note that `other` must be of the same type as this series.
   <a class="headerlink" href="#MultiCodeStringEventSeries.is_in" title="Permanent link">🔗</a>
 </div>
 <div markdown="block" class="indent">
-Return a boolean series which is True for each value in this series which is
-contained in `other`, where `other` can be any of the standard "container"
-types (tuple, list, set, frozenset, or dict) or another event series.
+This operation is not allowed. To check for the presence of any codes in
+a codelist, please use the `contains_any_of(codelist)` method instead.
 </div>
 
 <div class="attr-heading" id="MultiCodeStringEventSeries.is_not_in">
@@ -2435,7 +2436,10 @@ types (tuple, list, set, frozenset, or dict) or another event series.
   <a class="headerlink" href="#MultiCodeStringEventSeries.is_not_in" title="Permanent link">🔗</a>
 </div>
 <div markdown="block" class="indent">
-Return the inverse of `is_in()` above.
+This operation is not allowed. To check for the absence of all codes in a codelist,
+from a column called `column`, please use `~column.contains_any_of(codelist)`.
+NB the `contains_any_of(codelist)` will provide any records that contain any of the
+codes, which is then negated with the `~` operator.
 </div>
 
 <div class="attr-heading" id="MultiCodeStringEventSeries.map_values">

--- a/ehrql/query_language.py
+++ b/ehrql/query_language.py
@@ -1129,6 +1129,20 @@ class MultiCodeStringFunctions:
             "`.contains_any_of(codelist)` instead."
         )
 
+    def is_not_in(self, other):
+        """
+        This operation is not allowed. To check for the absence of all codes in a codelist,
+        from a column called `column`, please use `~column.contains_any_of(codelist)`.
+        NB the `contains_any_of(codelist)` will provide any records that contain any of the
+        codes, which is then negated with the `~` operator.
+        """
+        raise TypeError(
+            "You are attempting to use `.is_not_in()` on a column that contains multiple "
+            "clinical codes joined together. This is not allowed. If you want to know "
+            "if the column does not contain any of the codes from a codelist, then please use "
+            "`~column.contains_any_of(codelist)` instead."
+        )
+
     def contains(self, code):
         """
         Check if the list of codes contains a specific code string. This can

--- a/ehrql/query_language.py
+++ b/ehrql/query_language.py
@@ -1117,6 +1117,18 @@ class MultiCodeStringFunctions:
             "please use the `contains()` method"
         )
 
+    def is_in(self, other):
+        """
+        This operation is not allowed. To check for the presence of any codes in
+        a codelist, please use the `contains_any_of(codelist)` method instead.
+        """
+        raise TypeError(
+            "You are attempting to use `.is_in()` on a column that contains multiple "
+            "clinical codes joined together. This is not allowed. If you want to know "
+            "if the field contains any of the codes from a codelist, then please use "
+            "`.contains_any_of(codelist)` instead."
+        )
+
     def contains(self, code):
         """
         Check if the list of codes contains a specific code string. This can

--- a/tests/unit/test_query_language.py
+++ b/tests/unit/test_query_language.py
@@ -1088,6 +1088,10 @@ def test_icd10_multi_code_string_series_throws_on_invalid_comparison():
     with pytest.raises(TypeError):
         a.icd10_code_string != "I000"
 
+    # We don't allow is_in
+    with pytest.raises(TypeError):
+        a.icd10_code_string.is_in(["I000"])
+
     # ICD10 string prefixes must be valid prefixes
     with pytest.raises(TypeError):
         a.icd10_code_string.contains("ZZ2")
@@ -1109,6 +1113,10 @@ def test_opcs4_multi_code_string_series_throws_on_invalid_comparison():
     # We don't allow !=
     with pytest.raises(TypeError):
         a.opcs4_code_string != "I000"
+
+    # We don't allow is_in
+    with pytest.raises(TypeError):
+        a.opcs4_code_string.is_in(["I000"])
 
     # OPCS4 string prefixes must be valid prefixes
     with pytest.raises(TypeError):

--- a/tests/unit/test_query_language.py
+++ b/tests/unit/test_query_language.py
@@ -1092,6 +1092,10 @@ def test_icd10_multi_code_string_series_throws_on_invalid_comparison():
     with pytest.raises(TypeError):
         a.icd10_code_string.is_in(["I000"])
 
+    # We don't allow is_not_in
+    with pytest.raises(TypeError):
+        a.icd10_code_string.is_not_in(["I000"])
+
     # ICD10 string prefixes must be valid prefixes
     with pytest.raises(TypeError):
         a.icd10_code_string.contains("ZZ2")
@@ -1117,6 +1121,10 @@ def test_opcs4_multi_code_string_series_throws_on_invalid_comparison():
     # We don't allow is_in
     with pytest.raises(TypeError):
         a.opcs4_code_string.is_in(["I000"])
+
+    # We don't allow is_not_in
+    with pytest.raises(TypeError):
+        a.opcs4_code_string.is_not_in(["I000"])
 
     # OPCS4 string prefixes must be valid prefixes
     with pytest.raises(TypeError):


### PR DESCRIPTION
Following recent changes, `is_in()` and `is_not_in()` for `MultiCodeString`s throw errors as it's almost certain the behaviour people actually want is `contains_any_of()`. This improves the error messages, and docs, to point people to the right method.