### PR TITLE
Various improvements to the ehrQL autocomplete tests

### DIFF
--- a/tests/autocomplete/autocomplete_definition.py
+++ b/tests/autocomplete/autocomplete_definition.py
@@ -267,3 +267,42 @@ core.patients.is_alive_on(date_str)  ## type:BoolPatientSeries
 core.patients.is_dead_on(date_str)  ## type:BoolPatientSeries
 core.practice_registrations.exists_for_patient_on(date_str)  ## type:BoolPatientSeries
 core.practice_registrations.spanning(date_str, date_str)  ## type:practice_registrations
+
+# query_language series methods not yet tested
+core.clinical_events.date.is_after(date_str)  ## type: BoolEventSeries
+core.clinical_events.date.is_before(date_str)  ## type: BoolEventSeries
+core.clinical_events.date.is_on_or_after(date_str)  ## type: BoolEventSeries
+core.clinical_events.date.is_on_or_before(date_str)  ## type: BoolEventSeries
+core.clinical_events.date.to_first_of_month()  ## type: DateEventSeries
+core.clinical_events.snomedct_code.is_in([])  ## type: BoolEventSeries
+core.clinical_events.snomedct_code.is_null()  ## type: BoolEventSeries
+core.clinical_events.snomedct_code.is_null().as_int()  ## type: IntEventSeries
+core.clinical_events.snomedct_code.when_null_then(3)  ## type: CodeEventSeries
+core.patients.date_of_birth.day.as_float()  ## type: FloatPatientSeries
+core.patients.date_of_birth.day.as_int()  ## type: IntPatientSeries
+core.patients.date_of_birth.is_between_but_not_on(
+    date_str, date_str
+)  ## type: BoolPatientSeries
+core.patients.date_of_birth.is_during((date_str, date_str))  ## type: BoolPatientSeries
+core.patients.date_of_birth.is_on_or_between(
+    date_str, date_str
+)  ## type: BoolPatientSeries
+core.patients.date_of_birth.to_first_of_year()  ## type: DatePatientSeries
+core.patients.sex.is_not_in(["male"])  ## type: BoolPatientSeries
+core.patients.sex.is_not_null()  ## type: BoolPatientSeries
+core.patients.sex.is_null().as_int()  ## type: IntPatientSeries
+tpp.apcs.all_diagnoses.is_in([])  ## type:NoReturn
+tpp.apcs.all_diagnoses.is_not_in([])  ## type:NoReturn
+tpp.addresses.msoa_code.contains([])  ## type: BoolEventSeries
+
+# query_language non-series methods
+core.clinical_events.where(
+    core.clinical_events.snomedct_code.is_in([])
+)  ## type:clinical_events
+core.clinical_events.except_where(
+    core.clinical_events.snomedct_code.is_in([])
+)  ## type:clinical_events
+
+# Duration methods
+days(100).starting_on("2045-01-01")  ## type: list[tuple[date, date]]
+days(100).ending_on("2045-01-01")  ## type: list[tuple[date, date]]

--- a/tests/autocomplete/autocomplete_definition.py
+++ b/tests/autocomplete/autocomplete_definition.py
@@ -1,6 +1,5 @@
 from ehrql import days, maximum_of, minimum_of, weeks
-from ehrql.tables.core import clinical_events, patients
-from ehrql.tables.tpp import addresses, apcs, ons_deaths
+from ehrql.tables import core, emis, tpp
 
 
 # A file to keep track of things where we get good autocomplete behaviour.
@@ -9,14 +8,14 @@ from ehrql.tables.tpp import addresses, apcs, ons_deaths
 # though it must be formatted correctly or the tests will fail. Currently you can:
 #
 # - write a single command and confirm the type e.g.:
-#     patients.date_of_birth  ## type:DatePatientSeries
+#     core.patients.date_of_birth  ## type:DatePatientSeries
 #
 # - assign a single command to a variable and confirm the type e.g.:
-#     bool_invert = ~patients.exists_for_patient()  ## type:BoolPatientSeries
+#     bool_invert = ~core.patients.exists_for_patient()  ## type:BoolPatientSeries
 #
 # - either of the above but spanning multiple lines e.g.
 #     bool_and = (
-#       patients.exists_for_patient() & patients.exists_for_patient()
+#       core.patients.exists_for_patient() & core.patients.exists_for_patient()
 #     )  ## type:BoolPatientSeries
 
 # Currently all columns on all tables have type of "Series | Any",
@@ -24,25 +23,25 @@ from ehrql.tables.tpp import addresses, apcs, ons_deaths
 # class, and on the @table decorator means the column types are
 # correct e.g. IntPatientSeries, DateEventSeries etc. and therefore
 # we get autocomplete for all the properties and methods on each series.
-patients.date_of_birth  ## type:DatePatientSeries
-patients.sex  ## type:StrPatientSeries
-ons_deaths.underlying_cause_of_death  ## type:CodePatientSeries
+core.patients.date_of_birth  ## type:DatePatientSeries
+core.patients.sex  ## type:StrPatientSeries
+core.ons_deaths.underlying_cause_of_death  ## type:CodePatientSeries
 
-clinical_events.date  ## type:DateEventSeries
-clinical_events.numeric_value  ## type:FloatEventSeries
-clinical_events.snomedct_code  ## type:CodeEventSeries
-apcs.all_diagnoses  ## type:MultiCodeStringEventSeries
+core.clinical_events.date  ## type:DateEventSeries
+core.clinical_events.numeric_value  ## type:FloatEventSeries
+core.clinical_events.snomedct_code  ## type:CodeEventSeries
+tpp.apcs.all_diagnoses  ## type:MultiCodeStringEventSeries
 
-addresses.has_postcode  ## type:BoolEventSeries
-addresses.address_id  ## type:IntEventSeries
+tpp.addresses.has_postcode  ## type:BoolEventSeries
+tpp.addresses.address_id  ## type:IntEventSeries
 
 
 # There are some methods that always return the same type
-clinical_events.snomedct_code.count_distinct_for_patient()  ## type:IntPatientSeries
-clinical_events.numeric_value.mean_for_patient()  ## type:FloatPatientSeries
-clinical_events.date.count_episodes_for_patient(weeks(1))  ## type:IntPatientSeries
-patients.exists_for_patient()  ## type:BoolPatientSeries
-patients.count_for_patient()  ## type:IntPatientSeries
+core.clinical_events.snomedct_code.count_distinct_for_patient()  ## type:IntPatientSeries
+core.clinical_events.numeric_value.mean_for_patient()  ## type:FloatPatientSeries
+core.clinical_events.date.count_episodes_for_patient(weeks(1))  ## type:IntPatientSeries
+core.patients.exists_for_patient()  ## type:BoolPatientSeries
+core.patients.count_for_patient()  ## type:IntPatientSeries
 bool_eq = days(100) == days(100)  ## type:bool
 bool_neq = days(100) != days(100)  ## type:bool
 
@@ -50,21 +49,21 @@ bool_neq = days(100) != days(100)  ## type:bool
 # object or one of the arguments
 
 bool_and = (
-    patients.exists_for_patient() & patients.exists_for_patient()
+    core.patients.exists_for_patient() & core.patients.exists_for_patient()
 )  ## type:BoolPatientSeries
 bool_or = (
-    patients.exists_for_patient() | patients.exists_for_patient()
+    core.patients.exists_for_patient() | core.patients.exists_for_patient()
 )  ## type:BoolPatientSeries
-bool_invert = ~patients.exists_for_patient()  ## type:BoolPatientSeries
-numeric_neg = -clinical_events.numeric_value  ## type:FloatEventSeries
-clinical_events.date.to_first_of_year()  ## type:DateEventSeries
-patients.date_of_birth.to_first_of_month()  ## type:DatePatientSeries
+bool_invert = ~core.patients.exists_for_patient()  ## type:BoolPatientSeries
+numeric_neg = -core.clinical_events.numeric_value  ## type:FloatEventSeries
+core.clinical_events.date.to_first_of_year()  ## type:DateEventSeries
+core.patients.date_of_birth.to_first_of_month()  ## type:DatePatientSeries
 duration_negation = -days(100)  ## type:days
-patients.sex.when_null_then(patients.sex)  ## type:StrPatientSeries
-duration_add = days(100) + patients.date_of_birth  ## type:DatePatientSeries
-duration_radd = clinical_events.date + days(100)  ## type:DateEventSeries
+core.patients.sex.when_null_then(core.patients.sex)  ## type:StrPatientSeries
+duration_add = days(100) + core.patients.date_of_birth  ## type:DatePatientSeries
+duration_radd = core.clinical_events.date + days(100)  ## type:DateEventSeries
 duration_add_duration = days(100) + days(100)  ## type:days
-# duration_rsub = clinical_events.date - days(100)  ## type: DateEventSeries
+# duration_rsub = core.clinical_events.date - days(100)  ## type: DateEventSeries
 # !!! the above doesn't work and thinks its a DateDifference. I assume
 # !!! because the NotImplemented on the DateFunctions __sub__ method
 # !!! is only known at runtime
@@ -81,62 +80,66 @@ duration_sub_duration = days(100) - days(100)  ## type: days
 #
 # BaseSeries
 #
-base_eq = patients.sex == patients.sex  ## type:BoolPatientSeries
-base_ne = clinical_events.date != clinical_events.date  ## type:BoolEventSeries
-patients.sex.is_null()  ## type:BoolPatientSeries
-clinical_events.date.is_not_null()  ## type:BoolEventSeries
-patients.sex.is_in([])  ## type:BoolPatientSeries
-clinical_events.snomedct_code.is_not_in([])  ## type:BoolEventSeries
+base_eq = core.patients.sex == core.patients.sex  ## type:BoolPatientSeries
+base_ne = (
+    core.clinical_events.date != core.clinical_events.date
+)  ## type:BoolEventSeries
+core.patients.sex.is_null()  ## type:BoolPatientSeries
+core.clinical_events.date.is_not_null()  ## type:BoolEventSeries
+core.patients.sex.is_in([])  ## type:BoolPatientSeries
+core.clinical_events.snomedct_code.is_not_in([])  ## type:BoolEventSeries
 
 #
 # ComparableFunctions
 #
 comparable_lt = (
-    clinical_events.numeric_value < clinical_events.numeric_value
+    core.clinical_events.numeric_value < core.clinical_events.numeric_value
 )  ## type:BoolEventSeries
 comparable_le = (
-    clinical_events.numeric_value <= clinical_events.numeric_value
+    core.clinical_events.numeric_value <= core.clinical_events.numeric_value
 )  ## type:BoolEventSeries
 comparable_gt = (
-    clinical_events.numeric_value > clinical_events.numeric_value
+    core.clinical_events.numeric_value > core.clinical_events.numeric_value
 )  ## type:BoolEventSeries
 comparable_ge = (
-    clinical_events.numeric_value >= clinical_events.numeric_value
+    core.clinical_events.numeric_value >= core.clinical_events.numeric_value
 )  ## type:BoolEventSeries
 
 #
 # StrFunctions
 #
-patients.sex.contains("m")  ## type:BoolPatientSeries
+core.patients.sex.contains("m")  ## type:BoolPatientSeries
 
 #
 # NumericFunctions
 #
-numeric_truediv = clinical_events.numeric_value / 10  ## type:FloatEventSeries
-numeric_rtruediv = 10 / clinical_events.numeric_value  ## type:FloatEventSeries
-numeric_floordiv = clinical_events.numeric_value // 10  ## type:IntEventSeries
-numeric_rfloordiv = 10 // clinical_events.numeric_value  ## type:IntEventSeries
-clinical_events.numeric_value.as_int()  ## type:IntEventSeries
-clinical_events.numeric_value.as_float()  ## type:FloatEventSeries
+numeric_truediv = core.clinical_events.numeric_value / 10  ## type:FloatEventSeries
+numeric_rtruediv = 10 / core.clinical_events.numeric_value  ## type:FloatEventSeries
+numeric_floordiv = core.clinical_events.numeric_value // 10  ## type:IntEventSeries
+numeric_rfloordiv = 10 // core.clinical_events.numeric_value  ## type:IntEventSeries
+core.clinical_events.numeric_value.as_int()  ## type:IntEventSeries
+core.clinical_events.numeric_value.as_float()  ## type:FloatEventSeries
 
 #
 # DateFunctions
 #
 date_str = "2024-01-01"
-patients.date_of_birth.is_before(date_str)  ## type:BoolPatientSeries
-patients.date_of_birth.is_on_or_before(date_str)  ## type:BoolPatientSeries
-patients.date_of_birth.is_after(date_str)  ## type:BoolPatientSeries
-patients.date_of_birth.is_on_or_after(date_str)  ## type:BoolPatientSeries
-clinical_events.date.is_between_but_not_on(date_str, date_str)  ## type:BoolEventSeries
-clinical_events.date.is_on_or_between(date_str, date_str)  ## type:BoolEventSeries
-clinical_events.date.is_during((date_str, date_str))  ## type:BoolEventSeries
+core.patients.date_of_birth.is_before(date_str)  ## type:BoolPatientSeries
+core.patients.date_of_birth.is_on_or_before(date_str)  ## type:BoolPatientSeries
+core.patients.date_of_birth.is_after(date_str)  ## type:BoolPatientSeries
+core.patients.date_of_birth.is_on_or_after(date_str)  ## type:BoolPatientSeries
+core.clinical_events.date.is_between_but_not_on(
+    date_str, date_str
+)  ## type:BoolEventSeries
+core.clinical_events.date.is_on_or_between(date_str, date_str)  ## type:BoolEventSeries
+core.clinical_events.date.is_during((date_str, date_str))  ## type:BoolEventSeries
 
 
 #
 # MultiCodeStringFunctions
 #
-apcs.all_diagnoses.contains("N13")  ## type:BoolEventSeries
-apcs.all_diagnoses.contains_any_of(["N13"])  ## type:BoolEventSeries
+tpp.apcs.all_diagnoses.contains("N13")  ## type:BoolEventSeries
+tpp.apcs.all_diagnoses.contains_any_of(["N13"])  ## type:BoolEventSeries
 
 #
 # Couple of random list[tuple] types
@@ -146,57 +149,57 @@ ending_on = weeks(3).ending_on("2000-01-01")[0][0]  ## type:date
 #
 # Things that aggregate from EventSeries to PatientSeries
 # but that need to maintain the type (int, float, bool etc)
-clinical_events.numeric_value.sum_for_patient()  ## type:FloatPatientSeries
-clinical_events.numeric_value.as_int().sum_for_patient()  ## type:IntPatientSeries
+core.clinical_events.numeric_value.sum_for_patient()  ## type:FloatPatientSeries
+core.clinical_events.numeric_value.as_int().sum_for_patient()  ## type:IntPatientSeries
 
-clinical_events.numeric_value.minimum_for_patient()  ## type:FloatPatientSeries
-clinical_events.numeric_value.as_int().minimum_for_patient()  ## type:IntPatientSeries
-addresses.msoa_code.minimum_for_patient()  ## type:StrPatientSeries
-clinical_events.date.minimum_for_patient()  ## type:DatePatientSeries
+core.clinical_events.numeric_value.minimum_for_patient()  ## type:FloatPatientSeries
+core.clinical_events.numeric_value.as_int().minimum_for_patient()  ## type:IntPatientSeries
+tpp.addresses.msoa_code.minimum_for_patient()  ## type:StrPatientSeries
+core.clinical_events.date.minimum_for_patient()  ## type:DatePatientSeries
 
-clinical_events.numeric_value.maximum_for_patient()  ## type:FloatPatientSeries
-clinical_events.numeric_value.as_int().maximum_for_patient()  ## type:IntPatientSeries
-addresses.msoa_code.maximum_for_patient()  ## type:StrPatientSeries
-clinical_events.date.maximum_for_patient()  ## type:DatePatientSeries
+core.clinical_events.numeric_value.maximum_for_patient()  ## type:FloatPatientSeries
+core.clinical_events.numeric_value.as_int().maximum_for_patient()  ## type:IntPatientSeries
+tpp.addresses.msoa_code.maximum_for_patient()  ## type:StrPatientSeries
+core.clinical_events.date.maximum_for_patient()  ## type:DatePatientSeries
 
 #
 # NumericFunctions which maintain the series (Event or Patient)
 # and the type (int or float)
 
-numeric_add = clinical_events.numeric_value + 10  ## type:FloatEventSeries
-numeric_radd = 10 + clinical_events.numeric_value.as_int()  ## type:IntEventSeries
+numeric_add = core.clinical_events.numeric_value + 10  ## type:FloatEventSeries
+numeric_radd = 10 + core.clinical_events.numeric_value.as_int()  ## type:IntEventSeries
 numeric_add_patient = (
-    clinical_events.numeric_value.maximum_for_patient() + 10
+    core.clinical_events.numeric_value.maximum_for_patient() + 10
 )  ## type:FloatPatientSeries
 numeric_radd_patient = (
-    10 + clinical_events.numeric_value.as_int().maximum_for_patient()
+    10 + core.clinical_events.numeric_value.as_int().maximum_for_patient()
 )  ## type:IntPatientSeries
 numeric_add_series = (
-    clinical_events.numeric_value + clinical_events.numeric_value
+    core.clinical_events.numeric_value + core.clinical_events.numeric_value
 )  ## type:FloatEventSeries
 
-numeric_sub = clinical_events.numeric_value - 10  ## type:FloatEventSeries
-numeric_rsub = 10 - clinical_events.numeric_value.as_int()  ## type:IntEventSeries
+numeric_sub = core.clinical_events.numeric_value - 10  ## type:FloatEventSeries
+numeric_rsub = 10 - core.clinical_events.numeric_value.as_int()  ## type:IntEventSeries
 numeric_sub_patient = (
-    clinical_events.numeric_value.maximum_for_patient() - 10
+    core.clinical_events.numeric_value.maximum_for_patient() - 10
 )  ## type:FloatPatientSeries
 numeric_rsub_patient = (
-    10 - clinical_events.numeric_value.as_int().maximum_for_patient()
+    10 - core.clinical_events.numeric_value.as_int().maximum_for_patient()
 )  ## type:IntPatientSeries
 numeric_sub_series = (
-    clinical_events.numeric_value - clinical_events.numeric_value
+    core.clinical_events.numeric_value - core.clinical_events.numeric_value
 )  ## type:FloatEventSeries
 
-numeric_mul = clinical_events.numeric_value * 10  ## type:FloatEventSeries
-numeric_rmul = 10 * clinical_events.numeric_value.as_int()  ## type:IntEventSeries
+numeric_mul = core.clinical_events.numeric_value * 10  ## type:FloatEventSeries
+numeric_rmul = 10 * core.clinical_events.numeric_value.as_int()  ## type:IntEventSeries
 numeric_mul_patient = (
-    clinical_events.numeric_value.maximum_for_patient() * 10
+    core.clinical_events.numeric_value.maximum_for_patient() * 10
 )  ## type:FloatPatientSeries
 numeric_rmul_patient = (
-    10 * clinical_events.numeric_value.as_int().maximum_for_patient()
+    10 * core.clinical_events.numeric_value.as_int().maximum_for_patient()
 )  ## type:IntPatientSeries
 numeric_mul_series = (
-    clinical_events.numeric_value * clinical_events.numeric_value
+    core.clinical_events.numeric_value * core.clinical_events.numeric_value
 )  ## type:FloatEventSeries
 
 #
@@ -205,39 +208,62 @@ numeric_mul_series = (
 # type we can easily get is the first arg. So if the first thing is
 # a series then that's fine. Otherwise we ignore
 #
-max_of_float = maximum_of(clinical_events.numeric_value, 10)  ## type:FloatEventSeries
+max_of_float = maximum_of(
+    core.clinical_events.numeric_value, 10
+)  ## type:FloatEventSeries
 max_of_int = maximum_of(
-    clinical_events.numeric_value.as_int(), 10
+    core.clinical_events.numeric_value.as_int(), 10
 )  ## type:IntEventSeries
-max_of_date = maximum_of(clinical_events.date, "2024-01-01")  ## type:DateEventSeries
+max_of_date = maximum_of(
+    core.clinical_events.date, "2024-01-01"
+)  ## type:DateEventSeries
 max_of_float_patient = maximum_of(
-    clinical_events.numeric_value.maximum_for_patient(), 10
+    core.clinical_events.numeric_value.maximum_for_patient(), 10
 )  ## type:FloatPatientSeries
 max_of_int_patient = maximum_of(
-    clinical_events.numeric_value.maximum_for_patient().as_int(), 10
+    core.clinical_events.numeric_value.maximum_for_patient().as_int(), 10
 )  ## type:IntPatientSeries
 max_of_date_patient = maximum_of(
-    patients.date_of_birth, "2024-01-01"
+    core.patients.date_of_birth, "2024-01-01"
 )  ## type:DatePatientSeries
-min_of_float = minimum_of(clinical_events.numeric_value, 10)  ## type:FloatEventSeries
+min_of_float = minimum_of(
+    core.clinical_events.numeric_value, 10
+)  ## type:FloatEventSeries
 min_of_int = minimum_of(
-    clinical_events.numeric_value.as_int(), 10
+    core.clinical_events.numeric_value.as_int(), 10
 )  ## type:IntEventSeries
-min_of_date = minimum_of(clinical_events.date, "2024-01-01")  ## type:DateEventSeries
+min_of_date = minimum_of(
+    core.clinical_events.date, "2024-01-01"
+)  ## type:DateEventSeries
 min_of_float_patient = minimum_of(
-    clinical_events.numeric_value.minimum_for_patient(), 10
+    core.clinical_events.numeric_value.minimum_for_patient(), 10
 )  ## type:FloatPatientSeries
 min_of_int_patient = minimum_of(
-    clinical_events.numeric_value.minimum_for_patient().as_int(), 10
+    core.clinical_events.numeric_value.minimum_for_patient().as_int(), 10
 )  ## type:IntPatientSeries
 min_of_date_patient = minimum_of(
-    patients.date_of_birth, "2024-01-01"
+    core.patients.date_of_birth, "2024-01-01"
 )  ## type:DatePatientSeries
 
 # properties
-patients.date_of_birth.day  ## type:IntPatientSeries
-patients.date_of_birth.month  ## type:IntPatientSeries
-patients.date_of_birth.year  ## type:IntPatientSeries
-clinical_events.date.day  ## type:IntEventSeries
-clinical_events.date.month  ## type:IntEventSeries
-clinical_events.date.year  ## type:IntEventSeries
+core.patients.date_of_birth.day  ## type:IntPatientSeries
+core.patients.date_of_birth.month  ## type:IntPatientSeries
+core.patients.date_of_birth.year  ## type:IntPatientSeries
+core.clinical_events.date.day  ## type:IntEventSeries
+core.clinical_events.date.month  ## type:IntEventSeries
+core.clinical_events.date.year  ## type:IntEventSeries
+
+# Table methods not yet tested
+tpp.patients.is_alive_on(date_str)  ## type:BoolPatientSeries
+tpp.patients.is_dead_on(date_str)  ## type:BoolPatientSeries
+tpp.decision_support_values.electronic_frailty_index()  ## type:decision_support_values
+tpp.practice_registrations.spanning_with_systmone(
+    date_str, date_str
+)  ## type:practice_registrations
+emis.patients.has_practice_registration_spanning(
+    date_str, date_str
+)  ## type:BoolPatientSeries
+core.patients.is_alive_on(date_str)  ## type:BoolPatientSeries
+core.patients.is_dead_on(date_str)  ## type:BoolPatientSeries
+core.practice_registrations.exists_for_patient_on(date_str)  ## type:BoolPatientSeries
+core.practice_registrations.spanning(date_str, date_str)  ## type:practice_registrations

--- a/tests/autocomplete/language_server.py
+++ b/tests/autocomplete/language_server.py
@@ -78,6 +78,18 @@ class LanguageServer:
         self._message_id += 1
         return self._message_id
 
+    def get_completion_results_from_file(self, line, cursor_position):
+        """
+        For a given line and cursor_position returns the list of potential
+        completion results. This assumes that the file is already loaded by
+        the language server (via `open_doc`). If you want to test a single line
+        of code, then use the `get_completion_results()` method instead
+        """
+        completion_response = self._get_completion(line, cursor_position)
+        results = completion_response.get("result")
+        items = results.get("items")
+        return items
+
     def get_completion_results(
         self, text_for_completion, cursor_position=None
     ):  # pragma: no cover
@@ -97,10 +109,8 @@ class LanguageServer:
 
         if cursor_position is None:
             cursor_position = len(text_for_completion)
-        completion_response = self._get_completion(0, cursor_position)
-        results = completion_response.get("result")
-        items = results.get("items")
-        return items
+
+        return self.get_completion_results_from_file(0, cursor_position)
 
     def get_element_type_from_file(self, line, cursor_position):
         """
@@ -154,7 +164,7 @@ class LanguageServer:
 
         return self.get_element_type_from_file(0, cursor_position)
 
-    def _notify_document_change(self, line_number, new_text):
+    def _notify_document_change(self, line_number, new_text):  # pragma: no cover
         # Need to update text_document version
         self._text_document["version"] = f"v{self._next_id()}"
         self._send_notification(

--- a/tests/autocomplete/test_autocomplete.py
+++ b/tests/autocomplete/test_autocomplete.py
@@ -445,31 +445,29 @@ def query_language_methods():
     other_methods = {}
     ql_classes = inspect.getmembers(query_language, inspect.isclass)
     for class_name, class_obj in ql_classes:
-        if class_obj.__module__ == "ehrql.query_language":
-            # Get the base classes using __mro__
-            base_classes = [
-                base.__name__
-                for base in class_obj.__mro__
-                if base.__name__ != class_name
-            ]
-            class_parents[class_obj] = base_classes
+        if class_obj.__module__ != "ehrql.query_language":
+            continue
+        # Get the base classes using __mro__
+        base_classes = [
+            base.__name__ for base in class_obj.__mro__ if base.__name__ != class_name
+        ]
+        class_parents[class_obj] = base_classes
 
-            # Get the methods defined in the class
-            methods = [
-                method_name
-                for method_name, method in vars(class_obj).items()
-                if not method_name.startswith("_")
-                and not isinstance(method, int_property)
-            ]
-            class_methods[class_name] = methods
+        # Get the methods defined in the class
+        methods = [
+            method_name
+            for method_name, method in vars(class_obj).items()
+            if not method_name.startswith("_") and not isinstance(method, int_property)
+        ]
+        class_methods[class_name] = methods
 
-            # Get the `int_property`s defined in the class
-            int_props = [
-                method_name
-                for method_name, method in vars(class_obj).items()
-                if not method_name.startswith("_") and isinstance(method, int_property)
-            ]
-            class_int_props[class_name] = int_props
+        # Get the `int_property`s defined in the class
+        int_props = [
+            method_name
+            for method_name, method in vars(class_obj).items()
+            if not method_name.startswith("_") and isinstance(method, int_property)
+        ]
+        class_int_props[class_name] = int_props
 
     for cls in class_parents:
         if PatientSeries in cls.__mro__:


### PR DESCRIPTION
Quite a few changes but hopefully each commit is comprehensible.

Changes include:
- A refactor to use the `ast` and `tokenizer` modules to parse the `autocomplete_definition.py` file rather than my custom parser
- Ensure that all table methods (e.g. `patients.age_on()`) are either tested or ignored
- Ensure that all methods defined in `query_language.py` are either tested or ignored. This includes methods on `Series` such as `Base.Series.is_in()` and `DateFunctions.is_after()`, and ensures that the method is tested for both a `PatientSeries` and an `EventSeries` (if it can be used on both). It also includes other methods such as `Duration.starting_on()`
- Replaced the tests that manually checked the dropdown completion for items on the `core` tables, with an exhaustive test that looks for all items on all tables.