### PR TITLE
Accept dicts and lists of dicts interchangeably in test data

### DIFF
--- a/ehrql/assurance.py
+++ b/ehrql/assurance.py
@@ -3,7 +3,6 @@ from collections import defaultdict
 from ehrql.query_engines.in_memory import InMemoryQueryEngine
 from ehrql.query_engines.in_memory_database import InMemoryDatabase
 from ehrql.query_model.introspection import get_table_nodes
-from ehrql.query_model.nodes import has_one_row_per_patient
 
 
 UNEXPECTED_TEST_VALUE = "unexpected-test-value"
@@ -34,10 +33,11 @@ def validate(dataset, test_data):
     input_data = {table: [] for table in table_nodes}
     for patient_id, patient in test_data.items():
         for table in table_nodes:
-            if has_one_row_per_patient(table):
-                records = [patient[table.name]]
-            else:
-                records = patient[table.name]
+            records = patient[table.name]
+            # We treat directly supplied dict as being equivalent to a list with a
+            # single member
+            if isinstance(records, dict):
+                records = [records]
             constraints_error = validate_constraints(records, table)
             constraint_validation_errors[patient_id].extend(constraints_error)
             column_names = table.schema.column_names

--- a/tests/unit/test_assurance.py
+++ b/tests/unit/test_assurance.py
@@ -6,6 +6,7 @@ from ehrql.assurance import (
     UNEXPECTED_IN_POPULATION,
     UNEXPECTED_NOT_IN_POPULATION,
     UNEXPECTED_OUTPUT_VALUE,
+    UNEXPECTED_ROW_COUNT,
     UNEXPECTED_TEST_VALUE,
     present,
     validate,
@@ -104,6 +105,14 @@ invalid_test_data = {
         ],
         "expected_in_population": False,
     },
+    3: {
+        "patients": [
+            {"date_of_birth": date(1990, 1, 1)},
+            {"date_of_birth": date(1995, 1, 1)},
+        ],
+        "events": [],
+        "expected_in_population": False,
+    },
 }
 
 valid_and_invalid_test_data = {
@@ -192,6 +201,13 @@ expected_invalid_data_validation_results = {
                 ],
             },
         ],
+        3: [
+            {
+                "type": UNEXPECTED_ROW_COUNT,
+                "table": "patients",
+                "details": {"rows": 2},
+            },
+        ],
     },
     "test_validation_errors": {},
 }
@@ -250,7 +266,7 @@ def test_invalid_data_present_with_errors():
     assert (
         present(expected_invalid_data_validation_results).strip()
         == """
-Validate test data: Found errors with 2 patient(s)
+Validate test data: Found errors with 3 patient(s)
  * Patient 1 had 1 test data value(s) in table 'events' that did not meet the constraint(s)
    * for column 'code' with 'Constraint.NotNull()', got 'None'
  * Patient 1 had 2 test data value(s) in table 'patients' that did not meet the constraint(s)
@@ -261,6 +277,7 @@ Validate test data: Found errors with 2 patient(s)
      valid columns are: 'date', 'code'
  * Patient 2 had 1 test data value(s) in table 'patients' that did not meet the constraint(s)
    * for column 'date_of_birth' with 'Constraint.FirstOfMonth()', got '1990-01-02'
+ * Patient 3 had 2 rows of test data for table 'patients' but this table accepts at most one row per patient
 Validate results: All OK!
     """.strip()
     )

--- a/tests/unit/test_assurance.py
+++ b/tests/unit/test_assurance.py
@@ -64,7 +64,11 @@ valid_test_data = {
     },
     # Has correct expected_columns
     4: {
-        "patients": {"date_of_birth": date(2010, 1, 1)},
+        # Supply data as a single membered list rather than a dict to confirm these are
+        # treated equivalently
+        "patients": [
+            {"date_of_birth": date(2010, 1, 1)},
+        ],
         "events": [{"date": date(2020, 1, 1), "code": "11111111"}],
         "expected_columns": {
             "has_matching_event": True,


### PR DESCRIPTION
Previously the `assure` command required that data for one-row-per-patient tables was supplied as a dict, and data for many-rows-per-patient tables was supplied as a list of dicts. This was very easy to get wrong, as evidenced by the linked ticket in which the original author of the command gets it wrong in the official ehrQL docs ;)

Additionally, if you did get it wrong, it would blow up with an AttributeError rather than anything more helpful.

This PR changes things so we now treat a standalone dict as always equivalent to one wrapped in a list and then explicitly validate that you've supplied the right number of rows for the table you're defining.

I have confirmed that our documented example now works correctly.

Closes #2079