### PR TITLE
Correct "ealiest" to "earliest" in example

### DIFF
--- a/docs/includes/generated_docs/language__functions.md
+++ b/docs/includes/generated_docs/language__functions.md
@@ -65,6 +65,6 @@ Return the minimum value of a collection of Series or Values, disregarding NULLs
 
 Example usage:
 ```python
-ealiest_event_date = minimum_of(event_series_1.date, event_series_2.date, "2001-01-01")
+earliest_event_date = minimum_of(event_series_1.date, event_series_2.date, "2001-01-01")
 ```
 </div>

--- a/ehrql/query_language.py
+++ b/ehrql/query_language.py
@@ -2340,7 +2340,7 @@ def minimum_of(value, other_value, *other_values):
 
     Example usage:
     ```python
-    ealiest_event_date = minimum_of(event_series_1.date, event_series_2.date, "2001-01-01")
+    earliest_event_date = minimum_of(event_series_1.date, event_series_2.date, "2001-01-01")
     ```
     """
     args = cast_all_arguments((value, other_value, *other_values))


### PR DESCRIPTION
In docstring used to build documentation.