### PR TITLE
Handle NULL numerators in measures

### DIFF
--- a/ehrql/measures/calculate.py
+++ b/ehrql/measures/calculate.py
@@ -35,7 +35,15 @@ def get_measure_results(query_engine, measures, timeout=259200.0):
         calculator = MeasureCalculator(measure_group)
         results = calculator.get_results(query_engine)
         for measure, interval, numerator, denominator, group_dict in results:
-            ratio = numerator / denominator if denominator else None
+            # Given the way results are constructed we should never get a zero-valued or
+            # NULL denominator: we should just get no results at all for that measure
+            # row
+            assert denominator, (
+                f"{denominator!r} denominator in {measure.name} at {interval}"
+            )
+            if numerator is None:
+                numerator = 0
+            ratio = numerator / denominator
             yield (
                 measure.name,
                 interval[0],


### PR DESCRIPTION
This used to be handled by the old measures code:
https://github.com/opensafely-core/ehrql/blob/13de8adb9a3159697e83d050137117e510ad18fb/ehrql/measures/calculate.py#L133-L137

However somewhere along the way this turned instead into a check for a NULL or zero-valued denominator:
https://github.com/opensafely-core/ehrql/blob/f332932ad60c349a34751cdbea7e25964b0d0d8f/ehrql/measures/calculate.py#L38

The lack of NULL numerator handling recently resulted in an error for a user (see [thread][1]) which was misdiagnosed as an issue with `is_null()` (see #2445).

I'm _fairly_ confident that it's not possible to get either a NULL or a zero denominator value given the way measure results are generated. Certainly I haven't managed to construct a test case which produces one. So I've added an assertion to that effect along with hopefully enough debugging information to help us out if we ever do hit it.

[1]: https://bennettoxford.slack.com/archives/C01D7H9LYKB/p1745850451388559