### PR TITLE
Refactored autocomplete tests to increase speed

### DIFF
--- a/tests/autocomplete/autocomplete_definition.py
+++ b/tests/autocomplete/autocomplete_definition.py
@@ -43,8 +43,8 @@ clinical_events.numeric_value.mean_for_patient()  ## type:FloatPatientSeries
 clinical_events.date.count_episodes_for_patient(weeks(1))  ## type:IntPatientSeries
 patients.exists_for_patient()  ## type:BoolPatientSeries
 patients.count_for_patient()  ## type:IntPatientSeries
-days(100) == days(100)  ## type:bool
-days(100) != days(100)  ## type:bool
+bool_eq = days(100) == days(100)  ## type:bool
+bool_neq = days(100) != days(100)  ## type:bool
 
 # There are some things that return the same type as the calling
 # object or one of the arguments


### PR DESCRIPTION
The existing approach to testing autocomplete via the language server was:

1. Create a temporary file on disk with dummy lines
2. Notify the language server that we "opened" a file
3. For each test
    - Notify the language server that a line had changed to the thing we want to test
    - Ask the language server for completion, or type.

This was pretty slow because presumably the language server needs to re-parse the file each time.

This is now refactored so it's possible to:
1. Create a temporary file with all the content for a parameterized test
2. Notify the language server that we "opened" a file
3. For each test
    - Ask for completion, or type, for a given line, cursor position

This makes the run time go from 2-3 minutes, to 2-3 seconds.