### PR TITLE
Support event-level data behind feature flag

### DIFF
--- a/.env
+++ b/.env
@@ -13,3 +13,6 @@
 # is designed to protect against don't apply to ehrQL, and having consistent
 # output makes debugging much easier
 PYTHONHASHSEED=0
+
+# Enable event level queries for testing purposes, but not yet in production
+EHRQL_ENABLE_EVENT_LEVEL_QUERIES=True

--- a/ehrql/backends/tpp.py
+++ b/ehrql/backends/tpp.py
@@ -128,6 +128,7 @@ class TPPBackend(SQLBackend):
         return qm.Dataset(
             population=new_population,
             variables=dataset.variables,
+            events=dataset.events,
         )
 
     def get_exit_status_for_exception(self, exception):

--- a/ehrql/docs/language.py
+++ b/ehrql/docs/language.py
@@ -20,6 +20,7 @@ EXCLUDE_FROM_DOCS = {
     ql.DummyDataConfig,
     ql.Error,
     ql.int_property,  # Internal thing for type hints and autocomplete
+    ql.EventTable,
 }
 
 

--- a/ehrql/dummy_data/generator.py
+++ b/ehrql/dummy_data/generator.py
@@ -56,7 +56,9 @@ class DummyDataGenerator:
 
         # Create a version of the query with just the population definition, and an
         # in-memory engine to run it against
-        population_query = Dataset(population=self.dataset.population, variables={})
+        population_query = Dataset(
+            population=self.dataset.population, variables={}, events={}
+        )
         database = InMemoryDatabase()
         engine = InMemoryQueryEngine(database)
 

--- a/ehrql/dummy_data/measures.py
+++ b/ehrql/dummy_data/measures.py
@@ -67,6 +67,7 @@ def get_dataset(combined):
             f"column_{i}": column
             for i, column in enumerate([*combined.numerators, *combined.groups])
         },
+        events={},
     )
 
     # Use the maximum range over all intervals as a date range

--- a/ehrql/dummy_data_nextgen/generator.py
+++ b/ehrql/dummy_data_nextgen/generator.py
@@ -130,7 +130,9 @@ class DummyDataGenerator:
 
         # Create a version of the query with just the population definition, and an
         # in-memory engine to run it against
-        population_query = Dataset(population=self.dataset.population, variables={})
+        population_query = Dataset(
+            population=self.dataset.population, variables={}, events={}
+        )
         database = InMemoryDatabase()
         engine = InMemoryQueryEngine(database)
 

--- a/ehrql/dummy_data_nextgen/measures.py
+++ b/ehrql/dummy_data_nextgen/measures.py
@@ -71,6 +71,7 @@ def get_dataset(combined):
             f"column_{i}": column
             for i, column in enumerate([*combined.numerators, *combined.groups])
         },
+        events={},
     )
 
     # Use the maximum range over all intervals as a date range

--- a/ehrql/dummy_data_nextgen/query_info.py
+++ b/ehrql/dummy_data_nextgen/query_info.py
@@ -397,7 +397,7 @@ def filter_values(query, values):
 
     rows = list(
         engine.get_results(
-            Dataset(population=rewriter.rewrite(query), variables={}),
+            Dataset(population=rewriter.rewrite(query), variables={}, events={}),
         )
     )
 

--- a/ehrql/measures/calculate.py
+++ b/ehrql/measures/calculate.py
@@ -103,7 +103,7 @@ class MeasureCalculator:
         for measure in measures:
             self.add_measure(measure)
         self.placeholder_dataset = Dataset(
-            population=self.population, variables=self.variables
+            population=self.population, variables=self.variables, events={}
         )
 
     def get_results(self, query_engine):

--- a/ehrql/measures/measures.py
+++ b/ehrql/measures/measures.py
@@ -3,7 +3,7 @@ import datetime
 from collections import namedtuple
 
 from ehrql.query_language import (
-    VALID_VARIABLE_NAME_RE,
+    VALID_ATTRIBUTE_NAME_RE,
     BoolPatientSeries,
     DummyDataConfig,
     Duration,
@@ -167,7 +167,7 @@ class Measures:
                 raise Error(f"No value supplied for '{key}' and no default defined")
 
         # Ensure measure names are valid
-        if not VALID_VARIABLE_NAME_RE.match(name):
+        if not VALID_ATTRIBUTE_NAME_RE.match(name):
             raise Error(
                 f"Measure names must start with a letter and contain only"
                 f" alphanumeric characters and underscores, got: {name!r}"
@@ -276,7 +276,7 @@ class Measures:
                 raise Error(
                     f"`group_by` names must be strings, got '{type(key)}': {key!r}"
                 )
-            if not VALID_VARIABLE_NAME_RE.match(key):
+            if not VALID_ATTRIBUTE_NAME_RE.match(key):
                 raise Error(
                     f"`group_by` names must start with a letter and contain only"
                     f" alphanumeric characters and underscores, got: {key!r}"

--- a/ehrql/query_engines/base_sql.py
+++ b/ehrql/query_engines/base_sql.py
@@ -1,5 +1,6 @@
 import datetime
 import logging
+import os
 import secrets
 from functools import cached_property
 
@@ -112,13 +113,18 @@ class BaseSQLQueryEngine(BaseQueryEngine):
             dataset.variables,
         )
 
-        other_queries = [
-            self.add_variables_to_query(
-                self.get_select_query_for_node_domain(frame),
-                frame.members,
-            )
-            for frame in dataset.events.values()
-        ]
+        # We want to be able to run tests for this behaviour without enabling it in
+        # production
+        if os.environ.get("EHRQL_ENABLE_EVENT_LEVEL_QUERIES") == "True":
+            other_queries = [
+                self.add_variables_to_query(
+                    self.get_select_query_for_node_domain(frame),
+                    frame.members,
+                )
+                for frame in dataset.events.values()
+            ]
+        else:  # pragma: no cover
+            other_queries = []
 
         # We use an instance variable to store the population table in order to avoid
         # having to thread it through all our `get_sql`/`get_table` method calls. But

--- a/ehrql/query_engines/debug.py
+++ b/ehrql/query_engines/debug.py
@@ -25,7 +25,7 @@ class DebugQueryEngine(LocalFileQueryEngine):
             table_nodes = get_table_nodes(population_qm, *variables_qm.values())
         self.populate_database(table_nodes)
         return self.get_results_as_patient_table(
-            DatasetQM(population=population_qm, variables=variables_qm)
+            DatasetQM(population=population_qm, variables=variables_qm, events={})
         )
 
     def evaluate(self, element):

--- a/ehrql/query_engines/debug.py
+++ b/ehrql/query_engines/debug.py
@@ -24,9 +24,14 @@ class DebugQueryEngine(LocalFileQueryEngine):
             population_qm = dataset.population._qm_node
             table_nodes = get_table_nodes(population_qm, *variables_qm.values())
         self.populate_database(table_nodes)
-        return self.get_results_as_patient_table(
-            DatasetQM(population=population_qm, variables=variables_qm, events={})
+        results_tables = self.get_results_as_in_memory_tables(
+            DatasetQM(
+                population=population_qm,
+                variables=variables_qm,
+                events={},
+            )
         )
+        return results_tables[0]
 
     def evaluate(self, element):
         if isinstance(element, Dataset):

--- a/ehrql/query_engines/debug.py
+++ b/ehrql/query_engines/debug.py
@@ -10,7 +10,7 @@ from ehrql.query_model.nodes import Dataset as DatasetQM
 
 class DebugQueryEngine(LocalFileQueryEngine):
     def evaluate_dataset(self, dataset):
-        variables_qm = {k: v._qm_node for k, v in dataset.variables.items()}
+        variables_qm = {k: v._qm_node for k, v in dataset._variables.items()}
         if getattr(dataset, "population", None) is None:
             if not variables_qm:
                 return EmptyDataset()

--- a/ehrql/query_engines/local_file.py
+++ b/ehrql/query_engines/local_file.py
@@ -14,14 +14,14 @@ class LocalFileQueryEngine(InMemoryQueryEngine):
 
     database = None
 
-    def get_results_stream(self, dataset):
+    def get_results_tables(self, dataset):
         # Given the dataset supplied determine the tables used and load the associated
         # data into the database
         self.populate_database(
             get_table_nodes(dataset),
         )
         # Run the query as normal
-        return super().get_results_stream(dataset)
+        return super().get_results_tables(dataset)
 
     def populate_database(self, table_nodes, allow_missing_columns=True):
         table_specs = {

--- a/ehrql/query_language.py
+++ b/ehrql/query_language.py
@@ -85,7 +85,7 @@ class Dataset:
         # Set attributes with `object.__setattr__` to avoid using the
         # `__setattr__` method on this class, which prohibits use of these
         # attribute names
-        object.__setattr__(self, "variables", {})
+        object.__setattr__(self, "_variables", {})
         object.__setattr__(self, "dummy_data_config", DummyDataConfig())
 
     def define_population(self, population_condition):
@@ -183,9 +183,9 @@ class Dataset:
             raise AttributeError(
                 "Cannot set variable 'population'; use define_population() instead"
             )
-        if name in self.variables:
+        if name in self._variables:
             raise AttributeError(f"'{name}' is already set and cannot be reassigned")
-        if name in ("patient_id", "variables", "dummy_data_config"):
+        if name in ("patient_id", "dummy_data_config"):
             raise AttributeError(f"'{name}' is not an allowed variable name")
         if not VALID_VARIABLE_NAME_RE.match(name):
             raise AttributeError(
@@ -194,11 +194,11 @@ class Dataset:
                 f"variable '{name}')"
             )
         validate_patient_series(value, context=f"variable '{name}'")
-        self.variables[name] = value
+        self._variables[name] = value
 
     def __getattr__(self, name):
-        if name in self.variables:
-            return self.variables[name]
+        if name in self._variables:
+            return self._variables[name]
         if name == "population":
             raise AttributeError(
                 "A population has not been defined; define one with define_population()"
@@ -209,7 +209,7 @@ class Dataset:
     def _compile(self):
         return qm.Dataset(
             population=self.population._qm_node,
-            variables={k: v._qm_node for k, v in self.variables.items()},
+            variables={k: v._qm_node for k, v in self._variables.items()},
         )
 
 

--- a/ehrql/query_language.py
+++ b/ehrql/query_language.py
@@ -204,7 +204,7 @@ class Dataset:
 
     def add_event_table(self, name, **event_series):
         _validate_attribute_name(name, self._variables | self._events, context="table")
-        self._events[name] = EventTable(**event_series)
+        self._events[name] = EventTable(self, **event_series)
 
     def _compile(self):
         return qm.Dataset(
@@ -215,7 +215,9 @@ class Dataset:
 
 
 class EventTable:
-    def __init__(self, **series):
+    def __init__(self, dataset, **series):
+        # Store reference to the parent dataset to aid debug rendering
+        object.__setattr__(self, "_dataset", dataset)
         object.__setattr__(self, "_series", {})
         if not series:
             raise ValueError("event tables must be defined with at least one column")

--- a/ehrql/query_language.py
+++ b/ehrql/query_language.py
@@ -191,6 +191,10 @@ class Dataset:
         self._variables[name] = value
 
     def __getattr__(self, name):
+        # Make this method accessible while hiding it from autocomplete until we make it
+        # generally available
+        if name == "add_event_table":
+            return self._internal
         if name in self._variables:
             return self._variables[name]
         if name in self._events:
@@ -202,7 +206,9 @@ class Dataset:
         else:
             raise AttributeError(f"Variable '{name}' has not been defined")
 
-    def add_event_table(self, name, **event_series):
+    # This method ought to be called `add_event_table` but we're deliberately
+    # obfuscating its name for now
+    def _internal(self, name, **event_series):
         _validate_attribute_name(name, self._variables | self._events, context="table")
         self._events[name] = EventTable(self, **event_series)
 

--- a/ehrql/query_language.py
+++ b/ehrql/query_language.py
@@ -210,6 +210,7 @@ class Dataset:
         return qm.Dataset(
             population=self.population._qm_node,
             variables={k: v._qm_node for k, v in self._variables.items()},
+            events={},
         )
 
 

--- a/ehrql/query_model/column_specs.py
+++ b/ehrql/query_model/column_specs.py
@@ -30,9 +30,13 @@ def get_table_specs(dataset):
     """
     Return the specifications for all the results tables this Dataset will produce
     """
-    # At present, Datasets only ever produce a single results table (which we call
-    # `dataset`) but this gives us the API we need for future expansion
-    return {"dataset": get_column_specs_from_variables(dataset.variables)}
+    return {
+        "dataset": get_column_specs_from_variables(dataset.variables),
+        **{
+            name: get_column_specs_from_variables(frame.members)
+            for name, frame in dataset.events.items()
+        },
+    }
 
 
 def get_column_specs_from_variables(variables):

--- a/ehrql/query_model/population_validation.py
+++ b/ehrql/query_model/population_validation.py
@@ -95,7 +95,7 @@ class EmptyQueryEngine(InMemoryQueryEngine):
         return {1}
 
     def series_evaluates_true(self, series):
-        results = self.get_results(Dataset(population=series, variables={}))
+        results = self.get_results(Dataset(population=series, variables={}, events={}))
         return bool(list(results))
 
     def visit_SelectTable(self, node):

--- a/tests/autocomplete/test_autocomplete.py
+++ b/tests/autocomplete/test_autocomplete.py
@@ -617,6 +617,8 @@ def test_all_query_model_non_series_methods(query_language_methods):
         ("EventFrame", "sort_by"),
         ("when", "then"),
         ("WhenThen", "otherwise"),
+        # Temporarily ignore this while it's non-public
+        ("EventTable", "add_column"),
     ]
 
     # Same logic as in previous test to find methods actually tested in the autocomplete definition file

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -271,6 +271,11 @@ def in_memory_engine(request):
     return engine_factory(request, "in_memory")
 
 
+@pytest.fixture
+def sqlite_engine(request):
+    return engine_factory(request, "sqlite")
+
+
 @pytest.fixture(scope="session")
 def ehrql_image(show_delayed_warning):
     project_dir = Path(ehrql.__file__).parents[1]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -205,7 +205,9 @@ class QueryEngineFixture:
         results_tables = query_engine.get_results_tables(dataset)
         # We don't explicitly order the results and not all databases naturally
         # return in the same order
-        return [[row._asdict() for row in sorted(table)] for table in results_tables]
+        return [
+            [row._asdict() for row in sort_table(table)] for table in results_tables
+        ]
 
     def extract(self, dataset, **engine_kwargs):
         return self.get_results_tables(dataset, **engine_kwargs)[0]
@@ -218,6 +220,16 @@ class QueryEngineFixture:
 
     def sqlalchemy_engine(self):
         return self.query_engine().engine
+
+
+def sort_table(table):
+    # Python won't naturally compare None with other values, but we need to sort tables
+    # containg None values so we treat None as smaller than all other values
+    return sorted(table, key=sort_key_with_nones)
+
+
+def sort_key_with_nones(row):
+    return [(v is not None, v) for v in row]
 
 
 QUERY_ENGINE_NAMES = ("in_memory", "sqlite", "mssql", "trino")

--- a/tests/generative/example.py
+++ b/tests/generative/example.py
@@ -20,5 +20,6 @@ p0 = SelectPatientTable(
 dataset = Dataset(
     population=AggregateByPatient.Exists(p0),
     variables={"v": SelectColumn(p0, "i1")},
+    events={},
 )
 data = []

--- a/tests/generative/test_query_model.py
+++ b/tests/generative/test_query_model.py
@@ -412,6 +412,7 @@ def test_run_with_handles_date_errors(query_engines, operation, rhs):
                 rhs=Value(rhs),
             )
         },
+        events={},
     )
     instances = instantiate(data)
     for engine in query_engines.values():
@@ -438,9 +439,14 @@ def test_run_test_handles_errors_from_all_query_engines(query_engines, recorder)
                 rhs=Value(8000),
             )
         },
+        events={},
     )
     run_test(query_engines, data, dataset, recorder)
 
 
 def include_all_patients(dataset):
-    return Dataset(population=all_patients_query, variables=dataset.variables)
+    return Dataset(
+        population=all_patients_query,
+        variables=dataset.variables,
+        events={},
+    )

--- a/tests/generative/test_query_model.py
+++ b/tests/generative/test_query_model.py
@@ -20,6 +20,7 @@ from ehrql.query_model.nodes import (
     Parameter,
     SelectColumn,
     SelectPatientTable,
+    SeriesCollectionFrame,
     TableSchema,
     Value,
 )
@@ -360,6 +361,8 @@ def test_dataset_strategy_is_comprehensive():
         # Parameters don't themselves form part of valid queries: they are placeholders
         # which must all be replaced with Values before the query can be executed.
         Parameter,
+        # We don't yet generate examples of these
+        SeriesCollectionFrame,
     }
     all_operations = set(get_all_operations())
     unexpected_missing = all_operations - known_missing_operations - operations_seen

--- a/tests/generative/test_query_model.py
+++ b/tests/generative/test_query_model.py
@@ -20,7 +20,6 @@ from ehrql.query_model.nodes import (
     Parameter,
     SelectColumn,
     SelectPatientTable,
-    SeriesCollectionFrame,
     TableSchema,
     Value,
 )
@@ -361,8 +360,6 @@ def test_dataset_strategy_is_comprehensive():
         # Parameters don't themselves form part of valid queries: they are placeholders
         # which must all be replaced with Values before the query can be executed.
         Parameter,
-        # We don't yet generate examples of these
-        SeriesCollectionFrame,
     }
     all_operations = set(get_all_operations())
     unexpected_missing = all_operations - known_missing_operations - operations_seen

--- a/tests/generative/variable_strategies.py
+++ b/tests/generative/variable_strategies.py
@@ -620,7 +620,11 @@ def dataset(patient_tables, event_tables, schema, value_strategies):
 
 
 def make_dataset(population, variable):
-    return Dataset(population=population, variables={"v": variable})
+    return Dataset(
+        population=population,
+        variables={"v": variable},
+        events={},
+    )
 
 
 def is_valid_population(series):

--- a/tests/generative/variable_strategies.py
+++ b/tests/generative/variable_strategies.py
@@ -17,6 +17,7 @@ from ehrql.query_model.nodes import (
     SelectColumn,
     SelectPatientTable,
     SelectTable,
+    SeriesCollectionFrame,
     Sort,
     Value,
 )
@@ -602,9 +603,15 @@ def dataset(patient_tables, event_tables, schema, value_strategies):
     #
     # Puts everything above together to create a variable.
     @st.composite
-    def valid_variable(draw):
+    def valid_patient_variable(draw):
         type_ = draw(any_type())
         frame = draw(one_row_per_patient_frame())
+        return draw(series(type_, frame))
+
+    @st.composite
+    def valid_event_series(draw):
+        type_ = draw(any_type())
+        frame = draw(many_rows_per_patient_frame())
         return draw(series(type_, frame))
 
     # A population definition is a boolean-typed variable that meets some additional
@@ -616,14 +623,26 @@ def dataset(patient_tables, event_tables, schema, value_strategies):
         hyp.assume(is_valid_population(population))
         return population
 
-    return st.builds(make_dataset, valid_population(), valid_variable())
+    return st.builds(
+        make_dataset,
+        valid_population(),
+        valid_patient_variable(),
+        # Event series is optional
+        st.one_of(st.none(), valid_event_series()),
+    )
 
 
-def make_dataset(population, variable):
+def make_dataset(population, patient_variable, event_series):
     return Dataset(
         population=population,
-        variables={"v": variable},
-        events={},
+        variables={"v": patient_variable},
+        events=(
+            {
+                "event_table": SeriesCollectionFrame({"e": event_series}),
+            }
+            if event_series is not None
+            else {}
+        ),
     )
 
 

--- a/tests/integration/query_engines/test_mssql.py
+++ b/tests/integration/query_engines/test_mssql.py
@@ -22,6 +22,7 @@ def test_get_results_with_retries(mssql_engine):
     dataset = Dataset(
         population=AggregateByPatient.Exists(patient_table),
         variables={"i": SelectColumn(patient_table, "i")},
+        events={},
     )
     mssql_engine.populate(
         {

--- a/tests/integration/query_engines/test_trino_dialect.py
+++ b/tests/integration/query_engines/test_trino_dialect.py
@@ -24,6 +24,7 @@ def test_float_precision(trino_engine):
     dataset = Dataset(
         population=AggregateByPatient.Exists(t),
         variables={"v": Function.Subtract(f1, Function.Add(f1, f2))},
+        events={},
     )
 
     results = trino_engine.extract(dataset)

--- a/tests/integration/query_model/test_transforms.py
+++ b/tests/integration/query_model/test_transforms.py
@@ -46,7 +46,7 @@ def test_sort_booleans_null_first(engine):
         "b",
     )
     population = AggregateByPatient.Exists(events)
-    dataset = Dataset(population=population, variables={"v": variable})
+    dataset = Dataset(population=population, variables={"v": variable}, events={})
 
     assert engine.extract(dataset) == [
         dict(patient_id=0, v=True),  # True sorts after False

--- a/tests/integration/test_query_engines.py
+++ b/tests/integration/test_query_engines.py
@@ -397,6 +397,50 @@ def test_cast_to_int_on_minimum_of_float(engine):
     ]
 
 
+def test_basic_event_level_data_support(engine):
+    engine.populate(
+        {
+            patients: [
+                {"patient_id": 1, "i": 100},
+                {"patient_id": 2, "i": 200},
+                {"patient_id": 3, "i": 300},
+                {"patient_id": 4, "i": 400},
+            ],
+            events: [
+                {"patient_id": 1, "code": "a"},
+                {"patient_id": 1, "code": "b"},
+                {"patient_id": 1, "code": "c"},
+                {"patient_id": 2, "code": "d"},
+                {"patient_id": 3, "code": "e"},
+                {"patient_id": 3, "code": "f"},
+                {"patient_id": 4, "code": "g"},
+                {"patient_id": 4, "code": "h"},
+                {"patient_id": 5, "code": "i"},
+            ],
+        }
+    )
+    dataset = create_dataset()
+    dataset.define_population(patients.i != 300)
+    dataset.i = patients.i
+    dataset.add_event_table("events", c=events.code)
+
+    assert engine.get_results_tables(dataset) == [
+        [
+            {"patient_id": 1, "i": 100},
+            {"patient_id": 2, "i": 200},
+            {"patient_id": 4, "i": 400},
+        ],
+        [
+            {"patient_id": 1, "c": "a"},
+            {"patient_id": 1, "c": "b"},
+            {"patient_id": 1, "c": "c"},
+            {"patient_id": 2, "c": "d"},
+            {"patient_id": 4, "c": "g"},
+            {"patient_id": 4, "c": "h"},
+        ],
+    ]
+
+
 def build_dataset(*, population, variables=None, events=None):
     return Dataset(
         population=population, variables=variables or {}, events=events or {}

--- a/tests/integration/test_query_engines.py
+++ b/tests/integration/test_query_engines.py
@@ -34,7 +34,7 @@ def test_handles_degenerate_population(engine):
     # Specifying a population of "False" is obviously silly, but it's more work to
     # identify and reject just this kind of silliness than it is to handle it gracefully
     engine.setup(metadata=sqlalchemy.MetaData())
-    dataset = Dataset(
+    dataset = build_dataset(
         population=Value(False),
         variables={"v": Value(1)},
     )
@@ -196,7 +196,7 @@ def test_minimum_maximum_of_single_series(engine, operation):
         }
     )
 
-    dataset = Dataset(
+    dataset = build_dataset(
         population=as_query_model(patients.exists_for_patient()),
         variables={
             "v": operation(
@@ -332,7 +332,7 @@ def test_population_which_uses_combine_as_set_and_no_patient_frame(engine):
     # so it's possible to use it to create a population SQL expression which references
     # just a single event-level SQL table. This falsifies a previous assumption we made
     # and so we need to test that we handle it correctly.
-    dataset = Dataset(
+    dataset = build_dataset(
         population=Function.In(
             Value(1),
             AggregateByPatient.CombineAsSet(as_query_model(events.i)),
@@ -395,3 +395,9 @@ def test_cast_to_int_on_minimum_of_float(engine):
     assert engine.extract(dataset) == [
         {"patient_id": 1, "i": 1},
     ]
+
+
+def build_dataset(*, population, variables=None, events=None):
+    return Dataset(
+        population=population, variables=variables or {}, events=events or {}
+    )

--- a/tests/lib/test_gentest_example_simplify.py
+++ b/tests/lib/test_gentest_example_simplify.py
@@ -36,7 +36,11 @@ def test_gentest_example_simplify():
         ),
         Value(frozenset({1, 2, 3})),
     )
-    dataset = Dataset(population=population, variables={"v": variable})
+    dataset = Dataset(
+        population=population,
+        variables={"v": variable},
+        events={},
+    )
     data = [
         {"type": data_setup.P0, "patient_id": 1},
     ]

--- a/tests/unit/dummy_data_nextgen/test_edge_cases_for_coverage.py
+++ b/tests/unit/dummy_data_nextgen/test_edge_cases_for_coverage.py
@@ -75,6 +75,7 @@ def test_some_nonsense():
                     name="i1",
                 ),
             },
+            events={},
         )
     )
 

--- a/tests/unit/query_model/test_column_specs.py
+++ b/tests/unit/query_model/test_column_specs.py
@@ -45,6 +45,7 @@ def test_get_column_specs():
             code=SelectColumn(patients, "code"),
             category=SelectColumn(patients, "category"),
         ),
+        events={},
     )
     table_specs = get_table_specs(dataset)
     assert table_specs == {

--- a/tests/unit/query_model/test_transforms.py
+++ b/tests/unit/query_model/test_transforms.py
@@ -361,4 +361,4 @@ def test_substitute_parameters():
 
 
 def dataset_factory(**variables):
-    return Dataset(population=Value(False), variables=variables)
+    return Dataset(population=Value(False), variables=variables, events={})

--- a/tests/unit/test_debugger.py
+++ b/tests/unit/test_debugger.py
@@ -277,6 +277,61 @@ def test_render_related_event_series(dummy_tables_path):
     ]
 
 
+def test_render_dataset_event_tables_with_population(dummy_tables_path):
+    dataset = create_dataset()
+    dataset.define_population(patients.sex == "male")
+    dataset.add_event_table("test", date=events.date, code=events.code)
+    with activate_debug_context(
+        dummy_tables_path=dummy_tables_path,
+        render_function=json_render_function,
+    ) as ctx:
+        rendered = ctx.render(dataset.test)
+    assert json.loads(rendered) == [
+        {
+            "patient_id": 1,
+            "row_id": 1,
+            "date": "2010-01-01",
+            "code": "abc",
+        },
+        {
+            "patient_id": 1,
+            "row_id": 2,
+            "date": "2020-01-01",
+            "code": "def",
+        },
+    ]
+
+
+def test_render_dataset_event_tables_without_population(dummy_tables_path):
+    dataset = create_dataset()
+    dataset.add_event_table("test", date=events.date, code=events.code)
+    with activate_debug_context(
+        dummy_tables_path=dummy_tables_path,
+        render_function=json_render_function,
+    ) as ctx:
+        rendered = ctx.render(dataset.test)
+    assert json.loads(rendered) == [
+        {
+            "patient_id": 1,
+            "row_id": 1,
+            "date": "2010-01-01",
+            "code": "abc",
+        },
+        {
+            "patient_id": 1,
+            "row_id": 2,
+            "date": "2020-01-01",
+            "code": "def",
+        },
+        {
+            "patient_id": 2,
+            "row_id": 3,
+            "date": "2005-01-01",
+            "code": "abc",
+        },
+    ]
+
+
 def test_render_date_difference(dummy_tables_path):
     with activate_debug_context(
         dummy_tables_path=dummy_tables_path,

--- a/tests/unit/test_query_language.py
+++ b/tests/unit/test_query_language.py
@@ -120,6 +120,7 @@ def test_dataset():
                 )
             ),
         },
+        events={},
     )
 
 

--- a/tests/unit/test_query_language.py
+++ b/tests/unit/test_query_language.py
@@ -172,7 +172,7 @@ def test_dataset_accepts_valid_variable_names(name):
 def test_add_column():
     dataset = Dataset()
     dataset.add_column("foo", patients.i)
-    variables = list(dataset.variables.keys())
+    variables = list(dataset._variables.keys())
     assert variables == ["foo"]
 
 
@@ -180,7 +180,6 @@ def test_add_column():
     "variable_name,error",
     [
         ("population", "Cannot set variable 'population'; use define_population"),
-        ("variables", "'variables' is not an allowed variable name"),
         ("patient_id", "'patient_id' is not an allowed variable name"),
         (
             "dummy_data_config",


### PR DESCRIPTION
This PR adds event-level data as an undocumented feature, currently disabled in production. This will allow us to do some user-testing of the API and develop appropriate processes and safeguards around its use before making it generally available.

In addition to being undocumented we do some trickery to prevent the method appearing as an autocomplete option.

The new API consists of a new `Dataset.add_event_table()` method, used like so:
```py
dataset.add_event_table(
    "interesting_events",
    date=events_of_interest.date,
    code=events_of_interest.snomedct_code,
)
```

This will result in a new output file called e.g. `interesting_events.arrow` with `patient_id`, `date` and `code` columns and containing multiple rows per patient.

It's possible to add additional columns to the event table after defining it, as you would with normal dataset variables:
```py
dataset.interesting_events.numeric_value = interesting_events.numeric_value
```

Because the output of the dataset will no longer consist of a single file you won't be able to specify it as e.g. `--output results.arrow`. Instead you will need to write something like `--output results:arrow` which will produce a `results` _directory_ containing multiple files. In any case, the error messages raised if you do the wrong thing here should hopefully point the user in the right direction.
