### PR TITLE
Removed the `algorithm_type` from the `decision_support_values` table

### DIFF
--- a/docs/includes/generated_docs/schemas/tpp.md
+++ b/docs/includes/generated_docs/schemas/tpp.md
@@ -1197,18 +1197,6 @@ Returns values computed by decision support algorithms, for example the
   <div class="title">Columns</div>
   <dl markdown="block">
 <div markdown="block">
-  <dt id="decision_support_values.algorithm_type">
-    <strong>algorithm_type</strong>
-    <a class="headerlink" href="#decision_support_values.algorithm_type" title="Permanent link">🔗</a>
-    <code>integer</code>
-  </dt>
-  <dd markdown="block">
-A unique id for the decision support algorithm. Currently, the only option is '1' for the electronic frailty index.
-
-  </dd>
-</div>
-
-<div markdown="block">
   <dt id="decision_support_values.calculation_date">
     <strong>calculation_date</strong>
     <a class="headerlink" href="#decision_support_values.calculation_date" title="Permanent link">🔗</a>

--- a/ehrql/backends/tpp.py
+++ b/ehrql/backends/tpp.py
@@ -459,7 +459,6 @@ class TPPBackend(SQLBackend):
         """
             SELECT
                 decval.Patient_ID AS patient_id,
-                decval.AlgorithmType AS algorithm_type,
                 CAST(NULLIF(decval.CalculationDateTime, '9999-12-31T00:00:00') AS date) AS calculation_date,
                 decval.NumericValue AS numeric_value,
                 decvalref.AlgorithmDescription AS algorithm_description,

--- a/ehrql/tables/tpp.py
+++ b/ehrql/tables/tpp.py
@@ -816,10 +816,6 @@ class decision_support_values(EventFrame):
 
     """
 
-    algorithm_type = Series(
-        int,
-        description="A unique id for the decision support algorithm. Currently, the only option is '1' for the electronic frailty index.",
-    )
     calculation_date = Series(
         datetime.date,
         description="Date of calculation for the decision support algorithm.",

--- a/tests/integration/backends/test_tpp.py
+++ b/tests/integration/backends/test_tpp.py
@@ -1009,7 +1009,6 @@ def test_decision_support_values(select_all_tpp):
     assert results == [
         {
             "patient_id": 1,
-            "algorithm_type": 1,
             "calculation_date": date(2010, 1, 1),
             "numeric_value": 37.5,
             "algorithm_description": "UK Electronic Frailty Index (eFI)",
@@ -1017,7 +1016,6 @@ def test_decision_support_values(select_all_tpp):
         },
         {
             "patient_id": 1,
-            "algorithm_type": 1,
             "calculation_date": date(2011, 1, 1),
             "numeric_value": 40.5,
             "algorithm_description": "UK Electronic Frailty Index (eFI)",
@@ -1025,7 +1023,6 @@ def test_decision_support_values(select_all_tpp):
         },
         {
             "patient_id": 1,
-            "algorithm_type": 1,
             "calculation_date": date(2012, 1, 1),
             "numeric_value": 45.0,
             "algorithm_description": "UK Electronic Frailty Index (eFI)",
@@ -1033,7 +1030,6 @@ def test_decision_support_values(select_all_tpp):
         },
         {
             "patient_id": 1,
-            "algorithm_type": 1,
             "calculation_date": date(2013, 1, 1),
             "numeric_value": 47.0,
             "algorithm_description": "UK Electronic Frailty Index (eFI)",

--- a/tests/integration/tables/test_tpp.py
+++ b/tests/integration/tables/test_tpp.py
@@ -230,7 +230,6 @@ def test_decision_support_values_electronic_frailty_index(
             tpp.decision_support_values: [
                 dict(
                     patient_id=1,
-                    algorithm_type=1,
                     calculation_date=date(2012, 1, 1),
                     numeric_value=25.0,
                     algorithm_description="UK Electronic Frailty Index (eFI)",
@@ -238,7 +237,6 @@ def test_decision_support_values_electronic_frailty_index(
                 ),
                 dict(
                     patient_id=1,
-                    algorithm_type=1,
                     calculation_date=date(2010, 1, 1),
                     numeric_value=30.0,
                     algorithm_description="UK Electronic Frailty Index (eFI)",
@@ -246,7 +244,6 @@ def test_decision_support_values_electronic_frailty_index(
                 ),
                 dict(
                     patient_id=1,
-                    algorithm_type=2,
                     calculation_date=date(2010, 1, 1),
                     numeric_value=25.0,
                     algorithm_description="A different index",


### PR DESCRIPTION
The `algorithm_type` is just used to link the table with the actual values to the lookup table with the version and description of the algorithm. It seems preferable to only allow users to query the `algorithm_description` (e.g. `algorithm_description == 'UK Electronic Frailty Index"` rather than `algorithm_type == 1`. Both are set by TPP and it is unknown whether they will ever change, but if the description changes then the result will be nothing returned, which is better than if the type number changes and the code might start returning results for a different algorithm.