### PR TITLE
Use global temporary table for MSSQL results

### DIFF
--- a/justfile
+++ b/justfile
@@ -156,7 +156,7 @@ connect-to-mssql:
     # file to this commmand as well as using it interactively.
     docker exec -i `[ -t 0 ] && echo '-t'` \
         ehrql-mssql \
-            /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P 'Your_password123!' -d test
+            /opt/mssql-tools18/bin/sqlcmd -C -S localhost -U sa -P 'Your_password123!' -d test
 
 
 # Open an interactive trino shell

--- a/tests/integration/query_engines/test_mssql.py
+++ b/tests/integration/query_engines/test_mssql.py
@@ -78,7 +78,7 @@ def wrap_select_queries():
                 # itself. But I've tried and failed to do so, partly because the
                 # `pymssql` driver we use is a compiled library and so less amenable to
                 # monkey patching.
-                self._dbapi_connection = None
+                self.invalidate()
                 raise
         return original(self, *args, **kwargs)
 


### PR DESCRIPTION
This allows us to use a separate connection for downloading results which can safely reconnect and resume on error without losing the temporary table. This gives us the robustness we used to get when writing results to a persistent table but without the locking and performance problems which that gave us (and with the benefit of automatic cleanup should a job get interrupted).

This functions as a workaround to the problem described in #2345.

There are various bits of database behaviour which we've had to confirm empirically:
 * Running a `SELECT * INTO ##some_table ...` query doesn't take a global lock which prevents other such queries running simultaneously (as long as they are not run inside an explicit transaction).
 * Querying the table from a separate connection works, and allows us to successfully retry following a "DBPROCESS" error.
 * The table is automatically dropped if the ehrQL job is killed.

Associated Slack thread:
https://bennettoxford.slack.com/archives/C069YDR4NCA/p1738586172380799