### PR TITLE
Improved autocomplete for most ehrql things

### DIFF
--- a/ehrql/docs/language.py
+++ b/ehrql/docs/language.py
@@ -19,6 +19,7 @@ EXCLUDE_FROM_DOCS = {
     ql.when,
     ql.DummyDataConfig,
     ql.Error,
+    ql.int_property,  # Internal thing for type hints and autocomplete
 }
 
 

--- a/ehrql/query_language.py
+++ b/ehrql/query_language.py
@@ -290,7 +290,7 @@ class BaseSeries:
         """
         return self.is_null().__invert__()
 
-    def when_null_then(self, other):
+    def when_null_then(self: T, other: T) -> T:
         """
         Replace any NULL value in this series with the corresponding value in `other`.
 
@@ -377,7 +377,7 @@ class EventSeries(BaseSeries):
         # Register the series using its `_type` attribute
         REGISTERED_TYPES[cls._type, False] = cls
 
-    def count_distinct_for_patient(self):
+    def count_distinct_for_patient(self) -> "IntPatientSeries":
         """
         Return a integer patient series counting the number of distinct values for each
         patient in the series (ignoring any NULL values). Not that if a patient has no
@@ -391,7 +391,7 @@ class EventSeries(BaseSeries):
 
 
 class BoolFunctions:
-    def __and__(self, other):
+    def __and__(self: T, other: T) -> T:
         """
         Logical AND
 
@@ -401,7 +401,7 @@ class BoolFunctions:
         other = self._cast(other)
         return _apply(qm.Function.And, self, other)
 
-    def __or__(self, other):
+    def __or__(self: T, other: T) -> T:
         """
         Logical OR
 
@@ -411,7 +411,7 @@ class BoolFunctions:
         other = self._cast(other)
         return _apply(qm.Function.Or, self, other)
 
-    def __invert__(self):
+    def __invert__(self: T) -> T:
         """
         Logical NOT
 
@@ -579,7 +579,7 @@ class NumericFunctions(ComparableFunctions):
     def __rfloordiv__(self, other):
         return self // other
 
-    def __neg__(self):
+    def __neg__(self: T) -> T:
         """
         Return the negation of each value in this series.
         """
@@ -605,7 +605,7 @@ class NumericAggregations(ComparableAggregations):
         """
         return _apply(qm.AggregateByPatient.Sum, self)
 
-    def mean_for_patient(self):
+    def mean_for_patient(self) -> "FloatPatientSeries":
         """
         Return the arithmetic mean of any non-NULL values in the series for each
         patient.
@@ -698,14 +698,14 @@ class DateFunctions(ComparableFunctions):
         """
         return _apply(qm.Function.DayFromDate, self)
 
-    def to_first_of_year(self):
+    def to_first_of_year(self: T) -> T:
         """
         Return a date series with each date in this series replaced by the date of the
         first day in its corresponding calendar year.
         """
         return _apply(qm.Function.ToFirstOfYear, self)
 
-    def to_first_of_month(self):
+    def to_first_of_month(self: T) -> T:
         """
         Return a date series with each date in this series replaced by the date of the
         first day in its corresponding calendar month.
@@ -786,7 +786,7 @@ class DateFunctions(ComparableFunctions):
 
 
 class DateAggregations(ComparableAggregations):
-    def count_episodes_for_patient(self, maximum_gap):
+    def count_episodes_for_patient(self, maximum_gap) -> IntPatientSeries:
         """
         Counts the number of "episodes" for each patient where dates which are no more
         than `maximum_gap` apart are considered part of the same episode. The
@@ -895,7 +895,7 @@ class Duration:
         assert cls._date_add_qm is not None
 
     # The default dataclass equality/inequality methods don't behave correctly here
-    def __eq__(self, other):
+    def __eq__(self, other) -> bool:
         """
         Return a boolean indicating whether the two durations have the same value and units.
         """
@@ -903,7 +903,7 @@ class Duration:
             return False
         return self.value == other.value
 
-    def __ne__(self, other):
+    def __ne__(self, other) -> bool:
         """
         Return a boolean indicating whether the two durations do not have the same value
         and units.
@@ -916,7 +916,7 @@ class Duration:
         else:
             return is_equal.__invert__()
 
-    def __add__(self, other):
+    def __add__(self, other: T) -> T:
         """
         Add this duration to a date to produce a new date.
 
@@ -937,19 +937,19 @@ class Duration:
             # Nothing else is handled
             return NotImplemented
 
-    def __sub__(self, other):
+    def __sub__(self, other: T) -> T:
         """
         Subtract another duration of the same units from this duration.
         """
         return self.__add__(other.__neg__())
 
-    def __radd__(self, other):
+    def __radd__(self, other: T) -> T:
         return self.__add__(other)
 
-    def __rsub__(self, other):
+    def __rsub__(self, other: T) -> T:
         return self.__neg__().__add__(other)
 
-    def __neg__(self):
+    def __neg__(self: T) -> T:
         """
         Invert this duration so that rather that representing a movement, say, four
         weeks forwards in time it now represents a movement four weeks backwards.
@@ -1314,14 +1314,14 @@ class BaseFrame:
     def _select_column(self, name):
         return _wrap(qm.SelectColumn, source=self._qm_node, name=name)
 
-    def exists_for_patient(self):
+    def exists_for_patient(self) -> BoolPatientSeries:
         """
         Return a [boolean patient series](#BoolPatientSeries) which is True for each
         patient that has a row in this frame and False otherwise.
         """
         return _wrap(qm.AggregateByPatient.Exists, source=self._qm_node)
 
-    def count_for_patient(self):
+    def count_for_patient(self) -> IntPatientSeries:
         """
         Return an [integer patient series](#IntPatientSeries) giving the number of rows each
         patient has in this frame.

--- a/ehrql/query_language.py
+++ b/ehrql/query_language.py
@@ -1053,7 +1053,7 @@ class Duration:
         """
         return self.__class__(self.value.__neg__())
 
-    def starting_on(self, date):
+    def starting_on(self, date) -> list[tuple[datetime.date, datetime.date]]:
         """
         Return a list of time intervals covering the duration starting on the supplied
         date. For example:
@@ -1073,7 +1073,7 @@ class Duration:
         """
         return self._generate_intervals(date, self.value, 1, "starting_on")
 
-    def ending_on(self, date):
+    def ending_on(self, date) -> list[tuple[datetime.date, datetime.date]]:
         """
         Return a list of time intervals covering the duration ending on the supplied
         date. For example:

--- a/ehrql/query_language.py
+++ b/ehrql/query_language.py
@@ -258,6 +258,11 @@ class BaseSeries:
 
     # These are the basic operations that apply to any series regardless of type or
     # dimension
+    @overload
+    def __eq__(self: "PatientSeries", other) -> "BoolPatientSeries": ...
+    @overload
+    def __eq__(self: "EventSeries", other) -> "BoolEventSeries": ...
+
     def __eq__(self, other):
         """
         Return a boolean series comparing each value in this series with its
@@ -268,6 +273,10 @@ class BaseSeries:
         other = self._cast(other)
         return _apply(qm.Function.EQ, self, other)
 
+    @overload
+    def __ne__(self: "PatientSeries", other) -> "BoolPatientSeries": ...
+    @overload
+    def __ne__(self: "EventSeries", other) -> "BoolEventSeries": ...
     def __ne__(self, other):
         """
         Return the inverse of `==` above.
@@ -277,6 +286,10 @@ class BaseSeries:
         other = self._cast(other)
         return _apply(qm.Function.NE, self, other)
 
+    @overload
+    def is_null(self: "PatientSeries", other) -> "BoolPatientSeries": ...
+    @overload
+    def is_null(self: "EventSeries", other) -> "BoolEventSeries": ...
     def is_null(self):
         """
         Return a boolean series which is True for each value in this series which is
@@ -284,6 +297,10 @@ class BaseSeries:
         """
         return _apply(qm.Function.IsNull, self)
 
+    @overload
+    def is_not_null(self: "PatientSeries", other) -> "BoolPatientSeries": ...
+    @overload
+    def is_not_null(self: "EventSeries", other) -> "BoolEventSeries": ...
     def is_not_null(self):
         """
         Return the inverse of `is_null()` above.
@@ -301,6 +318,10 @@ class BaseSeries:
             otherwise=self._cast(other),
         )
 
+    @overload
+    def is_in(self: "PatientSeries", other) -> "BoolPatientSeries": ...
+    @overload
+    def is_in(self: "EventSeries", other) -> "BoolEventSeries": ...
     def is_in(self, other):
         """
         Return a boolean series which is True for each value in this series which is
@@ -337,6 +358,10 @@ class BaseSeries:
                 f"Note `is_in()` usually expects a list of values rather than a single value"
             )
 
+    @overload
+    def is_not_in(self: "PatientSeries", other) -> "BoolPatientSeries": ...
+    @overload
+    def is_not_in(self: "EventSeries", other) -> "BoolEventSeries": ...
     def is_not_in(self, other):
         """
         Return the inverse of `is_in()` above.
@@ -434,6 +459,10 @@ class BoolEventSeries(BoolFunctions, EventSeries):
 
 
 class ComparableFunctions:
+    @overload
+    def __lt__(self: "PatientSeries", other) -> "BoolPatientSeries": ...
+    @overload
+    def __lt__(self: "EventSeries", other) -> "BoolEventSeries": ...
     def __lt__(self, other):
         """
         Return a boolean series which is True for each value in this series that is
@@ -443,6 +472,10 @@ class ComparableFunctions:
         other = self._cast(other)
         return _apply(qm.Function.LT, self, other)
 
+    @overload
+    def __le__(self: "PatientSeries", other) -> "BoolPatientSeries": ...
+    @overload
+    def __le__(self: "EventSeries", other) -> "BoolEventSeries": ...
     def __le__(self, other):
         """
         Return a boolean series which is True for each value in this series that is less
@@ -452,6 +485,10 @@ class ComparableFunctions:
         other = self._cast(other)
         return _apply(qm.Function.LE, self, other)
 
+    @overload
+    def __ge__(self: "PatientSeries", other) -> "BoolPatientSeries": ...
+    @overload
+    def __ge__(self: "EventSeries", other) -> "BoolEventSeries": ...
     def __ge__(self, other):
         """
         Return a boolean series which is True for each value in this series that is
@@ -461,6 +498,10 @@ class ComparableFunctions:
         other = self._cast(other)
         return _apply(qm.Function.GE, self, other)
 
+    @overload
+    def __gt__(self: "PatientSeries", other) -> "BoolPatientSeries": ...
+    @overload
+    def __gt__(self: "EventSeries", other) -> "BoolEventSeries": ...
     def __gt__(self, other):
         """
         Return a boolean series which is True for each value in this series that is
@@ -492,6 +533,10 @@ class ComparableAggregations:
 
 
 class StrFunctions(ComparableFunctions):
+    @overload
+    def contains(self: "PatientSeries", other) -> "BoolPatientSeries": ...
+    @overload
+    def contains(self: "EventSeries", other) -> "BoolEventSeries": ...
     def contains(self, other):
         """
         Return a boolean series which is True for each string in this series which
@@ -552,6 +597,10 @@ class NumericFunctions(ComparableFunctions):
     def __rmul__(self, other):
         return self * other
 
+    @overload
+    def __truediv__(self: "PatientSeries", other) -> "FloatPatientSeries": ...
+    @overload
+    def __truediv__(self: "EventSeries", other) -> "FloatEventSeries": ...
     def __truediv__(self, other):
         """
         Return a series with each value in this series divided by its correponding value
@@ -562,9 +611,17 @@ class NumericFunctions(ComparableFunctions):
         other = self._cast(other)
         return _apply(qm.Function.TrueDivide, self, other)
 
+    @overload
+    def __rtruediv__(self: "PatientSeries", other) -> "FloatPatientSeries": ...
+    @overload
+    def __rtruediv__(self: "EventSeries", other) -> "FloatEventSeries": ...
     def __rtruediv__(self, other):
         return self / other
 
+    @overload
+    def __floordiv__(self: "PatientSeries", other) -> "IntPatientSeries": ...
+    @overload
+    def __floordiv__(self: "EventSeries", other) -> "IntEventSeries": ...
     def __floordiv__(self, other):
         """
         Return a series with each value in this series divided by its correponding value
@@ -576,6 +633,10 @@ class NumericFunctions(ComparableFunctions):
         other = self._cast(other)
         return _apply(qm.Function.FloorDivide, self, other)
 
+    @overload
+    def __rfloordiv__(self: "PatientSeries", other) -> "IntPatientSeries": ...
+    @overload
+    def __rfloordiv__(self: "EventSeries", other) -> "IntEventSeries": ...
     def __rfloordiv__(self, other):
         return self // other
 
@@ -585,12 +646,20 @@ class NumericFunctions(ComparableFunctions):
         """
         return _apply(qm.Function.Negate, self)
 
+    @overload
+    def as_int(self: "PatientSeries", other) -> "IntPatientSeries": ...
+    @overload
+    def as_int(self: "EventSeries", other) -> "IntEventSeries": ...
     def as_int(self):
         """
         Return each value in this series rounded down to the nearest integer.
         """
         return _apply(qm.Function.CastToInt, self)
 
+    @overload
+    def as_float(self: "PatientSeries", other) -> "FloatPatientSeries": ...
+    @overload
+    def as_float(self: "EventSeries", other) -> "FloatEventSeries": ...
     def as_float(self):
         """
         Return each value in this series as a float e.g 10 becomes 10.0
@@ -712,6 +781,10 @@ class DateFunctions(ComparableFunctions):
         """
         return _apply(qm.Function.ToFirstOfMonth, self)
 
+    @overload
+    def is_before(self: PatientSeries, other) -> BoolPatientSeries: ...
+    @overload
+    def is_before(self: EventSeries, other) -> BoolEventSeries: ...
     def is_before(self, other):
         """
         Return a boolean series which is True for each date in this series that is
@@ -720,6 +793,10 @@ class DateFunctions(ComparableFunctions):
         """
         return self.__lt__(other)
 
+    @overload
+    def is_on_or_before(self: PatientSeries, other) -> BoolPatientSeries: ...
+    @overload
+    def is_on_or_before(self: EventSeries, other) -> BoolEventSeries: ...
     def is_on_or_before(self, other):
         """
         Return a boolean series which is True for each date in this series that is
@@ -728,6 +805,10 @@ class DateFunctions(ComparableFunctions):
         """
         return self.__le__(other)
 
+    @overload
+    def is_after(self: PatientSeries, other) -> BoolPatientSeries: ...
+    @overload
+    def is_after(self: EventSeries, other) -> BoolEventSeries: ...
     def is_after(self, other):
         """
         Return a boolean series which is True for each date in this series that is later
@@ -736,6 +817,10 @@ class DateFunctions(ComparableFunctions):
         """
         return self.__gt__(other)
 
+    @overload
+    def is_on_or_after(self: PatientSeries, other) -> BoolPatientSeries: ...
+    @overload
+    def is_on_or_after(self: EventSeries, other) -> BoolEventSeries: ...
     def is_on_or_after(self, other):
         """
         Return a boolean series which is True for each date in this series that is later
@@ -744,6 +829,10 @@ class DateFunctions(ComparableFunctions):
         """
         return self.__ge__(other)
 
+    @overload
+    def is_between_but_not_on(self: PatientSeries, start, end) -> BoolPatientSeries: ...
+    @overload
+    def is_between_but_not_on(self: EventSeries, start, end) -> BoolEventSeries: ...
     def is_between_but_not_on(self, start, end):
         """
         Return a boolean series which is True for each date in this series which is
@@ -751,6 +840,10 @@ class DateFunctions(ComparableFunctions):
         """
         return (self > start) & (self < end)
 
+    @overload
+    def is_on_or_between(self: PatientSeries, start, end) -> BoolPatientSeries: ...
+    @overload
+    def is_on_or_between(self: EventSeries, start, end) -> BoolEventSeries: ...
     def is_on_or_between(self, start, end):
         """
         Return a boolean series which is True for each date in this series which is
@@ -758,6 +851,10 @@ class DateFunctions(ComparableFunctions):
         """
         return (self >= start) & (self <= end)
 
+    @overload
+    def is_during(self: PatientSeries, interval) -> BoolPatientSeries: ...
+    @overload
+    def is_during(self: EventSeries, interval) -> BoolEventSeries: ...
     def is_during(self, interval):
         """
         The same as `is_on_or_between()` above, but allows supplying a start/end date
@@ -1149,6 +1246,10 @@ class MultiCodeStringFunctions:
             "`~column.contains_any_of(codelist)` instead."
         )
 
+    @overload
+    def contains(self: PatientSeries, code) -> BoolPatientSeries: ...
+    @overload
+    def contains(self: EventSeries, code) -> BoolEventSeries: ...
     def contains(self, code):
         """
         Check if the list of codes contains a specific code string. This can
@@ -1162,6 +1263,10 @@ class MultiCodeStringFunctions:
         code = self._cast(code)
         return _apply(qm.Function.StringContains, self, code)
 
+    @overload
+    def contains_any_of(self: PatientSeries, codelist) -> BoolPatientSeries: ...
+    @overload
+    def contains_any_of(self: EventSeries, codelist) -> BoolEventSeries: ...
     def contains_any_of(self, codelist):
         """
         Returns true if any of the codes in the codelist occur in the multi code field.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,8 @@ exclude_also = [
     'if __name__ == "__main__":',
     # this indicates that a method should be defined in a subclass
     "raise NotImplementedError",
+    # this is just for type hints and doesn't appear in the runtime code
+    "@overload",
 ]
 omit = [
     "ehrql/docs/__main__.py",

--- a/tests/autocomplete/autocomplete_definition.py
+++ b/tests/autocomplete/autocomplete_definition.py
@@ -1,0 +1,25 @@
+# noqa: INP001
+from ehrql.tables.core import clinical_events, patients
+from ehrql.tables.tpp import addresses, apcs, ons_deaths
+
+
+# A file to keep track of things where we get good autocomplete
+# behaviour. At some point we could try and create tests for this
+# but it's tricky.
+
+# Currently all columns on all tables have type of "Series | Any",
+# so we don't get autocomplete. Providing type hints on the Series
+# class, and on the @table decorator means the column types are
+# correct e.g. IntPatientSeries, DateEventSeries etc. and therefore
+# we get autocomplete for all the properties and methods on each series.
+patients.date_of_birth  # DatePatientSeries
+patients.sex  # StrPatientSeries
+ons_deaths.underlying_cause_of_death  # CodePatientSeries
+
+clinical_events.date  # DateEventSeries
+clinical_events.numeric_value  # FloatEventSeries
+clinical_events.snomedct_code  # CodeEventSeries
+apcs.all_diagnoses  # MultiCodeStringEventSeries
+
+addresses.has_postcode  # BoolEventSeries
+addresses.address_id  # IntEventSeries

--- a/tests/autocomplete/autocomplete_definition.py
+++ b/tests/autocomplete/autocomplete_definition.py
@@ -58,3 +58,69 @@ duration_rsub = clinical_events.date - days(100)  # DateEventSeries
 # !!! because the NotImplemented on the DateFunctions __sub__ method
 # !!! is only known at runtime
 duration_sub_duration = days(100) - days(100)  # days
+
+
+# There are loads of things that return a series where the typ
+# (int, str, float etc.) is fixed, but it can be a PatientSeries
+# or an EventSeries depending on whether the calling object is a
+# PatientSeries or an EventSeries. This can be achieved with two
+# overloaded methods and type hints
+
+#
+# BaseSeries
+#
+base_eq = patients.sex == patients.date_of_birth  # BoolPatientSeries
+base_ne = clinical_events.date != clinical_events.numeric_value  # BoolEventSeries
+patients.sex.is_null()  # BoolPatientSeries
+clinical_events.date.is_not_null()  # BoolEventSeries
+patients.sex.is_in([])  # BoolPatientSeries
+clinical_events.snomedct_code.is_not_in([])  # BoolEventSeries
+
+#
+# ComparableFunctions
+#
+comparable_lt = (
+    clinical_events.numeric_value < clinical_events.numeric_value
+)  # BoolEventSeries
+comparable_le = (
+    clinical_events.numeric_value <= clinical_events.numeric_value
+)  # BoolEventSeries
+comparable_gt = (
+    clinical_events.numeric_value > clinical_events.numeric_value
+)  # BoolEventSeries
+comparable_ge = (
+    clinical_events.numeric_value >= clinical_events.numeric_value
+)  # BoolEventSeries
+
+#
+# StrFunctions
+#
+patients.sex.contains("m")  # BoolPatientSeries
+
+#
+# NumericFunctions
+#
+numeric_truediv = clinical_events.numeric_value / 10  # FloatEventSeries
+numeric_rtruediv = 10 / clinical_events.numeric_value  # FloatEventSeries
+numeric_floordiv = clinical_events.numeric_value // 10  # IntEventSeries
+numeric_rfloordiv = 10 // clinical_events.numeric_value  # IntEventSeries
+clinical_events.numeric_value.as_int()  # IntEventSeries
+clinical_events.numeric_value.as_float()  # FloatEventSeries
+
+#
+# DateFunctions
+#
+patients.date_of_birth.is_before()  # BoolPatientSeries
+patients.date_of_birth.is_on_or_before()  # BoolPatientSeries
+patients.date_of_birth.is_after()  # BoolPatientSeries
+patients.date_of_birth.is_on_or_after()  # BoolPatientSeries
+clinical_events.date.is_between_but_not_on()  # BoolEventSeries
+clinical_events.date.is_on_or_between()  # BoolEventSeries
+clinical_events.date.is_during()  # BoolEventSeries
+
+
+#
+# MultiCodeStringFunctions
+#
+apcs.all_diagnoses.contains("N13")  # BoolEventSeries
+apcs.all_diagnoses.contains_any_of([])  # BoolEventSeries

--- a/tests/autocomplete/autocomplete_definition.py
+++ b/tests/autocomplete/autocomplete_definition.py
@@ -1,5 +1,5 @@
 # noqa: INP001
-from ehrql import days, weeks
+from ehrql import days, maximum_of, minimum_of, weeks
 from ehrql.tables.core import clinical_events, patients
 from ehrql.tables.tpp import addresses, apcs, ons_deaths
 
@@ -129,3 +129,90 @@ apcs.all_diagnoses.contains_any_of([])  # BoolEventSeries
 # Couple of random list[tuple] types
 starting_on = weeks(3).starting_on("2000-01-01")[0][0]  # date
 ending_on = weeks(3).ending_on("2000-01-01")[0][0]  # date
+
+#
+# Things that aggregate from EventSeries to PatientSeries
+# but that need to maintain the type (int, float, bool etc)
+clinical_events.numeric_value.sum_for_patient()  # FloatPatientSeries
+clinical_events.numeric_value.as_int().sum_for_patient()  # IntPatientSeries
+
+clinical_events.numeric_value.minimum_for_patient()  # FloatPatientSeries
+clinical_events.numeric_value.as_int().minimum_for_patient()  # IntPatientSeries
+addresses.msoa_code.minimum_for_patient()  # StrPatientSeries
+clinical_events.date.minimum_for_patient()  # DatePatientSeries
+
+clinical_events.numeric_value.maximum_for_patient()  # FloatPatientSeries
+clinical_events.numeric_value.as_int().maximum_for_patient()  # IntPatientSeries
+addresses.msoa_code.maximum_for_patient()  # StrPatientSeries
+clinical_events.date.maximum_for_patient()  # DatePatientSeries
+
+#
+# NumericFunctions which maintain the series (Event or Patient)
+# and the type (int or float)
+
+numeric_add = clinical_events.numeric_value + 10  # FloatEventSeries
+numeric_radd = 10 + clinical_events.numeric_value.as_int()  # IntEventSeries
+numeric_add_patient = (
+    clinical_events.numeric_value.maximum_for_patient() + 10
+)  # FloatPatientSeries
+numeric_radd_patient = (
+    10 + clinical_events.numeric_value.as_int().maximum_for_patient()
+)  # IntPatientSeries
+numeric_add_series = (
+    clinical_events.numeric_value + clinical_events.numeric_value
+)  # FloatEventSeries
+
+numeric_sub = clinical_events.numeric_value - 10  # FloatEventSeries
+numeric_rsub = 10 - clinical_events.numeric_value.as_int()  # IntEventSeries
+numeric_sub_patient = (
+    clinical_events.numeric_value.maximum_for_patient() - 10
+)  # FloatPatientSeries
+numeric_rsub_patient = (
+    10 - clinical_events.numeric_value.as_int().maximum_for_patient()
+)  # IntPatientSeries
+numeric_sub_series = (
+    clinical_events.numeric_value - clinical_events.numeric_value
+)  # FloatEventSeries
+
+numeric_mul = clinical_events.numeric_value * 10  # FloatEventSeries
+numeric_rmul = 10 * clinical_events.numeric_value.as_int()  # IntEventSeries
+numeric_mul_patient = (
+    clinical_events.numeric_value.maximum_for_patient() * 10
+)  # FloatPatientSeries
+numeric_rmul_patient = (
+    10 * clinical_events.numeric_value.as_int().maximum_for_patient()
+)  # IntPatientSeries
+numeric_mul_series = (
+    clinical_events.numeric_value * clinical_events.numeric_value
+)  # FloatEventSeries
+
+#
+# Horizontal aggregations
+# The type checker casts eveything to the first series. But the only
+# type we can easily get is the first arg. So if the first thing is
+# a series then that's fine. Otherwise we ignore
+#
+max_of_float = maximum_of(clinical_events.numeric_value, 10)  # FloatEventSeries
+max_of_int = maximum_of(clinical_events.numeric_value.as_int(), 10)  # IntEventSeries
+max_of_date = maximum_of(clinical_events.date, "2024-01-01")  # DateEventSeries
+max_of_float_patient = maximum_of(
+    clinical_events.numeric_value.maximum_for_patient(), 10
+)  # FloatPatientSeries
+max_of_int_patient = maximum_of(
+    clinical_events.numeric_value.maximum_for_patient().as_int(), 10
+)  # IntPatientSeries
+max_of_date_patient = maximum_of(
+    patients.date_of_birth, "2024-01-01"
+)  # DatePatientSeries
+min_of_float = minimum_of(clinical_events.numeric_value, 10)  # FloatEventSeries
+min_of_int = minimum_of(clinical_events.numeric_value.as_int(), 10)  # IntEventSeries
+min_of_date = minimum_of(clinical_events.date, "2024-01-01")  # DateEventSeries
+min_of_float_patient = minimum_of(
+    clinical_events.numeric_value.minimum_for_patient(), 10
+)  # FloatPatientSeries
+min_of_int_patient = minimum_of(
+    clinical_events.numeric_value.minimum_for_patient().as_int(), 10
+)  # IntPatientSeries
+min_of_date_patient = minimum_of(
+    patients.date_of_birth, "2024-01-01"
+)  # DatePatientSeries

--- a/tests/autocomplete/autocomplete_definition.py
+++ b/tests/autocomplete/autocomplete_definition.py
@@ -29,7 +29,7 @@ addresses.address_id  # IntEventSeries
 # There are some methods that always return the same type
 clinical_events.snomedct_code.count_distinct_for_patient()  # IntPatientSeries
 clinical_events.numeric_value.mean_for_patient()  # FloatPatientSeries
-clinical_events.date.count_episodes_for_patient()  # IntPatientSeries
+clinical_events.date.count_episodes_for_patient(weeks(1))  # IntPatientSeries
 patients.exists_for_patient()  # BoolPatientSeries
 patients.count_for_patient()  # IntPatientSeries
 days(100) == days(100)  # bool
@@ -69,8 +69,8 @@ duration_sub_duration = days(100) - days(100)  # days
 #
 # BaseSeries
 #
-base_eq = patients.sex == patients.date_of_birth  # BoolPatientSeries
-base_ne = clinical_events.date != clinical_events.numeric_value  # BoolEventSeries
+base_eq = patients.sex == patients.sex  # BoolPatientSeries
+base_ne = clinical_events.date != clinical_events.date  # BoolEventSeries
 patients.sex.is_null()  # BoolPatientSeries
 clinical_events.date.is_not_null()  # BoolEventSeries
 patients.sex.is_in([])  # BoolPatientSeries
@@ -110,20 +110,21 @@ clinical_events.numeric_value.as_float()  # FloatEventSeries
 #
 # DateFunctions
 #
-patients.date_of_birth.is_before()  # BoolPatientSeries
-patients.date_of_birth.is_on_or_before()  # BoolPatientSeries
-patients.date_of_birth.is_after()  # BoolPatientSeries
-patients.date_of_birth.is_on_or_after()  # BoolPatientSeries
-clinical_events.date.is_between_but_not_on()  # BoolEventSeries
-clinical_events.date.is_on_or_between()  # BoolEventSeries
-clinical_events.date.is_during()  # BoolEventSeries
+date_str = "2024-01-01"
+patients.date_of_birth.is_before(date_str)  # BoolPatientSeries
+patients.date_of_birth.is_on_or_before(date_str)  # BoolPatientSeries
+patients.date_of_birth.is_after(date_str)  # BoolPatientSeries
+patients.date_of_birth.is_on_or_after(date_str)  # BoolPatientSeries
+clinical_events.date.is_between_but_not_on(date_str, date_str)  # BoolEventSeries
+clinical_events.date.is_on_or_between(date_str, date_str)  # BoolEventSeries
+clinical_events.date.is_during((date_str, date_str))  # BoolEventSeries
 
 
 #
 # MultiCodeStringFunctions
 #
 apcs.all_diagnoses.contains("N13")  # BoolEventSeries
-apcs.all_diagnoses.contains_any_of([])  # BoolEventSeries
+apcs.all_diagnoses.contains_any_of(["N13"])  # BoolEventSeries
 
 #
 # Couple of random list[tuple] types
@@ -216,3 +217,11 @@ min_of_int_patient = minimum_of(
 min_of_date_patient = minimum_of(
     patients.date_of_birth, "2024-01-01"
 )  # DatePatientSeries
+
+# properties
+patients.date_of_birth.day  # IntPatientSeries
+patients.date_of_birth.month  # IntPatientSeries
+patients.date_of_birth.year  # IntPatientSeries
+clinical_events.date.day  # IntEventSeries
+clinical_events.date.month  # IntEventSeries
+clinical_events.date.year  # IntEventSeries

--- a/tests/autocomplete/autocomplete_definition.py
+++ b/tests/autocomplete/autocomplete_definition.py
@@ -1,5 +1,5 @@
 # noqa: INP001
-from ehrql import days
+from ehrql import days, weeks
 from ehrql.tables.core import clinical_events, patients
 from ehrql.tables.tpp import addresses, apcs, ons_deaths
 
@@ -124,3 +124,8 @@ clinical_events.date.is_during()  # BoolEventSeries
 #
 apcs.all_diagnoses.contains("N13")  # BoolEventSeries
 apcs.all_diagnoses.contains_any_of([])  # BoolEventSeries
+
+#
+# Couple of random list[tuple] types
+starting_on = weeks(3).starting_on("2000-01-01")[0][0]  # date
+ending_on = weeks(3).ending_on("2000-01-01")[0][0]  # date

--- a/tests/autocomplete/autocomplete_definition.py
+++ b/tests/autocomplete/autocomplete_definition.py
@@ -1,4 +1,5 @@
 # noqa: INP001
+from ehrql import days
 from ehrql.tables.core import clinical_events, patients
 from ehrql.tables.tpp import addresses, apcs, ons_deaths
 
@@ -23,3 +24,37 @@ apcs.all_diagnoses  # MultiCodeStringEventSeries
 
 addresses.has_postcode  # BoolEventSeries
 addresses.address_id  # IntEventSeries
+
+
+# There are some methods that always return the same type
+clinical_events.snomedct_code.count_distinct_for_patient()  # IntPatientSeries
+clinical_events.numeric_value.mean_for_patient()  # FloatPatientSeries
+clinical_events.date.count_episodes_for_patient()  # IntPatientSeries
+patients.exists_for_patient()  # BoolPatientSeries
+patients.count_for_patient()  # IntPatientSeries
+days(100) == days(100)  # bool
+days(100) != days(100)  # bool
+
+# There are some things that return the same type as the calling
+# object or one of the arguments
+
+bool_and = (
+    patients.exists_for_patient() & patients.exists_for_patient()
+)  # BoolPatientSeries
+bool_or = (
+    patients.exists_for_patient() | patients.exists_for_patient()
+)  # BoolPatientSeries
+bool_invert = ~patients.exists_for_patient()  # BoolPatientSeries
+numeric_neg = -clinical_events.numeric_value  # FloatEventSeries
+clinical_events.date.to_first_of_year()  # DateEventSeries
+patients.date_of_birth.to_first_of_month()  # DatePatientSeries
+duration_negation = -days(100)  # days
+patients.sex.when_null_then(patients.sex)  # StrPatientSeries
+duration_add = days(100) + patients.date_of_birth  # DatePatientSeries
+duration_radd = clinical_events.date + days(100)  # DateEventSeries
+duration_add_duration = days(100) + days(100)  # days
+duration_rsub = clinical_events.date - days(100)  # DateEventSeries
+# !!! the above doesn't work and thinks its a DateDifference. I assume
+# !!! because the NotImplemented on the DateFunctions __sub__ method
+# !!! is only known at runtime
+duration_sub_duration = days(100) - days(100)  # days


### PR DESCRIPTION
The type checker/autocomplete now knows:
- the correct type of all column series (e.g. `patients.date_of_birth` is a `DatePatientSeries`)
- the return type of almost all methods on the series (e.g. `clinical_events.numeric_value.sum_for_patient()` is a `FloatPatientSeries`
- properties on series have the correct type (e.g. `patients.date_of_birth.day` is a `IntPatientSeries`)
- the return type for most operators like `+`, `-`, `>`, `/` etc.