### PR TITLE
Update QueryEngine API to support multiple results tables

### DIFF
--- a/docs/includes/generated_docs/cli.md
+++ b/docs/includes/generated_docs/cli.md
@@ -467,7 +467,7 @@ double-dash ` -- `.
   create-dummy-tables
 </h2>
 ```
-ehrql create-dummy-tables DEFINITION_FILE DUMMY_TABLES_PATH [--help]
+ehrql create-dummy-tables DEFINITION_FILE [DUMMY_TABLES_PATH] [--help]
       [ -- ... PARAMETERS ...]
 ```
 Generate dummy tables and write them out as files – one per table, CSV by

--- a/ehrql/__main__.py
+++ b/ehrql/__main__.py
@@ -662,13 +662,31 @@ def existing_python_file(value):
 
 
 def valid_output_path(value):
+    # This can be either a single file or a directory, but either way it needs to
+    # specify a valid output format
     path = Path(value)
-    extension = get_file_extension(path)
-    if extension not in FILE_FORMATS:
+    directory_ext = split_directory_and_extension(path)[1]
+    file_ext = get_file_extension(path)
+    if not directory_ext and not file_ext:
         raise ArgumentTypeError(
-            f"'{extension}' is not a supported format, must be one of: "
-            f"{backtick_join(FILE_FORMATS)}"
+            f"No file format supplied\n"
+            f"To write a single file use a file extension: {backtick_join(FILE_FORMATS)}"
+            f"To write multiple files use a directory extension: "
+            f"{backtick_join(format_directory_extension(e) for e in FILE_FORMATS)}\n"
         )
+    elif directory_ext:
+        if directory_ext not in FILE_FORMATS:
+            raise ArgumentTypeError(
+                f"'{format_directory_extension(directory_ext)}' is not a supported format, "
+                f"must be one of: "
+                f"{backtick_join(format_directory_extension(e) for e in FILE_FORMATS)}"
+            )
+    else:
+        if file_ext not in FILE_FORMATS:
+            raise ArgumentTypeError(
+                f"'{file_ext}' is not a supported format, must be one of: "
+                f"{backtick_join(FILE_FORMATS)}"
+            )
     return path
 
 

--- a/ehrql/__main__.py
+++ b/ehrql/__main__.py
@@ -293,6 +293,7 @@ def add_create_dummy_tables(subparsers, environ, user_args):
     add_dataset_definition_file_argument(parser, environ)
     parser.add_argument(
         "dummy_tables_path",
+        nargs="?",
         help=strip_indent(
             f"""
             Path to directory where files (one per table) will be written.

--- a/ehrql/__main__.py
+++ b/ehrql/__main__.py
@@ -701,7 +701,7 @@ def query_engine_from_id(str_id):
                 f"(or a full dotted path to a query engine class)"
             )
     query_engine = import_string(str_id)
-    assert_duck_type(query_engine, "query engine", "get_results")
+    assert_duck_type(query_engine, "query engine", "get_results_tables")
     return query_engine
 
 

--- a/ehrql/docs/cli.py
+++ b/ehrql/docs/cli.py
@@ -56,6 +56,13 @@ def get_argument(action):
             "usage_long": ", ".join(action.option_strings),
             "description": action.help,
         }
+    elif isinstance(action, argparse._StoreAction) and action.nargs == "?":
+        return {
+            "id": action.dest,
+            "usage_short": f"[{action.dest.upper()}]",
+            "usage_long": action.dest.upper(),
+            "description": action.help,
+        }
     elif isinstance(action, argparse._StoreAction) and not action.required:
         return {
             "id": action.option_strings[-1].lstrip("-"),

--- a/ehrql/dummy_data/generator.py
+++ b/ehrql/dummy_data/generator.py
@@ -131,10 +131,16 @@ class DummyDataGenerator:
             if i not in inline_patient_ids:
                 yield i
 
-    def get_results(self):
+    def get_results_tables(self):
         database = InMemoryDatabase(self.get_data())
         engine = InMemoryQueryEngine(database)
-        return engine.get_results(self.dataset)
+        return engine.get_results_tables(self.dataset)
+
+    def get_results(self):
+        tables = self.get_results_tables()
+        yield from next(tables)
+        for remaining in tables:
+            assert False, "Expected only one results table"
 
 
 class DummyPatientGenerator:

--- a/ehrql/dummy_data_nextgen/generator.py
+++ b/ehrql/dummy_data_nextgen/generator.py
@@ -245,10 +245,16 @@ class DummyDataGenerator:
             if i not in inline_patient_ids:
                 yield i
 
-    def get_results(self):
+    def get_results_tables(self):
         database = InMemoryDatabase(self.get_data())
         engine = InMemoryQueryEngine(database)
-        return engine.get_results(self.dataset)
+        return engine.get_results_tables(self.dataset)
+
+    def get_results(self):
+        tables = self.get_results_tables()
+        yield from next(tables)
+        for remaining in tables:
+            assert False, "Expected only one results table"
 
 
 class DummyPatientGenerator:

--- a/ehrql/file_formats/console.py
+++ b/ehrql/file_formats/console.py
@@ -1,0 +1,28 @@
+"""
+Handles writing rows/tables to the console for local development and debugging.
+
+At present, this just uses the CSV writer but there's scope for using something a bit
+prettier and more readable here in future.
+"""
+
+import sys
+
+from ehrql.file_formats.csv import write_rows_csv_lines
+
+
+def write_rows_console(rows, column_specs):
+    write_rows_csv_lines(sys.stdout, rows, column_specs)
+
+
+def write_tables_console(tables, table_specs):
+    write_table_names = len(table_specs) > 1
+    first_table = True
+    for rows, (table_name, column_specs) in zip(tables, table_specs.items()):
+        if first_table:
+            first_table = False
+        else:
+            # Add whitespace between tables
+            sys.stdout.write("\n\n")
+        if write_table_names:
+            sys.stdout.write(f"{table_name}\n")
+        write_rows_console(rows, column_specs)

--- a/ehrql/file_formats/csv.py
+++ b/ehrql/file_formats/csv.py
@@ -1,8 +1,6 @@
 import csv
 import datetime
 import gzip
-import sys
-from contextlib import nullcontext
 
 from ehrql.file_formats.base import (
     BaseRowsReader,
@@ -12,13 +10,8 @@ from ehrql.file_formats.base import (
 
 
 def write_rows_csv(filename, rows, column_specs):
-    if filename is None:
-        context = nullcontext(sys.stdout)
-    else:
-        # Set `newline` as per Python docs:
-        # https://docs.python.org/3/library/csv.html#id3
-        context = filename.open(mode="w", newline="")
-    with context as f:
+    # Set `newline` as per Python docs: https://docs.python.org/3/library/csv.html#id3
+    with filename.open(mode="w", newline="") as f:
         write_rows_csv_lines(f, rows, column_specs)
 
 

--- a/ehrql/file_formats/main.py
+++ b/ehrql/file_formats/main.py
@@ -35,9 +35,7 @@ def write_rows(filename, rows, column_specs):
     # whole thing into memory. So we wrap it in a function which draws the first item
     # upfront, but doesn't consume the rest of the iterator.
     rows = eager_iterator(rows)
-    # We use None for stdout
-    if filename is not None:
-        filename.parent.mkdir(parents=True, exist_ok=True)
+    filename.parent.mkdir(parents=True, exist_ok=True)
     writer(filename, rows, column_specs)
 
 
@@ -123,10 +121,7 @@ def write_tables(filename, tables, table_specs):
 
 
 def get_file_extension(filename):
-    if filename is None:
-        # If we have no filename we're writing to stdout, so default to CSV
-        return ".csv"
-    elif filename.suffix == ".gz":
+    if filename.suffix == ".gz":
         return "".join(filename.suffixes[-2:])
     else:
         return filename.suffix
@@ -180,8 +175,6 @@ def input_filename_supports_multiple_tables(filename):
 
 
 def output_filename_supports_multiple_tables(filename):
-    if filename is None:
-        return False
     # Again, at present only directories support multiple output tables but see above
     extension = split_directory_and_extension(filename)[1]
     return extension != ""

--- a/ehrql/file_formats/main.py
+++ b/ehrql/file_formats/main.py
@@ -48,6 +48,9 @@ def read_rows(filename, column_specs, allow_missing_columns=False):
 
 
 def read_tables(filename, table_specs, allow_missing_columns=False):
+    if not filename.exists():
+        raise FileValidationError(f"Missing file or directory: {filename}")
+
     # If we've got a single-table input file and only a single table to read then that's
     # fine, but it needs slightly special handling
     if not input_filename_supports_multiple_tables(filename):

--- a/ehrql/file_formats/main.py
+++ b/ehrql/file_formats/main.py
@@ -6,6 +6,7 @@ from ehrql.file_formats.arrow import (
     write_rows_arrow,
 )
 from ehrql.file_formats.base import FileValidationError
+from ehrql.file_formats.console import write_rows_console, write_tables_console
 from ehrql.file_formats.csv import (
     CSVGZRowsReader,
     CSVRowsReader,
@@ -23,6 +24,9 @@ FILE_FORMATS = {
 
 
 def write_rows(filename, rows, column_specs):
+    if filename is None:
+        return write_rows_console(rows, column_specs)
+
     extension = get_file_extension(filename)
     writer = FILE_FORMATS[extension][0]
     # `rows` is often a generator which won't actually execute until we start consuming
@@ -93,6 +97,9 @@ def read_tables(filename, table_specs, allow_missing_columns=False):
 
 
 def write_tables(filename, tables, table_specs):
+    if filename is None:
+        return write_tables_console(tables, table_specs)
+
     # If we've got a single-table output file and only a single table to write then
     # that's fine, but it needs slightly special handling
     if not output_filename_supports_multiple_tables(filename):

--- a/ehrql/main.py
+++ b/ehrql/main.py
@@ -35,8 +35,8 @@ from ehrql.measures import (
 from ehrql.query_engines.local_file import LocalFileQueryEngine
 from ehrql.query_engines.sqlite import SQLiteQueryEngine
 from ehrql.query_model.column_specs import (
-    get_column_specs,
     get_column_specs_from_schema,
+    get_table_specs,
 )
 from ehrql.query_model.graphs import graph_to_svg
 from ehrql.serializer import serialize
@@ -71,7 +71,10 @@ def generate_dataset(
         log.info(f"Testing dataset definition with tests in {str(definition_file)}")
         assure(test_data_file, environ=environ, user_args=user_args)
 
-    column_specs = get_column_specs(dataset)
+    table_specs = get_table_specs(dataset)
+    # For now we only handle datasets with a single output table
+    assert len(table_specs) == 1
+    column_specs = list(table_specs.values())[0]
 
     if dsn:
         log.info("Generating dataset")

--- a/ehrql/main.py
+++ b/ehrql/main.py
@@ -132,8 +132,10 @@ def create_dummy_tables(definition_file, dummy_tables_path, user_args, environ):
     generator = get_dummy_data_generator(dataset, dummy_data_config)
     table_data = generator.get_data()
 
-    directory, extension = split_directory_and_extension(dummy_tables_path)
-    log.info(f"Writing tables as '{extension}' files to '{directory}'")
+    if dummy_tables_path is not None:
+        directory, extension = split_directory_and_extension(dummy_tables_path)
+        log.info(f"Writing tables as '{extension}' files to '{directory}'")
+
     table_specs = {
         table.name: get_column_specs_from_schema(table.schema)
         for table in table_data.keys()

--- a/ehrql/main.py
+++ b/ehrql/main.py
@@ -175,8 +175,8 @@ def dump_dataset_sql(
 
 
 def get_sql_strings(query_engine, dataset):
-    results_query = query_engine.get_query(dataset)
-    setup_queries, cleanup_queries = get_setup_and_cleanup_queries([results_query])
+    results_queries = query_engine.get_queries(dataset)
+    setup_queries, cleanup_queries = get_setup_and_cleanup_queries(results_queries)
     dialect = query_engine.sqlalchemy_dialect()
     sql_strings = []
 
@@ -184,8 +184,11 @@ def get_sql_strings(query_engine, dataset):
         sql = clause_as_str(query, dialect)
         sql_strings.append(f"-- Setup query {i:03} / {len(setup_queries):03}\n{sql}")
 
-    sql = clause_as_str(results_query, dialect)
-    sql_strings.append(f"-- Results query\n{sql}")
+    for i, query in enumerate(results_queries, start=1):
+        sql = clause_as_str(query, dialect)
+        sql_strings.append(
+            f"-- Results query {i:03} / {len(results_queries):03}\n{sql}"
+        )
 
     for i, query in enumerate(cleanup_queries, start=1):
         sql = clause_as_str(query, dialect)

--- a/ehrql/main.py
+++ b/ehrql/main.py
@@ -176,7 +176,7 @@ def dump_dataset_sql(
 
 def get_sql_strings(query_engine, dataset):
     results_query = query_engine.get_query(dataset)
-    setup_queries, cleanup_queries = get_setup_and_cleanup_queries(results_query)
+    setup_queries, cleanup_queries = get_setup_and_cleanup_queries([results_query])
     dialect = query_engine.sqlalchemy_dialect()
     sql_strings = []
 

--- a/ehrql/query_engines/base.py
+++ b/ehrql/query_engines/base.py
@@ -2,6 +2,10 @@ from collections.abc import Iterator, Sequence
 from typing import Any
 
 from ehrql.query_model import nodes as qm
+from ehrql.utils.itertools_utils import iter_groups
+
+
+class Marker: ...
 
 
 class BaseQueryEngine:
@@ -11,6 +15,9 @@ class BaseQueryEngine:
     Inheriting classes must implement translating the query model into their particular
     flavour of tables and query language (SQL, pandas dataframes etc).
     """
+
+    # Sentinel value used to mark the start of a new results table in a stream of results
+    RESULTS_START = Marker()
 
     def __init__(self, dsn: str, backend: Any = None, config: dict | None = None):
         """
@@ -25,12 +32,42 @@ class BaseQueryEngine:
         self.backend = backend
         self.config = config or {}
 
-    def get_results(self, dataset: qm.Dataset) -> Iterator[Sequence]:
+    def get_results_tables(self, dataset: qm.Dataset) -> Iterator[Iterator[Sequence]]:
         """
-        Given a query model `Dataset` return the results as an iterator of "rows" (which
-        are usually tuples, but any sequence type will do)
+        Given a query model `Dataset` return an iterator of "results tables", where each
+        table is an iterator of rows (usually tuples, but any sequence type will do)
+
+        This is the primary interface to query engines and the one required method.
+
+        Typically however, query engine subclasses will implement `get_results_stream`
+        instead which yields a flat sequence of rows, with tables separated by the
+        `RESULTS_START` marker value. This is converted into the appropriate structure
+        by `iter_groups` which also enforces that the caller interacts with it safely.
+        """
+        return iter_groups(self.get_results_stream(dataset), self.RESULTS_START)
+
+    def get_results_stream(self, dataset: qm.Dataset) -> Iterator[Sequence | Marker]:
+        """
+        Given a query model `Dataset` return an iterator of rows over all the results
+        tables, with each table's results separated by the `RESULTS_START` marker value
 
         Override this method to do the things necessary to generate query code and
         execute it against a particular backend.
+
+        Emitting results in a flat sequence like this with separators between the tables
+        ends up making the query code _much_ easier to reason about because everything
+        happens in a clear linear sequence rather than inside nested generators. This
+        makes things like transaction management and error handling much more
+        straightforward.
         """
         raise NotImplementedError()
+
+    def get_results(self, dataset: qm.Dataset) -> Iterator[Sequence]:
+        """
+        Temporary method to continue to support code which assumes only a single results
+        table
+        """
+        tables = self.get_results_tables(dataset)
+        yield from next(tables)
+        for remaining in tables:
+            assert False, "Expected only one results table"

--- a/ehrql/query_engines/base_sql.py
+++ b/ehrql/query_engines/base_sql.py
@@ -837,7 +837,7 @@ class BaseSQLQueryEngine(BaseQueryEngine):
 
     def get_results(self, dataset):
         results_query = self.get_query(dataset)
-        setup_queries, cleanup_queries = get_setup_and_cleanup_queries(results_query)
+        setup_queries, cleanup_queries = get_setup_and_cleanup_queries([results_query])
         with self.engine.connect() as connection:
             for i, setup_query in enumerate(setup_queries, start=1):
                 log.info(f"Running setup query {i:03} / {len(setup_queries):03}")

--- a/ehrql/query_engines/in_memory.py
+++ b/ehrql/query_engines/in_memory.py
@@ -28,9 +28,10 @@ class InMemoryQueryEngine(BaseQueryEngine):
     tests, and a to provide a reference implementation for other engines.
     """
 
-    def get_results(self, dataset):
+    def get_results_stream(self, dataset):
         table = self.get_results_as_patient_table(dataset)
         Row = namedtuple("Row", table.name_to_col.keys())
+        yield self.RESULTS_START
         for record in table.to_records():
             yield Row(**record)
 

--- a/ehrql/query_engines/local_file.py
+++ b/ehrql/query_engines/local_file.py
@@ -14,14 +14,14 @@ class LocalFileQueryEngine(InMemoryQueryEngine):
 
     database = None
 
-    def get_results(self, dataset):
+    def get_results_stream(self, dataset):
         # Given the dataset supplied determine the tables used and load the associated
         # data into the database
         self.populate_database(
             get_table_nodes(dataset),
         )
         # Run the query as normal
-        return super().get_results(dataset)
+        return super().get_results_stream(dataset)
 
     def populate_database(self, table_nodes, allow_missing_columns=True):
         table_specs = {

--- a/ehrql/query_engines/mssql.py
+++ b/ehrql/query_engines/mssql.py
@@ -170,7 +170,7 @@ class MSSQLQueryEngine(BaseSQLQueryEngine):
         results_table = results_query.get_final_froms()[0]
         assert str(results_query) == str(sqlalchemy.select(results_table))
 
-        setup_queries, cleanup_queries = get_setup_and_cleanup_queries(results_query)
+        setup_queries, cleanup_queries = get_setup_and_cleanup_queries([results_query])
 
         with self.engine.connect() as connection:
             # All our queries are either (a) read-only queries against static data, or

--- a/ehrql/utils/itertools_utils.py
+++ b/ehrql/utils/itertools_utils.py
@@ -27,3 +27,77 @@ def iter_flatten(iterable, iter_classes=(list, tuple, GeneratorType)):
             yield from iter_flatten(item, iter_classes)
         else:
             yield item
+
+
+def iter_groups(iterable, separator):
+    """
+    Split a flat iterator of items into a nested iterator of groups of items. Groups are
+    delineated by the presence of a sentinel `separator` value which marks the start of
+    each group.
+
+    For example, the iterator:
+
+        - SEPARATOR
+        - 1
+        - 2
+        - SEPARATOR
+        - 3
+        - 4
+
+    Will be transformed into the nested iterator:
+
+        -
+          - 1
+          - 2
+        -
+          - 3
+          - 4
+
+    This is useful for situations where a nested iterator is the natural API for
+    representing the data but the flat iterator is much easier to generate correctly.
+    """
+    iterator = iter(iterable)
+    try:
+        first_item = next(iterator)
+    except StopIteration:
+        return
+    assert first_item is separator, (
+        f"Invalid iterator: does not start with `separator` value {separator!r}"
+    )
+    while True:
+        group_iter = GroupIterator(iterator, separator)
+        yield group_iter
+        # Prevent the caller from trying to consume the next group before they've
+        # finished consuming the current one (as would happen if you naively called
+        # `list()` on the result of `iter_groups()`)
+        assert group_iter._group_complete, (
+            "Cannot consume next group until current group has been exhausted"
+        )
+        if group_iter._exhausted:
+            break
+
+
+class GroupIterator:
+    def __init__(self, iterator, separator):
+        self._iterator = iterator
+        self._separator = separator
+        self._group_complete = False
+        self._exhausted = False
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        if self._group_complete:
+            raise StopIteration()
+        try:
+            value = next(self._iterator)
+        except StopIteration:
+            self._group_complete = True
+            self._exhausted = True
+            raise
+        if value is self._separator:
+            self._group_complete = True
+            raise StopIteration()
+        else:
+            return value

--- a/tests/functional/test_create_dummy_tables.py
+++ b/tests/functional/test_create_dummy_tables.py
@@ -51,3 +51,12 @@ def test_create_dummy_tables(
     lines = (dummy_tables_path / "patients.csv").read_text().splitlines()
     assert lines[0] == expected_columns
     assert len(lines) == 11  # 1 header, 10 rows
+
+
+def test_create_dummy_tables_console_output(call_cli, tmp_path):
+    dataset_definition_path = tmp_path / "dataset_definition.py"
+    dataset_definition_path.write_text(trivial_dataset_definition)
+    captured = call_cli("create-dummy-tables", dataset_definition_path)
+
+    assert "patient_id" in captured.out
+    assert "date_of_birth" in captured.out

--- a/tests/integration/backends/test_emis.py
+++ b/tests/integration/backends/test_emis.py
@@ -591,7 +591,7 @@ def test_inline_table_includes_organisation_hash(trino_database):
     ]
     assert len(set(inline_tables)) == 1
     inline_table = inline_tables[0]
-    setup_queries, cleanup_queries = get_setup_and_cleanup_queries(results_query)
+    setup_queries, cleanup_queries = get_setup_and_cleanup_queries([results_query])
 
     with query_engine.engine.connect() as connection:
         for setup_query in setup_queries:
@@ -646,7 +646,7 @@ def test_temp_table_includes_organisation_hash(trino_database):
     ]
     assert len(set(temp_tables)) == 1
     temp_table = temp_tables[0]
-    setup_queries, cleanup_queries = get_setup_and_cleanup_queries(results_query)
+    setup_queries, cleanup_queries = get_setup_and_cleanup_queries([results_query])
 
     with query_engine.engine.connect() as connection:
         for setup_query in setup_queries:

--- a/tests/integration/backends/test_emis.py
+++ b/tests/integration/backends/test_emis.py
@@ -583,15 +583,16 @@ def test_inline_table_includes_organisation_hash(trino_database):
 
     variables = dataset._compile()
 
-    results_query = query_engine.get_query(variables)
+    results_queries = query_engine.get_queries(variables)
+    assert len(results_queries) == 1
     inline_tables = [
         ch
-        for ch in results_query.get_children()
+        for ch in results_queries[0].get_children()
         if isinstance(ch, GeneratedTable) and "inline_data" in ch.name
     ]
     assert len(set(inline_tables)) == 1
     inline_table = inline_tables[0]
-    setup_queries, cleanup_queries = get_setup_and_cleanup_queries([results_query])
+    setup_queries, cleanup_queries = get_setup_and_cleanup_queries(results_queries)
 
     with query_engine.engine.connect() as connection:
         for setup_query in setup_queries:
@@ -638,15 +639,16 @@ def test_temp_table_includes_organisation_hash(trino_database):
     )
 
     variables = dataset._compile()
-    results_query = query_engine.get_query(variables)
+    results_queries = query_engine.get_queries(variables)
+    assert len(results_queries) == 1
     temp_tables = [
         ch
-        for ch in results_query.get_children()
+        for ch in results_queries[0].get_children()
         if isinstance(ch, GeneratedTable) and "tmp" in ch.name
     ]
     assert len(set(temp_tables)) == 1
     temp_table = temp_tables[0]
-    setup_queries, cleanup_queries = get_setup_and_cleanup_queries([results_query])
+    setup_queries, cleanup_queries = get_setup_and_cleanup_queries(results_queries)
 
     with query_engine.engine.connect() as connection:
         for setup_query in setup_queries:

--- a/tests/integration/file_formats/test_main.py
+++ b/tests/integration/file_formats/test_main.py
@@ -313,3 +313,28 @@ def test_read_tables_with_missing_file_raises_appropriate_error(tmp_path):
     }
     with pytest.raises(FileValidationError, match="Missing file or directory"):
         next(read_tables(missing_file, table_specs))
+
+
+def test_write_rows_without_filename_writes_to_console(capsys):
+    write_rows(None, TEST_FILE_DATA, TEST_FILE_SPECS)
+    output = capsys.readouterr().out
+    # The exact content here is tested elsewhere, we just want to make sure things are
+    # wired up correctly
+    assert "patient_id" in output
+
+
+def test_write_tables_without_filename_writes_to_console(capsys):
+    table_specs = {
+        "table_1": TEST_FILE_SPECS,
+        "table_2": TEST_FILE_SPECS,
+    }
+    table_data = [
+        TEST_FILE_DATA,
+        TEST_FILE_DATA,
+    ]
+    write_tables(None, table_data, table_specs)
+    output = capsys.readouterr().out
+    # The exact content here is tested elsewhere, we just want to make sure things are
+    # wired up correctly
+    assert "patient_id" in output
+    assert "table_2" in output

--- a/tests/integration/file_formats/test_main.py
+++ b/tests/integration/file_formats/test_main.py
@@ -302,3 +302,14 @@ def test_write_tables_rejects_single_table_format_if_multiple_tables(tmp_path):
         relpath = filename.relative_to(tmp_path)
         with pytest.raises(FileValidationError, match=expected_error.rstrip()):
             write_tables(relpath, table_data, table_specs)
+
+
+def test_read_tables_with_missing_file_raises_appropriate_error(tmp_path):
+    missing_file = tmp_path / "aint-no-such-file"
+    table_specs = {
+        "table_1": {"i": ColumnSpec(int), "s": ColumnSpec(str)},
+        "table_2": {"j": ColumnSpec(int), "k": ColumnSpec(float)},
+        "table_3": {"l": ColumnSpec(int), "m": ColumnSpec(float)},
+    }
+    with pytest.raises(FileValidationError, match="Missing file or directory"):
+        next(read_tables(missing_file, table_specs))

--- a/tests/integration/file_formats/test_main.py
+++ b/tests/integration/file_formats/test_main.py
@@ -1,4 +1,6 @@
+import contextlib
 import datetime
+import textwrap
 
 import pytest
 
@@ -230,3 +232,73 @@ def test_read_and_write_tables_roundtrip(tmp_path, extension):
     results = read_tables(tmp_path / "output", table_specs)
 
     assert [list(rows) for rows in results] == tables
+
+
+def test_read_tables_allows_single_table_format_if_only_one_table(tmp_path):
+    filename = tmp_path / "file.csv"
+    filename.write_text("i,s\n1,a\n2,b\n3,c\n")
+    table_specs = {
+        "table_1": {"i": ColumnSpec(int), "s": ColumnSpec(str)},
+    }
+    results = read_tables(filename, table_specs)
+    assert [list(rows) for rows in results] == [
+        [(1, "a"), (2, "b"), (3, "c")],
+    ]
+
+
+def test_write_tables_allows_single_table_format_if_only_one_table(tmp_path):
+    filename = tmp_path / "file.csv"
+    table_specs = {
+        "table_1": {"i": ColumnSpec(int), "s": ColumnSpec(str)},
+    }
+    table_data = [
+        [(1, "a"), (2, "b"), (3, "c")],
+    ]
+    write_tables(filename, table_data, table_specs)
+    assert filename.read_text() == "i,s\n1,a\n2,b\n3,c\n"
+
+
+def test_read_tables_rejects_single_table_format_if_multiple_tables(tmp_path):
+    filename = tmp_path / "input.csv"
+    filename.touch()
+    table_specs = {
+        "table_1": {"i": ColumnSpec(int), "s": ColumnSpec(str)},
+        "table_2": {"j": ColumnSpec(int), "k": ColumnSpec(float)},
+        "table_3": {"l": ColumnSpec(int), "m": ColumnSpec(float)},
+    }
+    expected_error = textwrap.dedent(
+        """\
+        Attempting to read 3 tables, but input only provides a single table
+              Try moving -> input.csv
+                      to -> input/table_1.csv
+                  adding -> table_2.csv, table_3.csv
+          and using path -> input/
+        """
+    )
+    with contextlib.chdir(tmp_path):
+        # Use relative paths to get predictable error message
+        relpath = filename.relative_to(tmp_path)
+        with pytest.raises(FileValidationError, match=expected_error.rstrip()):
+            list(read_tables(relpath, table_specs))
+
+
+def test_write_tables_rejects_single_table_format_if_multiple_tables(tmp_path):
+    filename = tmp_path / "output.csv"
+    table_specs = {
+        "table_1": {"i": ColumnSpec(int), "s": ColumnSpec(str)},
+        "table_2": {"j": ColumnSpec(int), "k": ColumnSpec(float)},
+        "table_3": {"l": ColumnSpec(int), "m": ColumnSpec(float)},
+    }
+    table_data = [[], []]
+    expected_error = textwrap.dedent(
+        """\
+        Attempting to write 3 tables, but output only supports a single table
+          Instead of -> output.csv
+                 try -> output/:csv
+        """
+    )
+    with contextlib.chdir(tmp_path):
+        # Use relative paths to get predictable error message
+        relpath = filename.relative_to(tmp_path)
+        with pytest.raises(FileValidationError, match=expected_error.rstrip()):
+            write_tables(relpath, table_data, table_specs)

--- a/tests/unit/dummy_data_nextgen/test_specific_datasets.py
+++ b/tests/unit/dummy_data_nextgen/test_specific_datasets.py
@@ -325,7 +325,7 @@ def test_will_raise_if_all_data_is_impossible(patched_time, query):
     generator.timeout = 1
     patched_time.time.side_effect = [0.0, 20.0]
     with pytest.raises(CannotGenerate):
-        generator.get_results()
+        next(generator.get_results())
 
 
 def test_generates_events_starting_from_birthdate():

--- a/tests/unit/file_formats/test_console.py
+++ b/tests/unit/file_formats/test_console.py
@@ -1,0 +1,85 @@
+import datetime
+import textwrap
+
+from ehrql.file_formats.console import write_rows_console, write_tables_console
+from ehrql.query_model.column_specs import ColumnSpec
+from ehrql.sqlalchemy_types import TYPE_MAP
+
+
+def test_write_rows_console(capsys):
+    column_specs = {
+        "patient_id": ColumnSpec(int),
+        "b": ColumnSpec(bool),
+        "i": ColumnSpec(int),
+        "f": ColumnSpec(float),
+        "s": ColumnSpec(str),
+        "c": ColumnSpec(str, categories=("A", "B")),
+        "d": ColumnSpec(datetime.date),
+    }
+
+    rows = [
+        (123, True, 1, 2.3, "a", "A", datetime.date(2020, 1, 1)),
+        (456, False, -5, -0.4, "b", "B", datetime.date(2022, 12, 31)),
+        (789, None, None, None, None, None, None),
+    ]
+
+    # Check the example uses at least one of every supported type
+    assert {spec.type for spec in column_specs.values()} == set(TYPE_MAP)
+
+    write_rows_console(rows, column_specs)
+    output = capsys.readouterr().out
+
+    # The CSV module does its own newline handling, hence the carriage returns below
+    assert output == textwrap.dedent(
+        """\
+        patient_id,b,i,f,s,c,d\r
+        123,T,1,2.3,a,A,2020-01-01\r
+        456,F,-5,-0.4,b,B,2022-12-31\r
+        789,,,,,,\r
+        """
+    )
+
+
+def test_write_tables_console(capsys):
+    table_specs = {
+        "table_1": {
+            "patient_id": ColumnSpec(int),
+            "b": ColumnSpec(bool),
+            "i": ColumnSpec(int),
+        },
+        "table_2": {
+            "patient_id": ColumnSpec(int),
+            "s": ColumnSpec(str),
+            "d": ColumnSpec(datetime.date),
+        },
+    }
+
+    tables = [
+        [
+            (123, True, 1),
+            (456, False, 2),
+        ],
+        [
+            (789, "a", datetime.date(2025, 1, 1)),
+            (987, "B", datetime.date(2025, 2, 3)),
+        ],
+    ]
+
+    write_tables_console(tables, table_specs)
+    output = capsys.readouterr().out
+
+    # The CSV module does its own newline handling, hence the carriage returns below
+    assert output == textwrap.dedent(
+        """\
+        table_1
+        patient_id,b,i\r
+        123,T,1\r
+        456,F,2\r
+
+
+        table_2
+        patient_id,s,d\r
+        789,a,2025-01-01\r
+        987,B,2025-02-03\r
+        """
+    )

--- a/tests/unit/file_formats/test_main.py
+++ b/tests/unit/file_formats/test_main.py
@@ -17,7 +17,6 @@ from ehrql.file_formats.main import (
 @pytest.mark.parametrize(
     "filename,extension",
     [
-        (None, ".csv"),
         (Path("a/b.c/file.txt"), ".txt"),
         (Path("a/b.c/file.txt.foo"), ".foo"),
         (Path("a/b.c/file.txt.gz"), ".txt.gz"),

--- a/tests/unit/query_model/test_column_specs.py
+++ b/tests/unit/query_model/test_column_specs.py
@@ -4,8 +4,8 @@ from ehrql.codes import SNOMEDCTCode
 from ehrql.query_model.column_specs import (
     ColumnSpec,
     get_categories,
-    get_column_specs,
     get_range,
+    get_table_specs,
 )
 from ehrql.query_model.nodes import (
     AggregateByPatient,
@@ -46,14 +46,16 @@ def test_get_column_specs():
             category=SelectColumn(patients, "category"),
         ),
     )
-    column_specs = get_column_specs(dataset)
-    assert column_specs == {
-        "patient_id": ColumnSpec(type=int, nullable=False, categories=None),
-        "dob": ColumnSpec(type=datetime.date, nullable=True, categories=None),
-        "code": ColumnSpec(type=str, nullable=True, categories=None),
-        "category": ColumnSpec(
-            type=str, nullable=True, categories=("123000", "456000")
-        ),
+    table_specs = get_table_specs(dataset)
+    assert table_specs == {
+        "dataset": {
+            "patient_id": ColumnSpec(type=int, nullable=False, categories=None),
+            "dob": ColumnSpec(type=datetime.date, nullable=True, categories=None),
+            "code": ColumnSpec(type=str, nullable=True, categories=None),
+            "category": ColumnSpec(
+                type=str, nullable=True, categories=("123000", "456000")
+            ),
+        }
     }
 
 

--- a/tests/unit/test___main__.py
+++ b/tests/unit/test___main__.py
@@ -248,7 +248,7 @@ def test_import_string_no_such_attribute():
 
 
 class DummyQueryEngine:
-    def get_results(self):
+    def get_results_tables(self):
         raise NotImplementedError()
 
 

--- a/tests/unit/test___main__.py
+++ b/tests/unit/test___main__.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pytest
 
 from ehrql.__main__ import (
@@ -10,6 +12,7 @@ from ehrql.__main__ import (
     import_string,
     main,
     query_engine_from_id,
+    valid_output_path,
 )
 from ehrql.backends.base import SQLBackend
 from ehrql.query_engines.base import BaseQueryEngine
@@ -323,3 +326,30 @@ def test_all_backends_have_an_alias():
 def test_all_backend_aliases_match_display_names():
     for alias in BACKEND_ALIASES.keys():
         assert backend_from_id(alias).display_name.lower() == alias
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "some/path/file.csv",
+        "some/path/dir:csv",
+        "some/path/dir/:csv",
+        "some/path/dir.foo:csv",
+    ],
+)
+def test_valid_output_path(path):
+    assert valid_output_path(path) == Path(path)
+
+
+@pytest.mark.parametrize(
+    "path, message",
+    [
+        ("no/extension", "No file format supplied"),
+        ("some/path.badfile", "'.badfile' is not a supported format"),
+        ("some/path:baddir", "':baddir' is not a supported format"),
+        ("some/path/:baddir", "':baddir' is not a supported format"),
+    ],
+)
+def test_valid_output_path_errors(path, message):
+    with pytest.raises(ArgumentTypeError, match=message):
+        valid_output_path(path)


### PR DESCRIPTION
This PR refactors the query engine API and the plumbing around it such that it _could_ in principle support returning event-level data if only we had some datasets which returned more than one query.

The one remaining piece of plumbing that needs doing is upgrading the `show()` debug command to output multiple tables when called on a dataset with event-level data. But that's not a total blocker so I'm going to defer working on that for now.


### Query Engine API

The major change to the query engine API is replacing the `get_results()` method, which returned an iterator over a single table of results, with `get_results_tables()` which returns a nested iterator over multiple tables of results.

To avoid massive changes to the test suite (and particularly to the under-development dummy data tests) we retain a `get_results()` method which asserts that we only have a single table of results and returns it as previously.

The SQL engines also change their `get_query()` method to `get_queries()` to support multiple queries.


### Plumbing

The major change here is supporting writing more than one table of output. If ehrQL sees that your dataset definition is going to produce multiple output tables then it will require that you give it an output path like `path/to/directory/:arrow`, with the final suffix indicating the type of file to produce.

If you don't supply any output path at all then it will write the tables to the console, one after the other. This involves adding a dedicated `console` output handler which at the moment is just a tiny wrapper around the CSV handler but could be updated to produce something more user-friendly like pretty-printed ASCII tables.