### PR TITLE
Expose decision support values table in ehrQL

### DIFF
--- a/docs/how-to/examples.md
+++ b/docs/how-to/examples.md
@@ -923,3 +923,27 @@ dataset.prescription_date = case(
 )
 dataset.define_population(patients.exists_for_patient())
 ```
+
+## Decision support values
+
+Examples for the [TPP decision support values table](../reference/schemas/tpp.md#decision_support_values).
+
+### Finding the most recent decision support value
+
+#### Finding each patient's EFI (electronic frailty index)
+
+```ehrql
+from ehrql import create_dataset
+from ehrql.tables.tpp import decision_support_values
+
+dataset = create_dataset()
+latest_efi_record = (
+  decision_support_values
+    .electronic_frailty_index()
+    .sort_by(decision_support_values.calculation_date)
+    .last_for_patient()
+)
+dataset.latest_efi = latest_efi_record.numeric_value
+dataset.latest_efi_date = latest_efi_record.calculation_date
+dataset.define_population(decision_support_values.exists_for_patient())
+```

--- a/docs/includes/generated_docs/schemas/tpp.md
+++ b/docs/includes/generated_docs/schemas/tpp.md
@@ -15,6 +15,7 @@ from ehrql.tables.tpp import (
     clinical_events,
     clinical_events_ranges,
     covid_therapeutics,
+    decision_support_values,
     ec,
     ec_cost,
     emergency_care_attendances,
@@ -1178,6 +1179,105 @@ a specific disease name may not be reliable.
 Entered by the clinician and can represent either a future planned start
 date or a past date at the time of form submission.
 
+  </dd>
+</div>
+
+  </dl>
+</div>
+
+
+<p class="dimension-indicator"><code>many rows per patient</code></p>
+## decision_support_values
+
+Returns values computed by decision support algorithms, for example the
+[Electronic Frailty Index (EFI)][efi_ref]
+
+[efi_ref]: https://www.england.nhs.uk/ourwork/clinical-policy/older-people/frailty/efi/
+<div markdown="block" class="definition-list-wrapper">
+  <div class="title">Columns</div>
+  <dl markdown="block">
+<div markdown="block">
+  <dt id="decision_support_values.algorithm_type">
+    <strong>algorithm_type</strong>
+    <a class="headerlink" href="#decision_support_values.algorithm_type" title="Permanent link">🔗</a>
+    <code>integer</code>
+  </dt>
+  <dd markdown="block">
+A unique id for the decision support algorithm. Currently, the only option is '1' for the electronic frailty index.
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="decision_support_values.calculation_date">
+    <strong>calculation_date</strong>
+    <a class="headerlink" href="#decision_support_values.calculation_date" title="Permanent link">🔗</a>
+    <code>date</code>
+  </dt>
+  <dd markdown="block">
+Date of calculation for the decision support algorithm.
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="decision_support_values.numeric_value">
+    <strong>numeric_value</strong>
+    <a class="headerlink" href="#decision_support_values.numeric_value" title="Permanent link">🔗</a>
+    <code>float</code>
+  </dt>
+  <dd markdown="block">
+The value computed by the decision support algorithm
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="decision_support_values.algorithm_description">
+    <strong>algorithm_description</strong>
+    <a class="headerlink" href="#decision_support_values.algorithm_description" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+The description of the decision support algorithm.
+
+  </dd>
+</div>
+
+<div markdown="block">
+  <dt id="decision_support_values.algorithm_version">
+    <strong>algorithm_version</strong>
+    <a class="headerlink" href="#decision_support_values.algorithm_version" title="Permanent link">🔗</a>
+    <code>string</code>
+  </dt>
+  <dd markdown="block">
+The version of the decision support algorithm.
+
+  </dd>
+</div>
+
+  </dl>
+</div>
+<div markdown="block" class="definition-list-wrapper">
+  <div class="title">Methods</div>
+  <dl markdown="block">
+<div markdown="block">
+  <dt id="decision_support_values.electronic_frailty_index">
+    <strong>electronic_frailty_index(</strong><strong>)</strong>
+    <a class="headerlink" href="#decision_support_values.electronic_frailty_index" title="Permanent link">🔗</a>
+    <code></code>
+  </dt>
+  <dd markdown="block">
+Returns every calculated electronic frailty index v1 (EFI) for each patient.
+    <details markdown="block">
+    <summary>View method definition</summary>
+```py
+return decision_support_values.where(
+    decision_support_values.algorithm_description == "UK Electronic Frailty Index (eFI)"
+).where(decision_support_values.algorithm_version == "1.0")
+
+```
+    </details>
   </dd>
 </div>
 

--- a/ehrql/backends/tpp.py
+++ b/ehrql/backends/tpp.py
@@ -455,6 +455,21 @@ class TPPBackend(SQLBackend):
         """
     )
 
+    decision_support_values = QueryTable(
+        """
+            SELECT
+                decval.Patient_ID AS patient_id,
+                decval.AlgorithmType AS algorithm_type,
+                CAST(NULLIF(decval.CalculationDateTime, '9999-12-31T00:00:00') AS date) AS calculation_date,
+                decval.NumericValue AS numeric_value,
+                decvalref.AlgorithmDescription AS algorithm_description,
+                decvalref.AlgorithmVersion AS algorithm_version
+            FROM DecisionSupportValue AS decval
+            LEFT JOIN DecisionSupportValueReference AS decvalref
+            ON decval.AlgorithmType = decvalref.AlgorithmType
+        """
+    )
+
     @QueryTable.from_function
     def ec(self):
         return self._union_over_hes_archive(

--- a/ehrql/tables/tpp.py
+++ b/ehrql/tables/tpp.py
@@ -28,6 +28,7 @@ __all__ = [
     "clinical_events",
     "clinical_events_ranges",
     "covid_therapeutics",
+    "decision_support_values",
     "ec",
     "ec_cost",
     "emergency_care_attendances",
@@ -803,6 +804,44 @@ class covid_therapeutics(EventFrame):
             date or a past date at the time of form submission.
         """,
     )
+
+
+@table
+class decision_support_values(EventFrame):
+    """
+    Returns values computed by decision support algorithms, for example the
+    [Electronic Frailty Index (EFI)][efi_ref]
+
+    [efi_ref]: https://www.england.nhs.uk/ourwork/clinical-policy/older-people/frailty/efi/
+
+    """
+
+    algorithm_type = Series(
+        int,
+        description="A unique id for the decision support algorithm. Currently, the only option is '1' for the electronic frailty index.",
+    )
+    calculation_date = Series(
+        datetime.date,
+        description="Date of calculation for the decision support algorithm.",
+    )
+    numeric_value = Series(
+        float,
+        description="The value computed by the decision support algorithm",
+    )
+    algorithm_description = Series(
+        str, description="The description of the decision support algorithm."
+    )
+    algorithm_version = Series(
+        str, description="The version of the decision support algorithm."
+    )
+
+    def electronic_frailty_index(self):
+        """
+        Returns every calculated electronic frailty index v1 (EFI) for each patient.
+        """
+        return self.where(
+            self.algorithm_description == "UK Electronic Frailty Index (eFI)"
+        ).where(self.algorithm_version == "1.0")
 
 
 @table

--- a/tests/integration/backends/test_tpp.py
+++ b/tests/integration/backends/test_tpp.py
@@ -28,6 +28,8 @@ from tests.lib.tpp_schema import (
     CodedEvent_SNOMED,
     CodedEventRange,
     CustomMedicationDictionary,
+    DecisionSupportValue,
+    DecisionSupportValueReference,
     EC_Cost,
     EC_Cost_ARCHIVED,
     EC_Diagnosis,
@@ -965,6 +967,77 @@ def test_covid_therapeutics_raw(select_all_tpp):
             "age_at_received_date": 60,
             "region": "l",
             "load_date": date(2023, 9, 14),
+        },
+    ]
+
+
+@register_test_for(tpp.decision_support_values)
+def test_decision_support_values(select_all_tpp):
+    results = select_all_tpp(
+        Patient(Patient_ID=1),
+        DecisionSupportValueReference(
+            AlgorithmDescription="UK Electronic Frailty Index (eFI)",
+            AlgorithmSourceLink="link",
+            AlgorithmType=1,
+            AlgorithmVersion="1.0",
+        ),
+        DecisionSupportValue(
+            Patient_ID=1,
+            AlgorithmType=1,
+            CalculationDateTime="2010-01-01T10:00:00",
+            NumericValue=37.5,
+        ),
+        DecisionSupportValue(
+            Patient_ID=1,
+            AlgorithmType=1,
+            CalculationDateTime="2011-01-01T10:00:00",
+            NumericValue=40.5,
+        ),
+        DecisionSupportValue(
+            Patient_ID=1,
+            AlgorithmType=1,
+            CalculationDateTime="2012-01-01T10:00:00",
+            NumericValue=45.0,
+        ),
+        DecisionSupportValue(
+            Patient_ID=1,
+            AlgorithmType=1,
+            CalculationDateTime="2013-01-01T10:00:00",
+            NumericValue=47.0,
+        ),
+    )
+    assert results == [
+        {
+            "patient_id": 1,
+            "algorithm_type": 1,
+            "calculation_date": date(2010, 1, 1),
+            "numeric_value": 37.5,
+            "algorithm_description": "UK Electronic Frailty Index (eFI)",
+            "algorithm_version": "1.0",
+        },
+        {
+            "patient_id": 1,
+            "algorithm_type": 1,
+            "calculation_date": date(2011, 1, 1),
+            "numeric_value": 40.5,
+            "algorithm_description": "UK Electronic Frailty Index (eFI)",
+            "algorithm_version": "1.0",
+        },
+        {
+            "patient_id": 1,
+            "algorithm_type": 1,
+            "calculation_date": date(2012, 1, 1),
+            "numeric_value": 45.0,
+            "algorithm_description": "UK Electronic Frailty Index (eFI)",
+            "algorithm_version": "1.0",
+        },
+        {
+            "patient_id": 1,
+            "algorithm_type": 1,
+            "calculation_date": date(2013, 1, 1),
+            "numeric_value": 47.0,
+            "algorithm_description": "UK Electronic Frailty Index (eFI)",
+            "algorithm_version": "1.0",
         },
     ]
 


### PR DESCRIPTION
Closes #2264 

Some thoughts:
- The `AlgorithmType` column is used to join the tables, but I've also exposed it to users. Given it's an internal TPP thing I'm not sure that's necessary - but then again to pick a particular algorithm you either need to search by `algorithm_type` or `algorithm_description` - both of which are defined by TPP so perhaps not much difference
- Are there any checks missing? It feels a bit uncomfortable exposing a new table but not being able to actually test the code on the actual database. Especially because the way we identify the EFI is by searching for a hard-coded string definition and version number.
- For the EFI, I've copied code from @evansd which looks for descriptions matching "UK Electronic Frailty Index (eFI)". I just want to double check this is the correct string. In cohort extractor the search was actually done by looking for an `AlgorithmType` of `1`, so perhaps we should do that.
- Do we have any way of checking the possible values in the `Type`, `Description` and `Version` columns. I think at the moment it is just v1 of the EFI, but it would be good to know if TPP change anything or add new ones.