### PR TITLE
Remove 'test-backend-validation' command from justfile

### DIFF
--- a/justfile
+++ b/justfile
@@ -178,11 +178,6 @@ test-acceptance *ARGS: devenv
     $BIN/python -m pytest tests/acceptance "$@"
 
 
-# Run the backend validation tests only
-test-backend-validation *ARGS: devenv
-    $BIN/python -m pytest tests/backend_validation "$@"
-
-
 # Run the ehrql-in-docker tests only
 test-docker *ARGS: devenv
     $BIN/python -m pytest tests/docker "$@"


### PR DESCRIPTION
This command ran tests in the `backend_validation` directory which was deleted in 2022: see https://github.com/opensafely-core/ehrql/pull/680, commit 2f5f03f2388975db2d57e94cde2a12d25dfbbda7.