### PR TITLE
Add option to dump example data to a custom directory

### DIFF
--- a/docs/includes/generated_docs/cli.md
+++ b/docs/includes/generated_docs/cli.md
@@ -382,7 +382,7 @@ Dotted import path to Backend class, or one of: `emis`, `tpp`
   dump-example-data
 </h2>
 ```
-ehrql dump-example-data [--help]
+ehrql dump-example-data [--help] [--dst-dir DST_DIR]
 ```
 Dump example data for the ehrQL tutorial to the current directory.
 
@@ -392,6 +392,15 @@ Dump example data for the ehrQL tutorial to the current directory.
 </div>
 <div markdown="block" class="indent">
 show this help message and exit
+
+</div>
+
+<div class="attr-heading" id="dump-example-data.dst-dir">
+  <tt>-d, --dst-dir DST_DIR</tt>
+  <a class="headerlink" href="#dump-example-data.dst-dir" title="Permanent link">🔗</a>
+</div>
+<div markdown="block" class="indent">
+Destination folder ('example-data' by default)
 
 </div>
 

--- a/ehrql/__main__.py
+++ b/ehrql/__main__.py
@@ -465,6 +465,14 @@ def add_dump_example_data(subparsers, environ, user_args):
     )
     parser.set_defaults(function=dump_example_data)
     parser.set_defaults(environ=environ)
+    parser.add_argument(
+        "-d",
+        "--dst-dir",
+        help=strip_indent("Destination folder ('example-data' by default)"),
+        type=Path,
+        dest="dst_dir",
+        default="example-data",
+    )
 
 
 def add_serialize_definition(subparsers, environ, user_args):

--- a/ehrql/main.py
+++ b/ehrql/main.py
@@ -363,9 +363,9 @@ def test_connection(backend_class, url, environ):
     print("SUCCESS")
 
 
-def dump_example_data(environ):
+def dump_example_data(environ, dst_dir):
     src_path = Path(__file__).parent / "example-data"
-    dst_path = Path(os.getcwd()) / "example-data"
+    dst_path = Path(os.getcwd()) / dst_dir
     shutil.copytree(src_path, dst_path, dirs_exist_ok=True)
 
 

--- a/tests/functional/test_dump_example_data.py
+++ b/tests/functional/test_dump_example_data.py
@@ -6,3 +6,10 @@ def test_dump_example_data(call_cli, tmp_path):
         call_cli("dump-example-data")
     filenames = [path.name for path in (tmp_path / "example-data").iterdir()]
     assert "patients.csv" in filenames
+
+
+def test_dump_example_data_to_custom_dir(call_cli, tmp_path):
+    with contextlib.chdir(tmp_path):
+        call_cli("dump-example-data", "-d", "custom-dir")
+    filenames = [path.name for path in (tmp_path / "custom-dir").iterdir()]
+    assert "patients.csv" in filenames


### PR DESCRIPTION
The example data is a set of CSV files that are generated for use in the ehrQL tutorial. In the tutorial repo, these CSVs are already present in a `dummy_tables` directory, for use with the `show()` command via the OpenSAFELY vs code extension.

After following the tutorial, users reasonably expect to be able to use the `show()` command in their own ehrQL, but it requires dummy tables, which the vs code extension expects to be found in a directory called `dummy_tables` at the top level of the study directory.

While it doesn't solve the chicken-egg problem with the `show()` command (users need dummy tables to help them write ehqrl, but the best way we have of creating dummy tables is to write ehrql), we can at least give them something to get started with as a default, by having the vs code extension dump the tutorial example data if there's no dummy tables available. In order to do that, we need to be able to dump the dummy tables to somewhere other that just the hard-coded `example-data` directory.