### PR TITLE
Add markers for html table output.

### DIFF
--- a/ehrql/renderers.py
+++ b/ehrql/renderers.py
@@ -1,6 +1,10 @@
 import re
 
 
+START_MARKER = "<!-- start debug output -->"
+END_MARKER = "<!-- end debug output -->"
+
+
 def records_to_html_table(records: list[dict]):
     rows = []
     headers_written = False
@@ -13,7 +17,7 @@ def records_to_html_table(records: list[dict]):
         rows.append(f"<tr>{row}</tr>")
     rows = "".join(rows)
 
-    return f"<table><thead>{headers}</thead><tbody>{rows}</tbody></table>"
+    return f"{START_MARKER}<table><thead>{headers}</thead><tbody>{rows}</tbody></table>{END_MARKER}"
 
 
 def records_to_ascii_table(records: list[dict]):
@@ -35,7 +39,7 @@ def _truncate_html_table(table_repr: str, head: int | None, tail: int | None):
     values to indicate where it's been truncated
     """
     regex = re.compile(
-        r"(?P<start>^<table>.*<tbody>)(?P<rows><tr>.*<\/tr>)(?P<end><\/tbody>.*<\/table>)"
+        rf"(?P<start>^{START_MARKER}<table>.*<tbody>)(?P<rows><tr>.*<\/tr>)(?P<end><\/tbody>.*<\/table>{END_MARKER})"
     )
     match = regex.match(table_repr)
     if match is None:

--- a/tests/unit/test_renderers.py
+++ b/tests/unit/test_renderers.py
@@ -38,6 +38,7 @@ def test_render_table(render_format):
             """
         ).strip(),
         "html": (
+            "<!-- start debug output -->"
             "<table>"
             "<thead>"
             "<th>patient_id</th><th>i1</th><th>i2</th>"
@@ -50,6 +51,7 @@ def test_render_table(render_format):
             "<tr><td>5</td><td>501</td><td>511</td></tr>"
             "</tbody>"
             "</table>"
+            "<!-- end debug output -->"
         ),
     }
     rendered = DISPLAY_RENDERERS[render_format](TABLE.to_records()).strip()
@@ -68,6 +70,7 @@ def test_render_column(render_format):
             """
         ).strip(),
         "html": (
+            "<!-- start debug output -->"
             "<table>"
             "<thead>"
             "<th>patient_id</th><th>value</th>"
@@ -77,6 +80,7 @@ def test_render_column(render_format):
             "<tr><td>2</td><td>201</td></tr>"
             "</tbody>"
             "</table>"
+            "<!-- end debug output -->"
         ),
     }
 
@@ -103,6 +107,7 @@ def test_render_table_head(render_format):
             """
         ).strip(),
         "html": (
+            "<!-- start debug output -->"
             "<table>"
             "<thead>"
             "<th>patient_id</th><th>i1</th><th>i2</th>"
@@ -113,6 +118,7 @@ def test_render_table_head(render_format):
             "<tr><td>...</td><td>...</td><td>...</td></tr>"
             "</tbody>"
             "</table>"
+            "<!-- end debug output -->"
         ),
     }
 
@@ -134,6 +140,7 @@ def test_render_table_tail(render_format):
             """
         ).strip(),
         "html": (
+            "<!-- start debug output -->"
             "<table>"
             "<thead>"
             "<th>patient_id</th><th>i1</th><th>i2</th>"
@@ -144,6 +151,7 @@ def test_render_table_tail(render_format):
             "<tr><td>5</td><td>501</td><td>511</td></tr>"
             "</tbody>"
             "</table>"
+            "<!-- end debug output -->"
         ),
     }
 
@@ -167,6 +175,7 @@ def test_render_table_head_and_tail(render_format):
             """
         ).strip(),
         "html": (
+            "<!-- start debug output -->"
             "<table>"
             "<thead>"
             "<th>patient_id</th><th>i1</th><th>i2</th>"
@@ -179,6 +188,7 @@ def test_render_table_head_and_tail(render_format):
             "<tr><td>5</td><td>501</td><td>511</td></tr>"
             "</tbody>"
             "</table>"
+            "<!-- end debug output -->"
         ),
     }
 
@@ -207,6 +217,7 @@ def test_render_table_bad_head_tail(render_format, head_tail):
             """
         ).strip(),
         "html": (
+            "<!-- start debug output -->"
             "<table>"
             "<thead>"
             "<th>patient_id</th><th>i1</th><th>i2</th>"
@@ -219,6 +230,7 @@ def test_render_table_bad_head_tail(render_format, head_tail):
             "<tr><td>5</td><td>501</td><td>511</td></tr>"
             "</tbody>"
             "</table>"
+            "<!-- end debug output -->"
         ),
     }
     head, tail = head_tail


### PR DESCRIPTION
We will then be able to use these markers to deliniate pre-formatted
html output from normal console output when rendering in the vscode
extension.
