### PR TITLE
Use simpler, more general approach to dict hashing

### DIFF
--- a/ehrql/utils/functools_utils.py
+++ b/ehrql/utils/functools_utils.py
@@ -71,23 +71,3 @@ class singledispatchmethod_with_cache(singledispatchmethod):
         # the whole thing pointless.
         obj.__dict__[self.attribute_name] = cached_method
         return cached_method
-
-
-def cached_method(method):
-    """
-    Decorate a zero-argument method to apply caching
-    """
-    MISSING = object()
-    cache_attr = f"__{method.__name__}_cache"
-
-    def wrapper(self):
-        value = getattr(self, cache_attr, MISSING)
-        if value is not MISSING:
-            return value
-        value = method(self)
-        # We want to use this with frozen dataclasses which override `__setattr__` to
-        # trigger an error, so we have to use the method from `object` to do this
-        object.__setattr__(self, cache_attr, value)
-        return value
-
-    return wrapper

--- a/tests/unit/utils/test_functools_utils.py
+++ b/tests/unit/utils/test_functools_utils.py
@@ -1,11 +1,6 @@
-import dataclasses
-
 import pytest
 
-from ehrql.utils.functools_utils import (
-    cached_method,
-    singledispatchmethod_with_cache,
-)
+from ehrql.utils.functools_utils import singledispatchmethod_with_cache
 
 
 @pytest.fixture
@@ -53,24 +48,3 @@ def test_clearing_cache_only_affects_single_instance(TestClass):
     obj1.test.cache_clear()
     assert result1 is not obj1.test("hello")
     assert result2 is obj2.test("hello")
-
-
-def test_cached_method():
-    CALL_COUNT = 0
-
-    @dataclasses.dataclass(frozen=True)
-    class SomeValue:
-        n: int
-
-        @cached_method
-        def n_plus_one(self):
-            nonlocal CALL_COUNT
-            CALL_COUNT += 1
-            return self.n + 1
-
-    value = SomeValue(42)
-    assert CALL_COUNT == 0
-    assert value.n_plus_one() == 43
-    assert CALL_COUNT == 1
-    assert value.n_plus_one() == 43
-    assert CALL_COUNT == 1


### PR DESCRIPTION
This avoids having to add a custom hash method every time we add a new query model type which uses a dict, as we seem to be doing more often these days.