### PR TITLE
Refactor debug rendering

### DIFF
--- a/ehrql/loaders.py
+++ b/ehrql/loaders.py
@@ -324,6 +324,12 @@ def load_definition_unsafe(
 
 
 def load_module(module_path, user_args=()):
+    """Load a module containing an ehrql dataset definition.
+
+    Renders the serialized query model as json to the callers stdout, and any
+    other output to stderr.
+    """
+
     # Taken from the official recipe for importing a module from a file path:
     # https://docs.python.org/3.9/library/importlib.html#importing-a-source-file-directly
     spec = importlib.util.spec_from_file_location(module_path.stem, module_path)

--- a/ehrql/query_engines/debug.py
+++ b/ehrql/query_engines/debug.py
@@ -57,5 +57,5 @@ class EmptyDataset:
     """This class exists to render something nice when a user tries to inspect a dataset
     with no columns with debugger.show()."""
 
-    def _render_(self, render_fn):
-        return render_fn([{"patient_id": ""}])
+    def to_records(self, convert_null=False):
+        return [{"patient_id": ""}]

--- a/ehrql/query_engines/in_memory_database.py
+++ b/ehrql/query_engines/in_memory_database.py
@@ -93,7 +93,7 @@ class PatientTable:
         return self._render_(DISPLAY_RENDERERS["ascii"])
 
     def _render_(self, render_fn):
-        return render_fn(self.to_records(convert_null=True))
+        return render_fn(list(self.to_records(convert_null=True)))
 
     def __getitem__(self, name):
         return self.name_to_col[name]
@@ -179,7 +179,7 @@ class EventTable:
         return self._render_(DISPLAY_RENDERERS["ascii"])
 
     def _render_(self, render_fn):
-        return render_fn(self.to_records(convert_null=True))
+        return render_fn(list(self.to_records(convert_null=True)))
 
     def __getitem__(self, name):
         return self.name_to_col[name]
@@ -257,7 +257,7 @@ class PatientColumn:
         return self._render_(DISPLAY_RENDERERS["ascii"])
 
     def _render_(self, render_fn):
-        return render_fn(self.to_records(convert_null=True))
+        return render_fn(list(self.to_records(convert_null=True)))
 
     def __getitem__(self, patient):
         return self.patient_to_value.get(patient, self.default)
@@ -318,7 +318,7 @@ class EventColumn:
         return self._render_(DISPLAY_RENDERERS["ascii"])
 
     def _render_(self, render_fn):
-        return render_fn(self.to_records(convert_null=True))
+        return render_fn(list(self.to_records(convert_null=True)))
 
     def __getitem__(self, patient):
         return self.patient_to_rows.get(patient, Rows({}))

--- a/ehrql/quiz.py
+++ b/ehrql/quiz.py
@@ -276,8 +276,8 @@ class Questions:
         # itself, regardless of how the quiz script was invoked. This kind of global
         # nastiness seems tolerable in the context of the quiz, and worth it for
         # avoiding potential confusion.
-        if ehrql.debugger.DEBUG_QUERY_ENGINE is not None:
-            ehrql.debugger.DEBUG_QUERY_ENGINE.dsn = path
+        if ehrql.debugger.DEBUG_CONTEXT is not None:
+            ehrql.debugger.DEBUG_CONTEXT.query_engine.dsn = path
 
     def __setitem__(self, index, question):
         question.index = index

--- a/ehrql/renderers.py
+++ b/ehrql/renderers.py
@@ -27,7 +27,11 @@ def headtail(sequence: typing.Sequence, head: int = 0, tail: int = 0):
 
 def records_to_html_table(records: list[dict], head: int = 0, tail: int = 0):
     rows = []
-    headers = "".join([f"<th>{header}</th>" for header in records[0].keys()])
+    headers = (
+        "".join([f"<th>{header}</th>" for header in records[0].keys()])
+        if records
+        else ""
+    )
     head_rows, ellipsis, tail_rows = headtail(records, head, tail)
 
     def html_row(row):
@@ -54,7 +58,7 @@ def records_to_ascii_table(records: list[dict], head: int = 0, tail: int = 0):
     width = 17
     lines = []
 
-    headers = records[0].keys()
+    headers = records[0].keys() if records else []
 
     lines.append(" | ".join(name.ljust(width) for name in headers))
     lines.append("-+-".join("-" * width for _ in headers))

--- a/ehrql/renderers.py
+++ b/ehrql/renderers.py
@@ -1,134 +1,75 @@
-import re
+import typing
 
 
 START_MARKER = "<!-- start debug output -->"
 END_MARKER = "<!-- end debug output -->"
 
 
-def records_to_html_table(records: list[dict]):
+def headtail(sequence: typing.Sequence, head: int = 0, tail: int = 0):
+    if head == tail == 0:
+        return sequence, False, []
+
+    # Check we have enough rows to truncate to head and tail
+    if len(sequence) <= head + tail:
+        return sequence, False, []
+
+    head_rows = []
+    tail_rows = []
+
+    if head:
+        head_rows = sequence[:head]
+
+    if tail:
+        tail_rows = sequence[-tail:]
+
+    return head_rows, True, tail_rows
+
+
+def records_to_html_table(records: list[dict], head: int = 0, tail: int = 0):
     rows = []
-    headers_written = False
+    headers = "".join([f"<th>{header}</th>" for header in records[0].keys()])
+    head_rows, ellipsis, tail_rows = headtail(records, head, tail)
 
-    for record in records:
-        if not headers_written:
-            headers = "".join([f"<th>{header}</th>" for header in record.keys()])
-            headers_written = True
-        row = "".join(f"<td>{val}</td>" for val in record.values())
-        rows.append(f"<tr>{row}</tr>")
-    rows = "".join(rows)
+    def html_row(row):
+        columns = "".join(f"<td>{v}</td>" for v in row.values())
+        return f"<tr>{columns}</tr>"
 
-    return f"{START_MARKER}<table><thead>{headers}</thead><tbody>{rows}</tbody></table>{END_MARKER}"
+    for row in head_rows:
+        rows.append(html_row(row))
+
+    if ellipsis:
+        ellipsis_columns = "<td>&hellip;</td>" * len(records[0])
+        rows.append(f"<tr>{ellipsis_columns}</tr>")
+
+    for row in tail_rows:
+        rows.append(html_row(row))
+
+    html_rows = "".join(rows)
+
+    return f"{START_MARKER}<table><thead><tr>{headers}</tr></thead><tbody>{html_rows}</tbody></table>{END_MARKER}"
 
 
-def records_to_ascii_table(records: list[dict]):
+def records_to_ascii_table(records: list[dict], head: int = 0, tail: int = 0):
+    head_rows, ellipsis, tail_rows = headtail(records, head, tail)
     width = 17
     lines = []
-    headers_written = False
-    for record in records:
-        if not headers_written:
-            lines.append(" | ".join(name.ljust(width) for name in record.keys()))
-            lines.append("-+-".join("-" * width for _ in record.keys()))
-            headers_written = True
-        lines.append(" | ".join(str(value).ljust(width) for value in record.values()))
-    return "\n".join(line.strip() for line in lines) + "\n"
 
+    headers = records[0].keys()
 
-def _truncate_html_table(table_repr: str, head: int | None, tail: int | None):
-    """
-    Truncate an html table string to the first/last N rows, with a row of ...
-    values to indicate where it's been truncated
-    """
-    regex = re.compile(
-        rf"(?P<start>^{START_MARKER}<table>.*<tbody>)(?P<rows><tr>.*<\/tr>)(?P<end><\/tbody>.*<\/table>{END_MARKER})"
-    )
-    match = regex.match(table_repr)
-    if match is None:
-        # if we can't parse the table, return None and let the fallback handle it
-        return
+    lines.append(" | ".join(name.ljust(width) for name in headers))
+    lines.append("-+-".join("-" * width for _ in headers))
 
-    start = match.group("start")
-    rows = match.group("rows")
-    end = match.group("end")
+    for line in head_rows:
+        lines.append(" | ".join(str(v).ljust(width) for v in line.values()))
 
-    # Check we have enough rows to truncate to head and tail
-    if rows.count("<tr>") <= ((head or 0) + (tail or 0)):
-        return table_repr
+    if ellipsis:
+        ellipsis_row = " | ".join("...".ljust(width) for _ in headers)
+        lines.append(ellipsis_row)
 
-    # split row on <tr> tokens, remove any empty strings (this will lose the first <tr> of
-    # each row, but we'll add it in again later)
-    rows = [row for row in rows.split("<tr>") if row]
-    # compose an "ellipsis row" to mark the place of truncated rows
-    td_count = rows[0].count("<td>")
-    ellipsis_row = f"{'<td>...</td>' * td_count}</tr>"
+    for line in tail_rows:
+        lines.append(" | ".join(str(v).ljust(width) for v in line.values()))
 
-    # Build the list of rows we need to include, with ellipsis rows where necessary
-    truncated_rows = []
-
-    head_rows = rows[:head] if head is not None else [ellipsis_row]
-    truncated_rows.extend(head_rows)
-
-    if head is not None and tail is not None:
-        truncated_rows.append(ellipsis_row)
-
-    tail_rows = rows[-tail:] if tail is not None else [ellipsis_row]
-    truncated_rows.extend(tail_rows)
-
-    # re-join the truncated rows with <tr>
-    truncated_rows = "<tr>" + "<tr>".join(truncated_rows)
-    return start + truncated_rows + end
-
-
-def _truncate_lines(
-    table_repr: str, headers: int = 0, head: int | None = None, tail: int | None = None
-):
-    table_rows = [row for row in table_repr.split("\n") if row]
-
-    # Check we have enough rows to truncate to head and tail
-    if len(table_rows) <= (headers + (head or 0) + (tail or 0)):
-        return table_repr
-
-    # compose an "ellipsis row" to mark the place of truncated rows
-    cell_count = table_rows[0].count("|") + 1
-    ellipsis_row = " | ".join("...".ljust(17) for i in range(cell_count)).strip()
-
-    # Build the list of rows we need to include, with ellipsis rows where necessary
-    truncated_rows = table_rows[:headers]
-
-    head_rows = (
-        table_rows[headers : headers + head] if head is not None else [ellipsis_row]
-    )
-    truncated_rows.extend(head_rows)
-
-    if head is not None and tail is not None:
-        truncated_rows.append(ellipsis_row)
-
-    tail_rows = table_rows[-tail:] if tail is not None else [ellipsis_row]
-    truncated_rows.extend(tail_rows)
-
-    return "\n".join(truncated_rows)
-
-
-def truncate_table(table_repr: str, head: int | None, tail: int | None):
-    """
-    Take a table repr (ascii or html format) and truncate it to show only the
-    first and/or last N rows.
-    """
-    if head is None and tail is None:
-        return table_repr
-
-    truncated_repr = None
-
-    if "<table>" in table_repr:
-        truncated_repr = _truncate_html_table(table_repr, head=head, tail=tail)
-    elif "---+---" in table_repr:
-        truncated_repr = _truncate_lines(table_repr, headers=2, head=head, tail=tail)
-
-    # if we didn't detect either an ascii or html table, or the html regex
-    # didn't match as expected, fall back to a simple truncation of lines using
-    # line breaks.
-    if truncated_repr is None:
-        truncated_repr = _truncate_lines(table_repr, head=head, tail=tail)
-    return truncated_repr
+    return "\n".join(line.strip() for line in lines)
 
 
 DISPLAY_RENDERERS = {

--- a/tests/unit/test_debugger.py
+++ b/tests/unit/test_debugger.py
@@ -23,12 +23,21 @@ def date_serializer(obj):
 def test_show(capsys):
     expected_output = textwrap.dedent(
         """
-        Show line 31:
+        Show line 3:
 
         """
     ).strip()
 
-    show("Hello")
+    exec(
+        textwrap.dedent(
+            """
+            # line 2
+            show("Hello")
+            # line 4
+            """
+        )
+    )
+
     captured = capsys.readouterr()
     assert captured.err.strip().startswith(expected_output), captured.err
 
@@ -36,12 +45,21 @@ def test_show(capsys):
 def test_show_with_label(capsys):
     expected_output = textwrap.dedent(
         """
-        Show line 44: Number
+        Show line 3: Number
 
         """
     ).strip()
 
-    show(14, label="Number")
+    exec(
+        textwrap.dedent(
+            """
+            # line 2
+            show(14, label="Number")
+            # line 4
+            """
+        )
+    )
+
     captured = capsys.readouterr()
     assert captured.err.strip().startswith(expected_output), captured.err
 
@@ -343,11 +361,20 @@ def test_show_does_not_raise_error_for_series_from_same_domain(
 def test_show_not_run_outside_debug_context(capsys):
     expected_output = textwrap.dedent(
         """
-        Show line 351:
+        Show line 3:
          - show() ignored because we're not running in debug mode
         """
     ).strip()
 
-    show(patients.date_of_birth, patients.sex)
+    exec(
+        textwrap.dedent(
+            """
+            # line 2
+            show(patients.date_of_birth, patients.sex)
+            # line 4
+            """
+        )
+    )
+
     captured = capsys.readouterr()
     assert captured.err.strip() == expected_output, captured.err

--- a/tests/unit/test_quiz.py
+++ b/tests/unit/test_quiz.py
@@ -339,9 +339,9 @@ def test_set_dummy_tables_path_in_debug_context():
     ):
         questions = quiz.Questions()
         questions.set_dummy_tables_path("bar")
-        assert debugger.DEBUG_QUERY_ENGINE.dsn.name == "bar"
+        assert debugger.DEBUG_CONTEXT.query_engine.dsn.name == "bar"
     # This should be unset outside of the context manager
-    assert debugger.DEBUG_QUERY_ENGINE is None
+    assert debugger.DEBUG_CONTEXT is None
 
 
 def test_hint(capfd):


### PR DESCRIPTION
The sandbox method of evaluating and rendering ehrql objects was via
monkey patching various repr functions  The initial debug implementation
re-used this method, and manually called `repr()` from within the show()
call.

Now that we don't have a sandbox, all rendering can be done explicitly
by the show() function, so there is no need for repr monkey patching.
This refactor switches the evaluate/render steps to be done explicitly
in show(), rather than going via repr.

However, the repr monkey patching implementation used a closure to
capture the supplied renderer and engine details in the monkeypatched
function. As `show()` is a user imported static function, it cannot use
a closure. Instead, we formalize the DEBUG_QUERY_ENGINE global into
a new DEBUG_CONTEXT global, which is set via `activate_debug_context`,
and then available to use inside `show()`. This DEBUG_CONTEXT stores the
engine instance and the renderer, and knows how to render and object
with those.

Also includes some follow refactors around truncation and tests.
