### PR TITLE
Fix passing of string column names to `sort_by()` in docs

### DIFF
--- a/docs/how-to/errors.md
+++ b/docs/how-to/errors.md
@@ -776,7 +776,7 @@ NameError: name 'date' is not defined
 
 #### Fixed dataset definition :heavy_check_mark:
 
-Columns can be specified as the table attribute:
+Columns must be specified as the table attribute:
 
 ```python
 from ehrql import create_dataset
@@ -784,17 +784,6 @@ from ehrql.tables.core import clinical_events
 
 dataset = create_dataset()
 first_event = clinical_events.sort_by(clinical_events.date).first_for_patient()
-dataset.event_date = first_event.date
-```
-
-They can also be specified as a name string:
-
-```python
-from ehrql import create_dataset
-from ehrql.tables.core import clinical_events
-
-dataset = create_dataset()
-first_event = clinical_events.sort_by("date").first_for_patient()
 dataset.event_date = first_event.date
 ```
 

--- a/docs/tutorial/building-a-dataset/index.md
+++ b/docs/tutorial/building-a-dataset/index.md
@@ -99,14 +99,14 @@ was_registered = (
 last_diagnosis_date = (
     previous_events
     .where(clinical_events.snomedct_code.is_in(diabetes_codes))
-    .sort_by("date")
+    .sort_by(clinical_events.date)
     .last_for_patient()
     .date
 )
 last_resolved_date = (
     previous_events
     .where(clinical_events.snomedct_code.is_in(resolved_codes))
-    .sort_by("date")
+    .sort_by(clinical_events.date)
     .last_for_patient()
     .date
 )

--- a/docs/tutorial/more-complex-transformations/index.md
+++ b/docs/tutorial/more-complex-transformations/index.md
@@ -188,14 +188,14 @@ resolved_codes = codelist_from_csv("codelists/nhsd-primary-care-domain-refsets-d
 
 last_diagnosis_date = (
     clinical_events.where(clinical_events.snomedct_code.is_in(diabetes_codes))
-    .sort_by("date")
+    .sort_by(clinical_events.date)
     .where(clinical_events.date <= index_date)
     .last_for_patient()
     .date
 )
 last_resolved_date = (
     clinical_events.where(clinical_events.snomedct_code.is_in(resolved_codes))
-    .sort_by("date")
+    .sort_by(clinical_events.date)
     .where(clinical_events.date <= index_date)
     .last_for_patient()
     .date
@@ -226,14 +226,14 @@ resolved_codes = codelist_from_csv("codelists/nhsd-primary-care-domain-refsets-d
 
 last_diagnosis_date = (
     clinical_events.where(clinical_events.snomedct_code.is_in(diabetes_codes))
-    .sort_by("date")
+    .sort_by(clinical_events.date)
     .where(clinical_events.date <= index_date)
     .last_for_patient()
     .date
 )
 last_resolved_date = (
     clinical_events.where(clinical_events.snomedct_code.is_in(resolved_codes))
-    .sort_by("date")
+    .sort_by(clinical_events.date)
     .where(clinical_events.date <= index_date)
     .last_for_patient()
     .date
@@ -275,14 +275,14 @@ is_registered = (
 
 last_diagnosis_date = (
     clinical_events.where(clinical_events.snomedct_code.is_in(diabetes_codes))
-    .sort_by("date")
+    .sort_by(clinical_events.date)
     .where(clinical_events.date <= index_date)
     .last_for_patient()
     .date
 )
 last_resolved_date = (
     clinical_events.where(clinical_events.snomedct_code.is_in(resolved_codes))
-    .sort_by("date")
+    .sort_by(clinical_events.date)
     .where(clinical_events.date <= index_date)
     .last_for_patient()
     .date


### PR DESCRIPTION
There's a long, complicated story behind why this not only doesn't raise an error but also, under certain circumstances, seems to do the right thing.

A subsequent PR will make this a hard (but hopefully helpful) error, but fixing the incorrect documentation feels like a quick and urgent thing.

Slack thread:
https://bennettoxford.slack.com/archives/C069YDR4NCA/p1737371753202199