### PR TITLE
Refactor gentests to support multiple results tables

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -198,11 +198,8 @@ class QueryEngineFixture:
         return self.query_engine_class(dsn, **engine_kwargs)
 
     def extract(self, dataset, **engine_kwargs):
-        assert isinstance(dataset, ql.Dataset)
-        dataset_qm = dataset._compile()
-        return self.extract_qm(dataset_qm, **engine_kwargs)
-
-    def extract_qm(self, dataset, **engine_kwargs):
+        if isinstance(dataset, ql.Dataset):
+            dataset = dataset._compile()
         assert isinstance(dataset, qm.Dataset)
         query_engine = self.query_engine(**engine_kwargs)
         results = query_engine.get_results(dataset)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -197,15 +197,18 @@ class QueryEngineFixture:
             dsn = self.database.host_url()
         return self.query_engine_class(dsn, **engine_kwargs)
 
-    def extract(self, dataset, **engine_kwargs):
+    def get_results_tables(self, dataset, **engine_kwargs):
         if isinstance(dataset, ql.Dataset):
             dataset = dataset._compile()
         assert isinstance(dataset, qm.Dataset)
         query_engine = self.query_engine(**engine_kwargs)
-        results = query_engine.get_results(dataset)
+        results_tables = query_engine.get_results_tables(dataset)
         # We don't explicitly order the results and not all databases naturally
         # return in the same order
-        return [row._asdict() for row in sorted(results)]
+        return [[row._asdict() for row in sorted(table)] for table in results_tables]
+
+    def extract(self, dataset, **engine_kwargs):
+        return self.get_results_tables(dataset, **engine_kwargs)[0]
 
     def dump_dataset_sql(self, dataset, **engine_kwargs):
         assert isinstance(dataset, ql.Dataset)

--- a/tests/generative/example.py
+++ b/tests/generative/example.py
@@ -3,6 +3,7 @@
 from ehrql.query_model.nodes import (
     AggregateByPatient,
     Column,
+    Dataset,
     SelectColumn,
     SelectPatientTable,
     TableSchema,
@@ -16,6 +17,8 @@ p0 = SelectPatientTable(
     ),
 )
 
-population = AggregateByPatient.Exists(p0)
-variable = SelectColumn(p0, "i1")
+dataset = Dataset(
+    population=AggregateByPatient.Exists(p0),
+    variables={"v": SelectColumn(p0, "i1")},
+)
 data = []

--- a/tests/generative/test_query_model.py
+++ b/tests/generative/test_query_model.py
@@ -232,7 +232,7 @@ def run_with(engine, instances, dataset):
     error_type = None
     try:
         engine.setup(instances, metadata=sqla_metadata)
-        return engine.extract_qm(
+        return engine.extract(
             dataset,
             config={
                 # In order to exercise the temporary table code path we set the limit

--- a/tests/generative/test_query_model.py
+++ b/tests/generative/test_query_model.py
@@ -22,7 +22,6 @@ from ehrql.query_model.nodes import (
     SelectPatientTable,
     TableSchema,
     Value,
-    get_series_type,
 )
 from ehrql.serializer import deserialize, serialize
 from tests.lib.query_model_utils import get_all_operations
@@ -209,12 +208,11 @@ def run_test(query_engines, data, dataset, recorder):
     # transitive)
     first_name = list(results.keys())[0]
     first_results = results.pop(first_name)
-    # If the results contain floats then we want only approximate equality to account
-    # for rounding differences
-    if any(get_series_type(v) is float for v in dataset.variables.values()):
-        first_results = [
-            [pytest.approx(row, rel=1e-5) for row in table] for table in first_results
-        ]
+    # We want only approximate equality for floats to account for rounding differences
+    # between different databases
+    first_results = [
+        [pytest.approx(row, rel=1e-5) for row in table] for table in first_results
+    ]
 
     for other_name, other_results in results.items():
         assert first_results == other_results, (

--- a/tests/generative/test_query_model.py
+++ b/tests/generative/test_query_model.py
@@ -70,7 +70,7 @@ value_strategies = {
     str: st.text(alphabet=["a", "b", "c"], min_size=0, max_size=3),
 }
 
-population_strategy, variable_strategy = variable_strategies.population_and_variable(
+dataset_strategy = variable_strategies.dataset(
     [c.__tablename__ for c in patient_classes],
     [c.__tablename__ for c in event_classes],
     schema,
@@ -139,45 +139,43 @@ else:
 
 
 @hyp.given(
-    population=population_strategy,
-    variable=variable_strategy,
+    dataset=dataset_strategy,
     data=data_strategy,
     enabled_engines=usually_all_of(SELECTED_QUERY_ENGINES),
     test_types=usually_all_of(TESTS_TO_RUN),
 )
 @hyp.settings(**settings)
 def test_query_model(
-    query_engines, population, variable, data, recorder, enabled_engines, test_types
+    query_engines, dataset, data, recorder, enabled_engines, test_types
 ):
     query_engines = {
         name: engine
         for name, engine in query_engines.items()
         if name in enabled_engines
     }
-    recorder.record_inputs(variable, data)
+    recorder.record_inputs(dataset, data)
 
     if EnabledTests.serializer in test_types:
-        run_serializer_test(population, variable)
+        run_serializer_test(dataset)
     if EnabledTests.dummy_data in test_types:
-        run_dummy_data_test(population, variable)
+        run_dummy_data_test(dataset)
     if EnabledTests.dummy_data_nextgen in test_types:
-        run_dummy_data_test(population, variable, next_gen=True)
+        run_dummy_data_test(dataset, next_gen=True)
     if EnabledTests.main_query in test_types:
-        run_test(query_engines, data, population, variable, recorder)
+        run_test(query_engines, data, dataset, recorder)
     if EnabledTests.pretty_printing in test_types:
-        pretty(population)
-        pretty(data)
+        pretty(dataset)
 
     if EnabledTests.all_population in test_types:
-        # We run the test again using a simplified population definition which includes all
-        # patients: this ensures that the calculated value of `variable` matches for all
-        # patients, not just those included in the original population (which may be zero,
-        # if `data` happens not to contain any matching patients)
-        run_test(query_engines, data, all_patients_query, variable, recorder)
+        # We run the test again using a simplified population definition which includes
+        # all patients: this ensures that the calculated variable values matches for all
+        # patients, not just those included in the original population (which may be
+        # zero, if `data` happens not to contain any matching patients)
+        run_test(query_engines, data, include_all_patients(dataset), recorder)
 
 
-def run_test(query_engines, data, population, variable, recorder):
-    instances, dataset = setup_test(data, population, variable)
+def run_test(query_engines, data, dataset, recorder):
+    instances = instantiate(data)
 
     all_results = {
         name: run_with(engine, instances, dataset)
@@ -222,15 +220,6 @@ def run_test(query_engines, data, population, variable, recorder):
         )
 
 
-def setup_test(data, population, variable):
-    instances = instantiate(data)
-    dataset = Dataset(
-        population=population,
-        variables={"v": variable},
-    )
-    return instances, dataset
-
-
 def instantiate(data):
     instances = []
     for item in data:
@@ -239,12 +228,12 @@ def instantiate(data):
     return instances
 
 
-def run_with(engine, instances, variables):
+def run_with(engine, instances, dataset):
     error_type = None
     try:
         engine.setup(instances, metadata=sqla_metadata)
         return engine.extract_qm(
-            variables,
+            dataset,
             config={
                 # In order to exercise the temporary table code path we set the limit
                 # here very low
@@ -265,22 +254,22 @@ def run_with(engine, instances, variables):
             engine.teardown()
 
 
-def run_dummy_data_test(population, variable, next_gen=False):
+def run_dummy_data_test(dataset, next_gen=False):
     try:
-        run_dummy_data_test_without_error_handling(population, variable, next_gen)
+        run_dummy_data_test_without_error_handling(dataset, next_gen)
     except Exception as e:  # pragma: no cover
         if not get_ignored_error_type(e):
             raise
 
 
-def run_dummy_data_test_without_error_handling(population, variable, next_gen=False):
+def run_dummy_data_test_without_error_handling(dataset, next_gen=False):
     # We can't do much more here than check that the generator runs without error, but
     # that's enough to catch quite a few issues
 
     dummy = dummy_data_nextgen if next_gen else dummy_data
 
     dummy_data_generator = dummy.DummyDataGenerator(
-        Dataset(population=population, variables={"v": variable}),
+        dataset,
         population_size=1,
         # We need a batch size bigger than one otherwise by chance (or, more strictly,
         # by deterministic combination of query and fixed random seed) we can end up
@@ -300,7 +289,7 @@ def run_dummy_data_test_without_error_handling(population, variable, next_gen=Fa
     # Using a simplified population definition which should always have matching patients
     # we can confirm that we generate at least some data
     dummy_data_generator = dummy.DummyDataGenerator(
-        Dataset(population=all_patients_query, variables={"v": variable}),
+        include_all_patients(dataset),
         population_size=1,
         batch_size=1,
         timeout=-1,
@@ -309,10 +298,9 @@ def run_dummy_data_test_without_error_handling(population, variable, next_gen=Fa
     assert sum(len(v) for v in dummy_tables.values()) > 0
 
 
-def run_serializer_test(population, variable):
-    # Test that the query correctly roundtrips through the serializer
-    query = {"population": population, "v": variable}
-    assert query == deserialize(serialize(query), root_dir=Path.cwd())
+def run_serializer_test(dataset):
+    # Test that the dataset correctly roundtrips through the serializer
+    assert dataset == deserialize(serialize(dataset), root_dir=Path.cwd())
 
 
 # META TESTS
@@ -334,8 +322,7 @@ def test_query_model_example_file(query_engines, recorder):
     test_func = test_query_model.hypothesis.inner_test
     test_func(
         query_engines,
-        example.population,
-        example.variable,
+        example.dataset,
         example.data,
         recorder,
         SELECTED_QUERY_ENGINES,
@@ -354,7 +341,7 @@ def load_module(module_path):
 
 # Ensure that we don't add new query model nodes without adding an appropriate strategy
 # for them.
-def test_variable_strategy_is_comprehensive():
+def test_dataset_strategy_is_comprehensive():
     operations_seen = set()
 
     # This uses a fixed seed and no example database to make it deterministic
@@ -363,9 +350,9 @@ def test_variable_strategy_is_comprehensive():
     # free to tweak the seed a bit and see if that fixes it.
     @hyp.settings(max_examples=600, database=None, deadline=None)
     @hyp.seed(3457902459072)
-    @hyp.given(variable=variable_strategy)
-    def record_operations_seen(variable):
-        operations_seen.update(type(node) for node in all_unique_nodes(variable))
+    @hyp.given(dataset=dataset_strategy)
+    def record_operations_seen(dataset):
+        operations_seen.update(type(node) for node in all_unique_nodes(dataset))
 
     record_operations_seen()
 
@@ -373,9 +360,6 @@ def test_variable_strategy_is_comprehensive():
         # Parameters don't themselves form part of valid queries: they are placeholders
         # which must all be replaced with Values before the query can be executed.
         Parameter,
-        # This is a structure which we put the generated operations into, but don't
-        # expect to generate itself
-        Dataset,
     }
     all_operations = set(get_all_operations())
     unexpected_missing = all_operations - known_missing_operations - operations_seen
@@ -418,32 +402,45 @@ def test_run_with_handles_date_errors(query_engines, operation, rhs):
             "d1": datetime.date(2000, 1, 1),
         }
     ]
-    variable = operation(
-        lhs=SelectColumn(
-            source=SelectPatientTable(name="p0", schema=schema), name="d1"
-        ),
-        rhs=Value(rhs),
+    dataset = Dataset(
+        population=all_patients_query,
+        variables={
+            "v": operation(
+                lhs=SelectColumn(
+                    source=SelectPatientTable(name="p0", schema=schema), name="d1"
+                ),
+                rhs=Value(rhs),
+            )
+        },
     )
-    instances, variables = setup_test(data, all_patients_query, variable)
+    instances = instantiate(data)
     for engine in query_engines.values():
-        result = run_with(engine, instances, variables)
+        result = run_with(engine, instances, dataset)
         assert result in [IgnoredError.DATE_OVERFLOW, [{"patient_id": 1, "v": None}]]
 
 
 def test_run_with_still_raises_non_ignored_errors(query_engines):
     # Make sure our ignored error code isn't inadvertently catching everything
     first_engine = list(query_engines.values())[0]
-    not_valid_variables = object()
+    not_valid_dataset = object()
     with pytest.raises(Exception):
-        run_with(first_engine, [], not_valid_variables)
+        run_with(first_engine, [], not_valid_dataset)
 
 
 def test_run_test_handles_errors_from_all_query_engines(query_engines, recorder):
     # Make sure we can handle a query which fails for all query engines
     data = [{"type": data_setup.P0, "patient_id": 1}]
-    population = AggregateByPatient.Exists(SelectPatientTable("p0", schema=schema))
-    variable = Function.DateAddYears(
-        lhs=Value(datetime.date(2000, 1, 1)),
-        rhs=Value(8000),
+    dataset = Dataset(
+        population=AggregateByPatient.Exists(SelectPatientTable("p0", schema=schema)),
+        variables={
+            "v": Function.DateAddYears(
+                lhs=Value(datetime.date(2000, 1, 1)),
+                rhs=Value(8000),
+            )
+        },
     )
-    run_test(query_engines, data, population, variable, recorder)
+    run_test(query_engines, data, dataset, recorder)
+
+
+def include_all_patients(dataset):
+    return Dataset(population=all_patients_query, variables=dataset.variables)

--- a/tests/generative/variable_strategies.py
+++ b/tests/generative/variable_strategies.py
@@ -8,6 +8,7 @@ from hypothesis.control import current_build_context
 from ehrql.query_model.nodes import (
     AggregateByPatient,
     Case,
+    Dataset,
     Filter,
     Function,
     InlinePatientTable,
@@ -110,7 +111,7 @@ def depth_bounded_one_of(draw, *options):
 #       strategy function.
 
 
-def population_and_variable(patient_tables, event_tables, schema, value_strategies):
+def dataset(patient_tables, event_tables, schema, value_strategies):
     # Every inner-function here returns a Hypothesis strategy for creating the thing it is named
     # for, not the thing itself.
     #
@@ -615,7 +616,11 @@ def population_and_variable(patient_tables, event_tables, schema, value_strategi
         hyp.assume(is_valid_population(population))
         return population
 
-    return valid_population(), valid_variable()
+    return st.builds(make_dataset, valid_population(), valid_variable())
+
+
+def make_dataset(population, variable):
+    return Dataset(population=population, variables={"v": variable})
 
 
 def is_valid_population(series):

--- a/tests/integration/query_engines/test_mssql.py
+++ b/tests/integration/query_engines/test_mssql.py
@@ -40,7 +40,7 @@ def test_get_results_with_retries(mssql_engine):
             None,
         ]
 
-        results = mssql_engine.extract_qm(dataset)
+        results = mssql_engine.extract(dataset)
 
         assert results == [
             {"patient_id": 1, "i": 10},

--- a/tests/integration/query_engines/test_trino_dialect.py
+++ b/tests/integration/query_engines/test_trino_dialect.py
@@ -26,5 +26,5 @@ def test_float_precision(trino_engine):
         variables={"v": Function.Subtract(f1, Function.Add(f1, f2))},
     )
 
-    results = trino_engine.extract_qm(dataset)
+    results = trino_engine.extract(dataset)
     assert results[0]["v"] == v1 - (v1 + v2)

--- a/tests/integration/query_model/test_transforms.py
+++ b/tests/integration/query_model/test_transforms.py
@@ -48,7 +48,7 @@ def test_sort_booleans_null_first(engine):
     population = AggregateByPatient.Exists(events)
     dataset = Dataset(population=population, variables={"v": variable})
 
-    assert engine.extract_qm(dataset) == [
+    assert engine.extract(dataset) == [
         dict(patient_id=0, v=True),  # True sorts after False
         dict(patient_id=1, v=True),  # True sorts after NULL
         dict(patient_id=2, v=False),  # False sorts after NULL

--- a/tests/integration/test_query_engines.py
+++ b/tests/integration/test_query_engines.py
@@ -38,7 +38,7 @@ def test_handles_degenerate_population(engine):
         population=Value(False),
         variables={"v": Value(1)},
     )
-    assert engine.extract_qm(dataset) == []
+    assert engine.extract(dataset) == []
 
 
 def test_handles_inline_patient_table(engine, tmp_path):
@@ -204,7 +204,7 @@ def test_minimum_maximum_of_single_series(engine, operation):
             )
         },
     )
-    assert engine.extract_qm(dataset) == [
+    assert engine.extract(dataset) == [
         {"patient_id": 1, "v": date(1980, 1, 1)},
         {"patient_id": 2, "v": date(1990, 2, 2)},
     ]
@@ -349,7 +349,7 @@ def test_population_which_uses_combine_as_set_and_no_patient_frame(engine):
         }
     )
 
-    assert engine.extract_qm(dataset) == [
+    assert engine.extract(dataset) == [
         {"patient_id": 1, "v": True},
     ]
 

--- a/tests/lib/gentest_example_simplify.py
+++ b/tests/lib/gentest_example_simplify.py
@@ -42,7 +42,7 @@ from ehrql.query_model.nodes import (
 TABLE_TYPES = SelectTable | SelectPatientTable | InlinePatientTable
 
 
-VARIABLE_NAMES = ["population", "variable", "data"]
+VARIABLE_NAMES = ["dataset", "data"]
 
 
 def main(filename, output=False):  # pragma: no cover

--- a/tests/lib/test_gentest_example_simplify.py
+++ b/tests/lib/test_gentest_example_simplify.py
@@ -7,6 +7,7 @@ from hypothesis.vendor.pretty import pretty
 from ehrql.query_model.nodes import (
     AggregateByPatient,
     Case,
+    Dataset,
     Function,
     InlinePatientTable,
     SelectColumn,
@@ -35,21 +36,20 @@ def test_gentest_example_simplify():
         ),
         Value(frozenset({1, 2, 3})),
     )
+    dataset = Dataset(population=population, variables={"v": variable})
     data = [
         {"type": data_setup.P0, "patient_id": 1},
     ]
     partial_output = textwrap.dedent(
         f"""\
         # As might be formatted when copied directly from Hypothesis output
-          population={pretty(population)},
-          variable={pretty(variable)},
+          dataset={pretty(dataset)},
           data={pretty(data)}
         """
     )
     source = simplify(partial_output)
     module = exec_as_module(source)
-    assert module.population == population
-    assert module.variable == variable
+    assert module.dataset == dataset
     assert module.data == data
 
     # Confirm we're idempotent
@@ -67,8 +67,7 @@ def test_gentest_example_simplify_on_real_example():
     simplified_source = simplify(orig_source)
     simplified_module = exec_as_module(simplified_source)
 
-    assert simplified_module.population == orig_module.population
-    assert simplified_module.variable == orig_module.variable
+    assert simplified_module.dataset == orig_module.dataset
     assert simplified_module.data == orig_module.data
 
 

--- a/tests/lib/test_gentest_example_simplify.py
+++ b/tests/lib/test_gentest_example_simplify.py
@@ -1,5 +1,6 @@
 import importlib.util
 import textwrap
+from pathlib import Path
 
 from hypothesis.vendor.pretty import pretty
 
@@ -53,6 +54,22 @@ def test_gentest_example_simplify():
 
     # Confirm we're idempotent
     assert source == simplify(source)
+
+
+# Check that the simplify command works on a file which is itself tested to be
+# executable by the gentests
+def test_gentest_example_simplify_on_real_example():
+    orig_source = (
+        Path(__file__).parents[1].joinpath("generative", "example.py").read_text()
+    )
+    orig_module = exec_as_module(orig_source)
+
+    simplified_source = simplify(orig_source)
+    simplified_module = exec_as_module(simplified_source)
+
+    assert simplified_module.population == orig_module.population
+    assert simplified_module.variable == orig_module.variable
+    assert simplified_module.data == orig_module.data
 
 
 def exec_as_module(source):


### PR DESCRIPTION
We'll need this when we start having datasets which return multiple results tables.