### PR TITLE
Refactor setup/cleanup query handling

### DIFF
--- a/ehrql/main.py
+++ b/ehrql/main.py
@@ -41,10 +41,7 @@ from ehrql.query_model.column_specs import (
 )
 from ehrql.query_model.graphs import graph_to_svg
 from ehrql.serializer import serialize
-from ehrql.utils.sqlalchemy_query_utils import (
-    clause_as_str,
-    get_setup_and_cleanup_queries,
-)
+from ehrql.utils.sqlalchemy_query_utils import clause_as_str
 
 
 log = logging.getLogger()
@@ -177,26 +174,14 @@ def dump_dataset_sql(
 
 
 def get_sql_strings(query_engine, dataset):
-    results_queries = query_engine.get_queries(dataset)
-    setup_queries, cleanup_queries = get_setup_and_cleanup_queries(results_queries)
+    queries = query_engine.get_queries(dataset)
     dialect = query_engine.sqlalchemy_dialect()
     sql_strings = []
 
-    for i, query in enumerate(setup_queries, start=1):
+    for i, (has_results, query) in enumerate(queries, start=1):
+        description = "Fetch results from" if has_results else "Run"
         sql = clause_as_str(query, dialect)
-        sql_strings.append(f"-- Setup query {i:03} / {len(setup_queries):03}\n{sql}")
-
-    for i, query in enumerate(results_queries, start=1):
-        sql = clause_as_str(query, dialect)
-        sql_strings.append(
-            f"-- Results query {i:03} / {len(results_queries):03}\n{sql}"
-        )
-
-    for i, query in enumerate(cleanup_queries, start=1):
-        sql = clause_as_str(query, dialect)
-        sql_strings.append(
-            f"-- Cleanup query {i:03} / {len(cleanup_queries):03}\n{sql}"
-        )
+        sql_strings.append(f"-- {description} query {i:03} / {len(queries):03}\n{sql}")
 
     return sql_strings
 

--- a/ehrql/query_engines/base_sql.py
+++ b/ehrql/query_engines/base_sql.py
@@ -906,11 +906,17 @@ class BaseSQLQueryEngine(BaseQueryEngine):
         dialect_name = self.sqlalchemy_dialect.__name__
         sqlalchemy.dialects.registry.impls[dialect_name] = self.sqlalchemy_dialect
         engine_url = sqlalchemy.engine.make_url(self.dsn).set(drivername=dialect_name)
-        engine = sqlalchemy.create_engine(engine_url)
+        engine = sqlalchemy.create_engine(
+            engine_url,
+            **self.get_sqlalchemy_execution_options(),
+        )
         # The above relies on abusing SQLAlchemy internals so it's possible it will
         # break in future — we want to know immediately if it does
         assert isinstance(engine.dialect, self.sqlalchemy_dialect)
         return engine
+
+    def get_sqlalchemy_execution_options(self):
+        return {}
 
 
 def apply_patient_joins(query):

--- a/ehrql/query_engines/mssql.py
+++ b/ehrql/query_engines/mssql.py
@@ -147,8 +147,8 @@ class MSSQLQueryEngine(BaseSQLQueryEngine):
         ]
         return table
 
-    def get_queries(self, dataset):
-        results_queries = super().get_queries(dataset)
+    def get_results_queries(self, dataset):
+        results_queries = super().get_results_queries(dataset)
         # Write results to temporary tables and select them from there. This allows us
         # to use more efficient/robust mechanisms to retrieve the results.
         select_queries = []

--- a/ehrql/query_engines/mssql.py
+++ b/ehrql/query_engines/mssql.py
@@ -15,11 +15,7 @@ from ehrql.utils.sqlalchemy_exec_utils import (
     execute_with_retry_factory,
     fetch_table_in_batches,
 )
-from ehrql.utils.sqlalchemy_query_utils import (
-    GeneratedTable,
-    InsertMany,
-    get_setup_and_cleanup_queries,
-)
+from ehrql.utils.sqlalchemy_query_utils import GeneratedTable, InsertMany
 
 
 log = logging.getLogger()
@@ -172,68 +168,49 @@ class MSSQLQueryEngine(BaseSQLQueryEngine):
             select_queries.append(select_query)
         return select_queries
 
-    def get_results_stream(self, dataset):
-        results_queries = self.get_queries(dataset)
+    def execute_query_no_results(self, connection, query, query_id):
+        execute_with_log(connection, query, log.info, query_id=query_id)
 
+    def execute_query_with_results(self, connection, query, query_id):
         # We're expecting queries in a very specific form which is "select everything
-        # from one table"; so we assert that they have this form and retrieve references
-        # to the tables
-        results_tables = []
-        for results_query in results_queries:
-            results_table = results_query.get_final_froms()[0]
-            assert str(results_query) == str(sqlalchemy.select(results_table))
-            results_table = results_table._annotate(results_query._annotations)
-            results_tables.append(results_table)
+        # from one table"; so we assert that each query has this form and retrieve a
+        # reference to the table
+        results_table = query.get_final_froms()[0]
+        assert str(query) == str(sqlalchemy.select(results_table))
 
-        setup_queries, cleanup_queries = get_setup_and_cleanup_queries(results_queries)
+        # The query type tells us whether or not we can depend on a unique patient_id
+        # column. We need to pass this information to the batch fetcher as it changes
+        # the algorithm we can use.
+        has_unique_key = {
+            self.QueryType.PATIENT_LEVEL: True,
+            self.QueryType.EVENT_LEVEL: False,
+        }
+        key_is_unique = has_unique_key[query._annotations["query_type"]]
 
-        with self.engine.connect() as connection:
-            for i, setup_query in enumerate(setup_queries, start=1):
-                query_id = f"setup query {i:03} / {len(setup_queries):03}"
-                log.info(f"Running {query_id}")
-                execute_with_log(connection, setup_query, log.info, query_id=query_id)
+        # We use a separate connection to retrieve the results. Our intial connection
+        # keeps the temporary table "alive" and then this connection can be safely reset
+        # and retried if we hit errors during the download (which we often do for
+        # reasons we don't yet understand).
+        with self.engine.connect() as results_connection:
+            # Retry 4 times over the course of 1 minute
+            execute_with_retry = execute_with_retry_factory(
+                results_connection,
+                max_retries=4,
+                retry_sleep=4.0,
+                backoff_factor=2,
+                log=log.info,
+            )
 
-            # We use a separate connection to retrieve the results. Our intial
-            # connection keeps the temporary table "alive" and then this connection can
-            # be safely reset and retried if we hit errors during the download (which we
-            # often do for reasons we don't yet understand).
-            with self.engine.connect() as results_connection:
-                # Retry 4 times over the course of 1 minute
-                execute_with_retry = execute_with_retry_factory(
-                    results_connection,
-                    max_retries=4,
-                    retry_sleep=4.0,
-                    backoff_factor=2,
-                    log=log.info,
-                )
-
-                unique_key = {
-                    self.QueryType.PATIENT_LEVEL: True,
-                    self.QueryType.EVENT_LEVEL: False,
-                }
-
-                for i, results_table in enumerate(results_tables):
-                    # The query type tells us whether or not we can depend on a unique
-                    # patient_id column. We need to pass this information to the batch
-                    # fetcher as it changes the algorithm we can use.
-                    key_is_unique = unique_key[results_table._annotations["query_type"]]
-
-                    yield self.RESULTS_START
-                    yield from fetch_table_in_batches(
-                        execute_with_retry,
-                        results_table,
-                        key_column=results_table.c.patient_id,
-                        key_is_unique=key_is_unique,
-                        # This value was copied from the previous cohortextractor. I
-                        # suspect it has no real scientific basis.
-                        batch_size=32000,
-                        log=log.info,
-                    )
-
-            for i, cleanup_query in enumerate(cleanup_queries, start=1):
-                query_id = f"cleanup query {i:03} / {len(cleanup_queries):03}"
-                log.info(f"Running {query_id}")
-                execute_with_log(connection, cleanup_query, log.info, query_id=query_id)
+            yield from fetch_table_in_batches(
+                execute_with_retry,
+                results_table,
+                key_column=results_table.c.patient_id,
+                key_is_unique=key_is_unique,
+                # This value was copied from the previous cohortextractor. I suspect it
+                # has no real scientific basis.
+                batch_size=32000,
+                log=log.info,
+            )
 
     def get_sqlalchemy_execution_options(self):
         # All our queries are either (a) read-only queries against static data, or

--- a/ehrql/utils/sqlalchemy_query_utils.py
+++ b/ehrql/utils/sqlalchemy_query_utils.py
@@ -72,15 +72,11 @@ class GeneratedTable(sqlalchemy.Table):
         return cls(name, metadata, *columns, **kwargs)
 
 
-def get_setup_and_cleanup_queries(queries):
+def add_setup_and_cleanup_queries(queries):
     """
-    Given a list of SQLAlchemy queries find all GeneratedTables embedded in them and
-    return a pair:
-
-        setup_queries, cleanup_queries
-
-    which are the combination of all the setup and cleanup queries from those
-    GeneratedTables in the correct order for execution.
+    Given a list of SQLAlchemy queries, find all GeneratedTables embedded in them and
+    return a list which includes the original queries plus all the necessary setup and
+    cleanup queries from those GeneratedTables in an appropriate order for execution.
     """
     # GeneratedTables can be arbitrarily nested in that their setup queries can
     # themselves contain references to GeneratedTables and so on. We need to
@@ -116,7 +112,7 @@ def get_setup_and_cleanup_queries(queries):
     # risk errors by trying to delete objects which still have dependents.
     cleanup_queries = flatten_iter(t.cleanup_queries for t in reversed(tables))
 
-    return setup_queries, cleanup_queries
+    return setup_queries + queries + cleanup_queries
 
 
 def get_generated_table_dependencies(queries, parent_table=None, seen_tables=None):


### PR DESCRIPTION
The big change here is to do away with the "three lists" representation of our queries in the form:

    setup_queries, results_queries, cleanup_queries

and instead have a flat list of queries paired with a boolean indicating whether that query is expected to return any results e.g

    False, sqlalchemy.text("CREATE TABLE ...")
    False, sqlalchemy.text("INSERT INTO ...")
    True,  sqlalchemy.text("SELECT * FROM ...")
    False, sqlalchemy.text("DROP TABLE ...")

This generally simplifies the code and also allows us to arbitrarily interleave query types so that we're not restricted to doing cleanup only after all the results queries have run. This will allow us to do much longer sequences of queries (e.g all the queries required for a set of measures) without fear of running out of temporary table space.

This does mean that our logs no longer explicitly distinguish between setup and cleanup queries, but I don't think this is any great loss: given that we log the query itself it's pretty obvious what sort it is.

At present, we still return queries in the same order (setup followed by results followed by cleanup) but a subsequent PR can now change the logic in `add_setup_and_cleanup_queries()` without requiring any changes elsewhere.

We also make two related improvements:

 * We now annotate the results queries with their "type" (which at present means patient-level or event-level but in future can included aggregated results as well) so that query engines can use the appropriate technique to download the results. (Previously we hardcoded the assumption that the first query was patient-level and subsequent ones were event-level.)

 * We reduce the divergence between the MSSQL engine and the base SQL engine so that we no longer need to re-implement the whole query loop in MSSQL and instead can just specialise the database query methods.

Partially addresses #2411