### PR TITLE
Monitor changes in TPP decision support ref table

### DIFF
--- a/.github/workflows/update-tpp-schema.yml
+++ b/.github/workflows/update-tpp-schema.yml
@@ -30,14 +30,20 @@ jobs:
         id: create_pr
         uses: peter-evans/create-pull-request@67ccf781d68cd99b580ae25a5c18a1cc84ffff1f # v7.0.6
         with:
-          add-paths: tests/lib/tpp_schema.*
+          add-paths: tests/lib/*
           branch: bot/update-tpp-schema
           base: main
           author: "opensafely-github-bot <opensafely-github-bot@users.noreply.github.com>"
           committer: "opensafely-github-bot <opensafely-github-bot@users.noreply.github.com>"
-          commit-message: "Update `test/lib/tpp_schema.py`"
-          title: "Update `test/lib/tpp_schema.py`"
+          commit-message: "Update TPP schema or data dictionary"
+          title: "Update TPP schema or data dictionary"
           body: |
+            This PR was created by the `update-tpp-schema.yml` file. It means that something about the TPP schema or data dictionary has changed.
+
+            If `tpp_decision_support_reference.csv` has changed then we may need to update parts of the `decision_support_values` table. E.g.
+             - if there is a new algorithm, or a new version of an existing algorithm, we may want to expose it
+             - if an existing algorithm's name has changed we may need to update our code
+
             To get tests to run on this PR there's an odd workflow:
              - Approve it
              - Close it

--- a/.github/workflows/update-tpp-schema.yml
+++ b/.github/workflows/update-tpp-schema.yml
@@ -40,6 +40,8 @@ jobs:
           body: |
             This PR was created by the `update-tpp-schema.yml` file. It means that something about the TPP schema or data dictionary has changed.
 
+            If `tpp_categorical_columns.csv` has changed then we may need to update any tables that have the values hard-coded.
+
             If `tpp_decision_support_reference.csv` has changed then we may need to update parts of the `decision_support_values` table. E.g.
              - if there is a new algorithm, or a new version of an existing algorithm, we may want to expose it
              - if an existing algorithm's name has changed we may need to update our code

--- a/tests/lib/update_tpp_schema.py
+++ b/tests/lib/update_tpp_schema.py
@@ -17,6 +17,7 @@ SCHEMA_DIR = Path(__file__).parent
 SCHEMA_CSV = SCHEMA_DIR / "tpp_schema.csv"
 SCHEMA_PYTHON = SCHEMA_DIR / "tpp_schema.py"
 DATA_DICTIONARY_CSV = SCHEMA_DIR / "tpp_data_dictionary.csv"
+DECISION_SUPPORT_REF_CSV = SCHEMA_DIR / "tpp_decision_support_reference.csv"
 
 TYPE_MAP = {
     "bit": (0, lambda _: "t.Boolean"),
@@ -88,6 +89,10 @@ def fetch_schema_and_data_dictionary():
     SCHEMA_CSV.write_text(requests.get(rows_url).text)
     data_dictionary_url = urljoin(SERVER_URL, file_urls["output/data_dictionary.csv"])
     DATA_DICTIONARY_CSV.write_text(requests.get(data_dictionary_url).text)
+    decision_support_ref_url = urljoin(
+        SERVER_URL, file_urls["output/decision_support_value_reference.csv"]
+    )
+    DECISION_SUPPORT_REF_CSV.write_text(requests.get(decision_support_ref_url).text)
 
 
 def build_schema():

--- a/tests/lib/update_tpp_schema.py
+++ b/tests/lib/update_tpp_schema.py
@@ -18,6 +18,7 @@ SCHEMA_CSV = SCHEMA_DIR / "tpp_schema.csv"
 SCHEMA_PYTHON = SCHEMA_DIR / "tpp_schema.py"
 DATA_DICTIONARY_CSV = SCHEMA_DIR / "tpp_data_dictionary.csv"
 DECISION_SUPPORT_REF_CSV = SCHEMA_DIR / "tpp_decision_support_reference.csv"
+CATEGORICAL_COLUMNS_CSV = SCHEMA_DIR / "tpp_categorical_columns.csv"
 
 TYPE_MAP = {
     "bit": (0, lambda _: "t.Boolean"),
@@ -93,6 +94,10 @@ def fetch_schema_and_data_dictionary():
         SERVER_URL, file_urls["output/decision_support_value_reference.csv"]
     )
     DECISION_SUPPORT_REF_CSV.write_text(requests.get(decision_support_ref_url).text)
+    categorical_columns_url = urljoin(
+        SERVER_URL, file_urls["output/results_categorical_columns.csv"]
+    )
+    CATEGORICAL_COLUMNS_CSV.write_text(requests.get(categorical_columns_url).text)
 
 
 def build_schema():


### PR DESCRIPTION
Added the values from the `DecisionSupportValuesReference` table to the script that creates a pull request if the TPP schema or data dictionary changes.

I haven't committed the csv file that will be created by the github action to double check that it works as expected - e.g. a PR will be raised after this is committed.