### PR TITLE
Ensure date of death dummy data values is weighted towards None

### DIFF
--- a/ehrql/dummy_data_nextgen/generator.py
+++ b/ehrql/dummy_data_nextgen/generator.py
@@ -66,6 +66,8 @@ class PopulationSubset:
             if n < len(result):
                 indices = self.random.sample(range(0, len(result)), n)
                 indices.sort()
+                if result[0] is None and 0 not in indices:
+                    indices = [0, *indices]
                 result = [result[i] for i in indices]
         self.__cache[column_info] = result
         return result

--- a/ehrql/dummy_data_nextgen/generator.py
+++ b/ehrql/dummy_data_nextgen/generator.py
@@ -591,7 +591,22 @@ class DummyPatientGenerator:
 
     def choose_random_value(self, column_info, values):
         if column_info.type is date:
-            result = self.rnd.choice(values)
+            # If this date column is date of death, and None is a possible
+            # value (but not the only one), we want to skew the dummy data towards
+            # producing None values most often.  The actual weights here are a bit arbitrary,
+            # but result in None being picked around 90% of the time
+            if (
+                column_info.name == "date_of_death"
+                and values[0] is None
+                and len(values) > 1
+            ):
+                # total weights are 10; None is given a weight of 9 and all other
+                # values get weightings that add up to 1
+                other_weights = [1 / (len(values) - 1)] * (len(values) - 1)
+                weights = [9, *other_weights]
+            else:
+                weights = None
+            result = self.rnd.choices(values, weights=weights, k=1)[0]
             if result is None:
                 return result
             if self.events_start <= result <= self.events_end:

--- a/tests/unit/dummy_data/test_generator.py
+++ b/tests/unit/dummy_data/test_generator.py
@@ -92,6 +92,33 @@ def test_dummy_data_generator():
         assert r.imd in {None, 0, 1000, 2000, 3000, 4000, 5000}
 
 
+def test_dummy_data_generator_date_of_death_in_population_query():
+    # Define a basic dataset with nullable date of death in the population query
+    # Test that None values are more likely to be produced than not-None
+    dataset = Dataset()
+    dataset.define_population(
+        patients.exists_for_patient()
+        & (
+            patients.date_of_death.is_after("2020-01-01")
+            | patients.date_of_death.is_null()
+        )
+    )
+    dataset.date_of_death = patients.date_of_death
+
+    # Generate some results
+    target_size = 10
+
+    variable_definitions = dataset._compile()
+    generator = DummyDataGenerator(variable_definitions, population_size=target_size)
+    generator.batch_size = 7
+    results = list(generator.get_results())
+
+    assert len(results) == target_size
+    date_of_death_results = [r.date_of_death for r in results]
+    # Dates of death are None 70-90% of time
+    assert 0.70 <= (date_of_death_results.count(None) / target_size) <= 0.9
+
+
 @mock.patch("ehrql.dummy_data.generator.time")
 def test_dummy_data_generator_timeout_with_some_results(patched_time):
     dataset = Dataset()

--- a/tests/unit/dummy_data_nextgen/test_measures.py
+++ b/tests/unit/dummy_data_nextgen/test_measures.py
@@ -43,7 +43,7 @@ def test_dummy_measures_data_generator():
 
     intervals = years(2).starting_on("2020-01-01")
     measures = Measures()
-    measures.dummy_data_config.population_size = 300
+    measures.dummy_data_config.population_size = 350
 
     measures.define_measure(
         "foo_events_by_sex",


### PR DESCRIPTION
Fixes #2374 

- Ensure that None is always a possible value in a population subset
- When picking a date of death from a list of possible values, and one of those values is None, make None the most highly weighted choice (around 90%, with no other scientiifc basis other than that it's more or less consistent with the None rate in the legacy dummy data)