### PR TITLE
feat: Prefetch measure variables that do not vary accross intervals

### DIFF
--- a/ehrql/dummy_data/__init__.py
+++ b/ehrql/dummy_data/__init__.py
@@ -1,4 +1,5 @@
 from ehrql.dummy_data.generator import DummyDataGenerator
+from ehrql.dummy_data.measures import DummyMeasuresDataGenerator
 
 
-__all__ = ["DummyDataGenerator"]
+__all__ = ["DummyDataGenerator", "DummyMeasuresDataGenerator"]

--- a/ehrql/main.py
+++ b/ehrql/main.py
@@ -7,7 +7,7 @@ from contextlib import nullcontext
 from pathlib import Path
 
 from ehrql import assurance
-from ehrql.dummy_data import DummyDataGenerator
+from ehrql.dummy_data import DummyDataGenerator, DummyMeasuresDataGenerator
 from ehrql.dummy_data_nextgen import DummyDataGenerator as NextGenDummyDataGenerator
 from ehrql.dummy_data_nextgen import (
     DummyMeasuresDataGenerator as NextGenDummyMeasuresDataGenerator,
@@ -28,7 +28,6 @@ from ehrql.loaders import (
     load_test_definition,
 )
 from ehrql.measures import (
-    DummyMeasuresDataGenerator,
     apply_sdc_to_measure_results,
     get_column_specs_for_measures,
     get_measure_results,

--- a/ehrql/measures/__init__.py
+++ b/ehrql/measures/__init__.py
@@ -1,4 +1,3 @@
-from ehrql.dummy_data.measures import DummyMeasuresDataGenerator
 from ehrql.measures.calculate import (
     get_column_specs_for_measures,
     get_measure_results,
@@ -11,7 +10,6 @@ __all__ = [
     "get_column_specs_for_measures",
     "get_measure_results",
     "apply_sdc_to_measure_results",
-    "DummyMeasuresDataGenerator",
     "INTERVAL",
     "Measures",
     "create_measures",

--- a/tests/unit/dummy_data/test_measures.py
+++ b/tests/unit/dummy_data/test_measures.py
@@ -3,7 +3,8 @@ from datetime import date
 import pytest
 
 from ehrql import years
-from ehrql.measures import INTERVAL, DummyMeasuresDataGenerator, Measures
+from ehrql.dummy_data.measures import DummyMeasuresDataGenerator
+from ehrql.measures import INTERVAL, Measures
 from ehrql.tables import Constraint, EventFrame, PatientFrame, Series, table
 
 


### PR DESCRIPTION
Measures fetch results for each defined interval; if variables don't vary over the intervals (determined by the presence of the interval parameter in the variable definition), we fetch them once in advance of the intervals, and use the results to create an `InlinePatientTable`. We then replace the unvarying variables in the dataset definition with simple `SelectColumn`s from the inline table.

This means that we can avoid fetching expensive variables multiple times if they don't change across intervals (e.g. ethnicity), with the caveat that the definition of ethnicity used mustn't depend on the intervals. E.g. I've seen ethnicity definitions that look for ethnicity codes with a `.where(clinical_events.date.is_on_or_before(INTERVAL.start_date))`, which would need to be changed to define ethnicity with a fixed date (this is how it would have been defined in an old cohort-extractor plus cohort-joiner study). 

