### PR TITLE
Don't attempt to fetch measure results in batches

### DIFF
--- a/ehrql/query_engines/base_sql.py
+++ b/ehrql/query_engines/base_sql.py
@@ -64,6 +64,7 @@ class BaseSQLQueryEngine(BaseQueryEngine):
     class QueryType(enum.Enum):
         PATIENT_LEVEL = "patient_level"
         EVENT_LEVEL = "event_level"
+        AGGREGATED = "aggregated"
 
     sqlalchemy_dialect: sqlalchemy.engine.interfaces.Dialect
 
@@ -144,7 +145,7 @@ class BaseSQLQueryEngine(BaseQueryEngine):
             self.grouping_id(*all_group_by_cols.values()),
         ).group_by(sqlalchemy.func.grouping_sets(*grouping_sets))
 
-        return [measures_query._annotate({"query_type": self.QueryType.EVENT_LEVEL})]
+        return [measures_query._annotate({"query_type": self.QueryType.AGGREGATED})]
 
     def get_results_queries(self, dataset):
         """


### PR DESCRIPTION
Batched fetching was introduced to work around the unreliability of the database connection as it allows us to retry part way through the download without starting again from the beginning. The problem is particularly acute for patient and event-level results which number in the millions and where there is an obvious column (`patient_id`) to page on. However this is less of an issue for aggregated results (specifically measures) as there are fewer rows to deal with, and these also lack a natural paging column.

Attempting to use batched fetching on measures results is now causing issues (see linked ticket) and so the simplest solution is just to stop doing it.

See also discussion at:
https://bennettoxford.slack.com/archives/C069YDR4NCA/p1747925981081259

Closes #2466