### PR TITLE
Fix and simplify gentest randomisation toggle

### DIFF
--- a/.github/workflows/generative-tests.yml
+++ b/.github/workflows/generative-tests.yml
@@ -28,7 +28,6 @@ jobs:
 
           export \
             GENTEST_EXAMPLES=150 \
-            GENTEST_RANDOMIZE=t \
             GENTEST_MAX_DEPTH=25
 
           # We get a maximum of 6 hours runtime with Github Actions so breaking

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -74,27 +74,21 @@ results are the same.
 
 To get the most out of our generative tests we want them to run for a
 long time and to explore different parts of the query space each time
-they're run. But neither of these qualities are desirable in CI or in
-local test runs. For this reason, the default configuration generates
-only a small number of examples, of limited query depth, and in a
-determinstic fashion. They thus function more as a test that the
-generative test machinery is working correctly than as a serious attempt
-to do generative testing.
+they're run. But neither of these qualities are desirable in CI.
 
-By default, CI generates more examples than the local tests on the basis
-that the extra time is less noticeble there and it gives us a better
-chance of actully catching some novel bugs. But the examples are still
-deterministic for reasons of sanity preservation.
+For this reason, the CI configuration generates only a small number of
+examples, of limited query depth, and in a determinstic fashion. They
+thus function more as a test that the generative test machinery is
+working correctly than as a serious attempt to do generative testing.
 
-To do some "proper" generative testing you can run the command:
+When running locally, although randomisation is enabled by default,
+the number of examples is still very small (to keep test runtimes
+reasonable). To do some "proper" generative testing you can run the
+command:
 ```
 just test-generative
 ```
-which increases the example count even further and enables randomisation
-by setting:
-```
-GENTEST_RANDOMIZE=t
-```
+which increases the example count by setting `GENTEST_EXAMPLES`.
 
 It would be worth running these locally when adding new query model
 operations or making significant changes to a query engine. You may even

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -119,9 +119,9 @@ small examples can appear overwhelmingly verbose due to the repetitive
 nature of query model reprs. To help with this there is some tooling,
 and a process to follow:
 
- * Copy the `population`, `variable` and `data` arguments from the
-   example that Hypothesis displays and paste them into a new file.
-   (Don't worry about stripping indentation or trailing commas here.)
+ * Copy the `dataset` and `data` arguments from the example that
+   Hypothesis displays and paste them into a new file.  (Don't worry
+   about stripping indentation or trailing commas here.)
 
  * Run the command:
    ```

--- a/justfile
+++ b/justfile
@@ -219,7 +219,6 @@ test-unit *ARGS: devenv
 # Run generative tests using more than the small deterministic set of examples used in CI
 test-generative *ARGS: devenv
     GENTEST_EXAMPLES=${GENTEST_EXAMPLES:-200} \
-    GENTEST_RANDOMIZE=${GENTEST_RANDOMIZE:-t} \
       $BIN/python -m pytest tests/generative "$@"
 
 
@@ -228,6 +227,7 @@ test-generative *ARGS: devenv
     #!/usr/bin/env bash
     set -euo pipefail
 
+    GENTEST_DERANDOMIZE=t \
     GENTEST_EXAMPLES=${GENTEST_EXAMPLES:-100} \
     GENTEST_CHECK_IGNORED_ERRORS=t \
       $BIN/python -m pytest \

--- a/tests/generative/test_query_model.py
+++ b/tests/generative/test_query_model.py
@@ -84,14 +84,7 @@ data_strategy = data_strategies.data(
 settings = dict(
     max_examples=(int(os.environ.get("GENTEST_EXAMPLES", 10))),
     deadline=None,
-    # On CI we want to run derandomized unless we're explicitly in the
-    # long-running bug finding tests. This prevents flaky CI.
-    # In development we never want to run with derandomize because it's
-    # less effective at finding bugs and, more importantly, has very slow
-    # replay due to turning off the test database
-    derandomize=bool(os.environ.get("GENTEST_RANDOMIZE"))
-    if os.environ.get("CI")
-    else False,
+    derandomize=bool(os.environ.get("GENTEST_DERANDOMIZE")),
     # The explain phase is comparatively expensive here given how
     # costly data generation is for our tests here, so we turn it
     # off by default.


### PR DESCRIPTION
The comment correctly described the behaviour we wanted, but the code logic was backwards. This is easy enough to do when you've got an env var called "RANDOMIZE" toggling a config value called "derandomize" so we switch the name of the env var to match.

This makes it clear that there's exactly one circumstance where we don't want randomisation and that's in the CI tests.

Related Slack thread:
https://bennettoxford.slack.com/archives/C069YDR4NCA/p1739440049238879