### PR TITLE
De-prioritise "raw" schemas in search results

### DIFF
--- a/docs/includes/generated_docs/schemas/core.md
+++ b/docs/includes/generated_docs/schemas/core.md
@@ -1,3 +1,4 @@
+
 # <strong>core</strong> schema
 
 Available on backends: [**TPP**](../backends.md#tpp), [**EMIS**](../backends.md#emis)

--- a/docs/includes/generated_docs/schemas/emis.md
+++ b/docs/includes/generated_docs/schemas/emis.md
@@ -1,3 +1,4 @@
+
 # <strong>emis</strong> schema
 
 Available on backends: [**EMIS**](../backends.md#emis)

--- a/docs/includes/generated_docs/schemas/raw.core.md
+++ b/docs/includes/generated_docs/schemas/raw.core.md
@@ -1,3 +1,8 @@
+---
+search:
+  boost: 0.5
+---
+
 # <strong>raw.core</strong> schema
 
 Available on backends: [**TPP**](../backends.md#tpp), [**EMIS**](../backends.md#emis)

--- a/docs/includes/generated_docs/schemas/raw.emis.md
+++ b/docs/includes/generated_docs/schemas/raw.emis.md
@@ -1,3 +1,8 @@
+---
+search:
+  boost: 0.5
+---
+
 # <strong>raw.emis</strong> schema
 
 Available on backends: [**EMIS**](../backends.md#emis)

--- a/docs/includes/generated_docs/schemas/raw.tpp.md
+++ b/docs/includes/generated_docs/schemas/raw.tpp.md
@@ -1,3 +1,8 @@
+---
+search:
+  boost: 0.5
+---
+
 # <strong>raw.tpp</strong> schema
 
 Available on backends: [**TPP**](../backends.md#tpp)

--- a/docs/includes/generated_docs/schemas/smoketest.md
+++ b/docs/includes/generated_docs/schemas/smoketest.md
@@ -1,3 +1,4 @@
+
 # <strong>smoketest</strong> schema
 
 Available on backends: [**TPP**](../backends.md#tpp), [**EMIS**](../backends.md#emis)

--- a/docs/includes/generated_docs/schemas/tpp.md
+++ b/docs/includes/generated_docs/schemas/tpp.md
@@ -1,3 +1,4 @@
+
 # <strong>tpp</strong> schema
 
 Available on backends: [**TPP**](../backends.md#tpp)

--- a/ehrql/docs/render_includes/schemas.py
+++ b/ehrql/docs/render_includes/schemas.py
@@ -34,6 +34,7 @@ def implemented_by_list(backends, depth=1):
 
 
 SCHEMA_TEMPLATE = """\
+{metadata_header}
 # <strong>{name}</strong> schema
 
 {implemented_by_list}
@@ -50,9 +51,19 @@ from {dotted_path} import (
 """
 
 
+SEARCH_PRIORITY_HEADER = """\
+---
+search:
+  boost: 0.5
+---
+"""
+
+
 def render_schema(schema):
     return SCHEMA_TEMPLATE.format(
         **schema,
+        # De-prioritise raw schemas in the search results
+        metadata_header=SEARCH_PRIORITY_HEADER if schema["is_raw"] else "",
         implemented_by_list=implemented_by_list(schema["implemented_by"], depth=2),
         table_imports=table_imports(schema["tables"]),
         table_descriptions=table_descriptions(schema["tables"]),

--- a/ehrql/docs/schemas.py
+++ b/ehrql/docs/schemas.py
@@ -47,6 +47,7 @@ def build_schemas(backends=()):
                 "hierarchy": hierarchy,
                 "docstring": docstring,
                 "implemented_by": implemented_by,
+                "is_raw": ".raw." in dotted_path,
                 "tables": sorted(module_tables, key=lambda t: t["name"]),
             }
         )


### PR DESCRIPTION
Currently the search has a tendency to return results from the "raw" schemas ahead of the standard ones which has caused confusion in the past.

Closes #2086