### PR TITLE
Fix quiz error checking for series defaults

### DIFF
--- a/ehrql/quiz.py
+++ b/ehrql/quiz.py
@@ -137,10 +137,18 @@ def check_patient_column_values(
         incorrect = sorted(
             ev_answer.patient_to_value.items() - ev_expected.patient_to_value.items()
         )
-        # Last check for Patient Frames/Series; Expect incorrect to be non-empty
+        # Last check for Patient Frames/Series
         # Only show the first incorrect value
-        for k, v in incorrect:  # pragma: no branch
+        for k, v in incorrect:
             return f"Incorrect{column_name}value for patient {k}: expected {str(ev_expected[k])}, got {str(v)} instead."
+        # It should only be possible to get here if the defaults are different,
+        # otherwise the difference must come from a specific patient and we'll return
+        # early above
+        assert ev_answer.default != ev_expected.default
+        return (
+            f"Series has the wrong default value for patients with no matching "
+            f"records: expected {ev_expected.default} but got {ev_answer.default}"
+        )
     return None
 
 

--- a/tests/unit/test_quiz.py
+++ b/tests/unit/test_quiz.py
@@ -245,6 +245,28 @@ def test_check_answer_incorrect_event_selection_for_patient(engine):
     )
 
 
+def test_check_answer_patient_series_has_incorrect_default(engine):
+    date_1 = (
+        clinical_events.where(clinical_events.snomedct_code.is_in(["60621009"]))
+        .sort_by(clinical_events.date)
+        .last_for_patient()
+        .date
+    )
+    date_2 = (
+        clinical_events.where(clinical_events.snomedct_code.is_in(["60621010"]))
+        .sort_by(clinical_events.date)
+        .last_for_patient()
+        .date
+    )
+    answer = (date_1 > date_2) | (date_1.is_null() & date_2.is_null())
+    expected = date_1 > date_2
+    msg = quiz.check_answer(engine=engine, answer=answer, expected=expected)
+    assert msg == (
+        "Series has the wrong default value for patients with no matching records: "
+        "expected None but got True"
+    )
+
+
 def test_check_answer_unidentified_error_shows_fallback_message(engine):
     with patch("ehrql.quiz.check_patient_table_values", return_value=None):
         msg = quiz.check_answer(


### PR DESCRIPTION
This attempts to address the confusing behaviour identified in:
 * https://github.com/opensafely/ehrql-tutorial/issues/24

The issue was that although the proposed series gave the right answer for all patients contained within the series, it would not give the right answer when combined with series containing other patients.

This is because the final clause:

    | ((has_moderate_or_severe.is_null()) & (has_mild.is_null())))

means the value default to True for missing patients whereas it should default to False.

Preventing this kind of confusion was the aim of a previous change to the in-memory engine, but unfortunately it turns out not to be easy to do this without breaking things elsewhere. See:
 * https://github.com/opensafely-core/ehrql/pull/2256

The new error message is not as absolutely clear as we might like, but it's an improvement on the status quo.