### PR TITLE
Improve error message for invalid test data columns

### DIFF
--- a/ehrql/assurance.py
+++ b/ehrql/assurance.py
@@ -26,6 +26,8 @@ def validate(dataset, test_data):
 
     # Create objects to insert into database
     table_nodes = get_table_nodes(dataset)
+    # Check tables in consistent order for easier testing
+    table_nodes = sorted(table_nodes, key=lambda i: i.name)
 
     constraint_validation_errors = defaultdict(list)
     input_data = {table: [] for table in table_nodes}

--- a/ehrql/assurance.py
+++ b/ehrql/assurance.py
@@ -7,6 +7,7 @@ from ehrql.query_model.nodes import has_one_row_per_patient
 
 
 UNEXPECTED_TEST_VALUE = "unexpected-test-value"
+UNEXPECTED_COLUMN = "unexpected-column"
 UNEXPECTED_IN_POPULATION = "unexpected-in-population"
 UNEXPECTED_NOT_IN_POPULATION = "unexpected-not-in-population"
 UNEXPECTED_OUTPUT_VALUE = "unexpected-output-value"
@@ -72,10 +73,14 @@ def validate(dataset, test_data):
 
 def validate_constraints(records, table):
     unexpected_test_values = []
+    unexpected_columns = []
     for record in records:
         for column, value in record.items():
-            constraints = table.schema.schema[column].constraints
-            for constraint in constraints:
+            schema_column = table.schema.schema.get(column)
+            if schema_column is None:
+                unexpected_columns.append(column)
+                continue
+            for constraint in schema_column.constraints:
                 is_valid = constraint.validate(value)
                 if not is_valid:
                     unexpected_test_values.append(
@@ -85,16 +90,28 @@ def validate_constraints(records, table):
                             "value": f"{value}",
                         }
                     )
-    if not unexpected_test_values:
-        return []
-    else:
-        return [
+    results = []
+    if unexpected_test_values:
+        results.append(
             {
-                "table": table.name,
                 "type": UNEXPECTED_TEST_VALUE,
+                "table": table.name,
                 "details": unexpected_test_values,
             }
-        ]
+        )
+    if unexpected_columns:
+        results.append(
+            {
+                "type": UNEXPECTED_COLUMN,
+                "table": table.name,
+                "details": {
+                    # De-duplicate while retaining order
+                    "invalid": list(dict.fromkeys(unexpected_columns)),
+                    "valid": list(table.schema.schema.keys()),
+                },
+            }
+        )
+    return results
 
 
 def validate_patient(patient_id, patient, results):
@@ -134,6 +151,12 @@ def present(validation_results):
                         lines.append(
                             f"   * for column '{detail['column']}' with '{detail['constraint']}', got '{detail['value']}'"
                         )
+                elif result["type"] == UNEXPECTED_COLUMN:
+                    lines.append(
+                        f" * Patient {patient_id} had invalid columns in the test data for table '{result['table']}'\n"
+                        f"       invalid columns: {', '.join(map(repr, result['details']['invalid']))}\n"
+                        f"     valid columns are: {', '.join(map(repr, result['details']['valid']))}"
+                    )
                 else:
                     assert False, result["type"]
         return "\n".join(lines)

--- a/ehrql/assurance.py
+++ b/ehrql/assurance.py
@@ -78,10 +78,12 @@ def validate_constraints(records, table):
                         }
                     )
     if unexpected_test_values:
-        return {
-            "type": UNEXPECTED_TEST_VALUE,
-            "details": unexpected_test_values,
-        }
+        return [
+            {
+                "type": UNEXPECTED_TEST_VALUE,
+                "details": unexpected_test_values,
+            }
+        ]
 
 
 def validate_patient(patient_id, patient, results):
@@ -111,17 +113,18 @@ def present(validation_results):
         lines.append(
             f"Validate test data: Found errors with {len(constraint_validation_errors)} patient(s)"
         )
-        for patient_id, result in constraint_validation_errors.items():
-            if result["type"] == UNEXPECTED_TEST_VALUE:
-                lines.append(
-                    f" * Patient {patient_id} had {len(result['details'])} test data value(s) that did not meet the constraint(s)"
-                )
-                for detail in result["details"]:
+        for patient_id, results in constraint_validation_errors.items():
+            for result in results:
+                if result["type"] == UNEXPECTED_TEST_VALUE:
                     lines.append(
-                        f"   * for column '{detail['column']}' with '{detail['constraint']}', got '{detail['value']}'"
+                        f" * Patient {patient_id} had {len(result['details'])} test data value(s) that did not meet the constraint(s)"
                     )
-            else:
-                assert False, result["type"]
+                    for detail in result["details"]:
+                        lines.append(
+                            f"   * for column '{detail['column']}' with '{detail['constraint']}', got '{detail['value']}'"
+                        )
+                else:
+                    assert False, result["type"]
         return "\n".join(lines)
 
     def present_results(test_validation_errors):

--- a/ehrql/assurance.py
+++ b/ehrql/assurance.py
@@ -88,6 +88,7 @@ def validate_constraints(records, table):
     else:
         return [
             {
+                "table": table.name,
                 "type": UNEXPECTED_TEST_VALUE,
                 "details": unexpected_test_values,
             }
@@ -125,7 +126,7 @@ def present(validation_results):
             for result in results:
                 if result["type"] == UNEXPECTED_TEST_VALUE:
                     lines.append(
-                        f" * Patient {patient_id} had {len(result['details'])} test data value(s) that did not meet the constraint(s)"
+                        f" * Patient {patient_id} had {len(result['details'])} test data value(s) in table '{result['table']}' that did not meet the constraint(s)"
                     )
                     for detail in result["details"]:
                         lines.append(

--- a/ehrql/assurance.py
+++ b/ehrql/assurance.py
@@ -35,10 +35,7 @@ def validate(dataset, test_data):
                 records = patient[table.name]
             constraints_error = validate_constraints(records, table)
             if constraints_error:
-                constraint_validation_errors[patient_id] = {
-                    "type": UNEXPECTED_TEST_VALUE,
-                    "details": constraints_error,
-                }
+                constraint_validation_errors[patient_id] = constraints_error
             column_names = table.schema.column_names
             input_data[table].extend(
                 [(patient_id, *[r.get(c) for c in column_names]) for r in records]
@@ -80,7 +77,11 @@ def validate_constraints(records, table):
                             "value": f"{value}",
                         }
                     )
-    return unexpected_test_values
+    if unexpected_test_values:
+        return {
+            "type": UNEXPECTED_TEST_VALUE,
+            "details": unexpected_test_values,
+        }
 
 
 def validate_patient(patient_id, patient, results):

--- a/tests/unit/test_assurance.py
+++ b/tests/unit/test_assurance.py
@@ -130,47 +130,53 @@ expected_valid_data_validation_results = {
 
 expected_invalid_data_validation_results = {
     "constraint_validation_errors": {
-        1: {
-            "type": UNEXPECTED_TEST_VALUE,
-            "details": [
-                {
-                    "column": "date_of_birth",
-                    "constraint": "Constraint.NotNull()",
-                    "value": "None",
-                },
-                {
-                    "column": "sex",
-                    "constraint": "Constraint.Categorical(values=('female', 'male', 'intersex', 'unknown'))",
-                    "value": "not-known",
-                },
-            ],
-        },
-        2: {
-            "type": UNEXPECTED_TEST_VALUE,
-            "details": [
-                {
-                    "column": "date_of_birth",
-                    "constraint": "Constraint.FirstOfMonth()",
-                    "value": "1990-01-02",
-                }
-            ],
-        },
+        1: [
+            {
+                "type": UNEXPECTED_TEST_VALUE,
+                "details": [
+                    {
+                        "column": "date_of_birth",
+                        "constraint": "Constraint.NotNull()",
+                        "value": "None",
+                    },
+                    {
+                        "column": "sex",
+                        "constraint": "Constraint.Categorical(values=('female', 'male', 'intersex', 'unknown'))",
+                        "value": "not-known",
+                    },
+                ],
+            }
+        ],
+        2: [
+            {
+                "type": UNEXPECTED_TEST_VALUE,
+                "details": [
+                    {
+                        "column": "date_of_birth",
+                        "constraint": "Constraint.FirstOfMonth()",
+                        "value": "1990-01-02",
+                    }
+                ],
+            }
+        ],
     },
     "test_validation_errors": {},
 }
 
 expected_valid_and_invalid_data_validation_results = {
     "constraint_validation_errors": {
-        2: {
-            "type": UNEXPECTED_TEST_VALUE,
-            "details": [
-                {
-                    "column": "date_of_birth",
-                    "constraint": "Constraint.FirstOfMonth()",
-                    "value": "1990-01-02",
-                }
-            ],
-        },
+        2: [
+            {
+                "type": UNEXPECTED_TEST_VALUE,
+                "details": [
+                    {
+                        "column": "date_of_birth",
+                        "constraint": "Constraint.FirstOfMonth()",
+                        "value": "1990-01-02",
+                    }
+                ],
+            }
+        ],
     },
     "test_validation_errors": {
         1: {"type": UNEXPECTED_IN_POPULATION},

--- a/tests/unit/test_assurance.py
+++ b/tests/unit/test_assurance.py
@@ -2,6 +2,7 @@ from datetime import date
 
 from ehrql import Dataset
 from ehrql.assurance import (
+    UNEXPECTED_COLUMN,
     UNEXPECTED_IN_POPULATION,
     UNEXPECTED_NOT_IN_POPULATION,
     UNEXPECTED_OUTPUT_VALUE,
@@ -93,7 +94,10 @@ invalid_test_data = {
     # Has date_of_birth value that does not meet FirstOfMonth constraint
     2: {
         "patients": {"date_of_birth": date(1990, 1, 2)},
-        "events": [],
+        "events": [
+            # Has extra column not present in the schema
+            {"date": date(2020, 1, 1), "code": "11111111", "extra_column": 1},
+        ],
         "expected_in_population": False,
     },
 }
@@ -165,6 +169,14 @@ expected_invalid_data_validation_results = {
         ],
         2: [
             {
+                "type": UNEXPECTED_COLUMN,
+                "table": "events",
+                "details": {
+                    "invalid": ["extra_column"],
+                    "valid": ["date", "code"],
+                },
+            },
+            {
                 "type": UNEXPECTED_TEST_VALUE,
                 "table": "patients",
                 "details": [
@@ -174,7 +186,7 @@ expected_invalid_data_validation_results = {
                         "value": "1990-01-02",
                     }
                 ],
-            }
+            },
         ],
     },
     "test_validation_errors": {},
@@ -240,6 +252,9 @@ Validate test data: Found errors with 2 patient(s)
  * Patient 1 had 2 test data value(s) in table 'patients' that did not meet the constraint(s)
    * for column 'date_of_birth' with 'Constraint.NotNull()', got 'None'
    * for column 'sex' with 'Constraint.Categorical(values=('female', 'male', 'intersex', 'unknown'))', got 'not-known'
+ * Patient 2 had invalid columns in the test data for table 'events'
+       invalid columns: 'extra_column'
+     valid columns are: 'date', 'code'
  * Patient 2 had 1 test data value(s) in table 'patients' that did not meet the constraint(s)
    * for column 'date_of_birth' with 'Constraint.FirstOfMonth()', got '1990-01-02'
 Validate results: All OK!

--- a/tests/unit/test_assurance.py
+++ b/tests/unit/test_assurance.py
@@ -133,6 +133,7 @@ expected_invalid_data_validation_results = {
         1: [
             {
                 "type": UNEXPECTED_TEST_VALUE,
+                "table": "patients",
                 "details": [
                     {
                         "column": "date_of_birth",
@@ -150,6 +151,7 @@ expected_invalid_data_validation_results = {
         2: [
             {
                 "type": UNEXPECTED_TEST_VALUE,
+                "table": "patients",
                 "details": [
                     {
                         "column": "date_of_birth",
@@ -168,6 +170,7 @@ expected_valid_and_invalid_data_validation_results = {
         2: [
             {
                 "type": UNEXPECTED_TEST_VALUE,
+                "table": "patients",
                 "details": [
                     {
                         "column": "date_of_birth",
@@ -217,10 +220,10 @@ def test_invalid_data_present_with_errors():
         present(expected_invalid_data_validation_results).strip()
         == """
 Validate test data: Found errors with 2 patient(s)
- * Patient 1 had 2 test data value(s) that did not meet the constraint(s)
+ * Patient 1 had 2 test data value(s) in table 'patients' that did not meet the constraint(s)
    * for column 'date_of_birth' with 'Constraint.NotNull()', got 'None'
    * for column 'sex' with 'Constraint.Categorical(values=('female', 'male', 'intersex', 'unknown'))', got 'not-known'
- * Patient 2 had 1 test data value(s) that did not meet the constraint(s)
+ * Patient 2 had 1 test data value(s) in table 'patients' that did not meet the constraint(s)
    * for column 'date_of_birth' with 'Constraint.FirstOfMonth()', got '1990-01-02'
 Validate results: All OK!
     """.strip()
@@ -239,7 +242,7 @@ def test_valid_and_invalid_data_present_with_errors():
         present(expected_valid_and_invalid_data_validation_results).strip()
         == """
 Validate test data: Found errors with 1 patient(s)
- * Patient 2 had 1 test data value(s) that did not meet the constraint(s)
+ * Patient 2 had 1 test data value(s) in table 'patients' that did not meet the constraint(s)
    * for column 'date_of_birth' with 'Constraint.FirstOfMonth()', got '1990-01-02'
 Validate results: Found errors with 1 patient(s)
  * Patient 1 was unexpectedly in the population


### PR DESCRIPTION
This adds an explicit validation check to the `assure` command which ensures that columns supplied in the test data actually exist on their corresponding tables. Previously this would just blow up with an exception (see #2462).

In order to make this work I've had to do some minor refactoring to the `assure` command although I've stuck as closely as possible to the original style here. I think there's probably a broader piece of work to think about the implementation of this command, but I'm deliberately not tackling that now.

However as part of the refactoring I've made a couple of drive-by improvements:
1. Where there are errors with multiple tables of test data we now report them all instead of only the last.
2. When reporting errors we include the name of the table in question.

Taking the example from the linked ticket the error message now looks like this:
```
Validate test data: Found errors with 1 patient(s)
 * Patient 1 had invalid columns in the test data for table 'patients'
       invalid columns: 'some_invalid_column'
     valid columns are: 'date_of_birth', 'sex', 'date_of_death'
Validate results: All OK!
```

Closes #2462