### PR TITLE
Treat `CombineAsSet` as unspecializable operation

### DIFF
--- a/ehrql/dummy_data_nextgen/query_info.py
+++ b/ehrql/dummy_data_nextgen/query_info.py
@@ -269,6 +269,7 @@ def specialize(query, column) -> Node | None:
             AggregateByPatient.Count()
             | AggregateByPatient.CountDistinct()
             | AggregateByPatient.Exists()
+            | AggregateByPatient.CombineAsSet()
         ):
             return None
         case (


### PR DESCRIPTION
I think probably the reason this wasn't included originally is that it's harder to construct the problematic cases. But the reasons for excluding it are the same.

Closes #2396