### PR TITLE
Add missing name to public query model namespace

### DIFF
--- a/ehrql/query_model/nodes.py
+++ b/ehrql/query_model/nodes.py
@@ -38,6 +38,7 @@ __all__ = [
     "InvalidSortError",
     "PatientDomainError",
     "Dataset",
+    "SeriesCollectionFrame",
     "has_one_row_per_patient",
     "has_many_rows_per_patient",
     "get_series_type",

--- a/tests/lib/test_gentest_example_simplify.py
+++ b/tests/lib/test_gentest_example_simplify.py
@@ -12,6 +12,8 @@ from ehrql.query_model.nodes import (
     InlinePatientTable,
     SelectColumn,
     SelectPatientTable,
+    SelectTable,
+    SeriesCollectionFrame,
     Value,
 )
 from tests.generative.test_query_model import data_setup, schema
@@ -37,7 +39,14 @@ def test_gentest_example_simplify():
         Value(frozenset({1, 2, 3})),
     )
     dataset = Dataset(
-        population=population, variables={"v": variable}, events={}, measures=None
+        population=population,
+        variables={"v": variable},
+        events={
+            "event_table": SeriesCollectionFrame(
+                members={"e": SelectColumn(SelectTable("e0", schema), "i1")}
+            )
+        },
+        measures=None,
     )
     data = [
         {"type": data_setup.P0, "patient_id": 1},


### PR DESCRIPTION
We need a `SeriesCollectionFrame` in order to construct a `Dataset` with event-level tables. This was missing from the public namespace and therefore our tooling to simplify generative test examples would fail on examples using event-level tables.