### PR TITLE
Convert bool type user parameters

### DIFF
--- a/docs/how-to/parameterise-ehrql.md
+++ b/docs/how-to/parameterise-ehrql.md
@@ -86,14 +86,23 @@ param2 = get_parameter("param2", type=float, default=1.0)
 param3 = get_parameter("param3", type=Path, default=Path("output"))
 ```
 
-!!! Warning bool type
-    It is NOT recommended to use the `bool` type. This will interpret an empty string as True, and
-    any non-empty string as False. i.e.
+!!! Info "`bool` type parameters"
+    The `bool` type will interpret values as `True` or `False`.  Valid values are:
+
+    - "1", "True", "true": interpreted as True
+    - "0", "False", "false": interpreted as False
+
+    i.e. `has_diagnosis` will be interpreted as False in all of the cases below.
     ```
+    ... -- --has_diagnosis 0
     ... -- --has_diagnosis False
+    ... -- --has_diagnosis false
     ```
-    will be parsed as the simple string "False", and interpreted as the python boolean True. This
-    is almost certainly not what you want.
+
+    In your ehrQL, define it as a `bool` type parameter:
+    ```
+    has_diagnosis = get_parameter("has_diagnosis", type=bool)
+    ```
 
 
 ## Multiple parameter values

--- a/ehrql/user_parameters.py
+++ b/ehrql/user_parameters.py
@@ -17,7 +17,8 @@ def convert_string_to_bool(value):
             return False
         case _:
             raise ParameterError(
-                f"'{value}' is an invalid value for `bool` type parameter"
+                f"'{value}' is an invalid value for `bool` type parameter\n\n"
+                f"Valid values are 1/True/true or 0/False/false."
             )
 
 
@@ -111,7 +112,8 @@ def get_parameter(name, type: callable = str, default: Any | None = None):  # NO
             return default
         raise ParameterError(
             f"{sys.argv[0]} error: parameter `{name}` defined but no values found. Pass parameters in the "
-            f"form `--{name} <value>` or provide a default value to `get_parameter()`"
+            f"form `--{name} <value>` or provide a default value to `get_parameter()`\n\n"
+            "Note that custom parameters MUST be provided last, and must follow a double-dash `--`."
         )
     if len(value) == 1:
         value = value[0]

--- a/ehrql/user_parameters.py
+++ b/ehrql/user_parameters.py
@@ -9,6 +9,18 @@ from ehrql.exceptions import ParameterError
 logger = logging.getLogger(__name__)
 
 
+def convert_string_to_bool(value):
+    match value:
+        case "true" | "True" | "1":
+            return True
+        case "false" | "False" | "0":
+            return False
+        case _:
+            raise ParameterError(
+                f"'{value}' is an invalid value for `bool` type parameter"
+            )
+
+
 def get_parameter(name, type: callable = str, default: Any | None = None):  # NOQA: A002
     """
     Define and retrieve user-specified parameters that have been passed on the command line.
@@ -81,6 +93,9 @@ def get_parameter(name, type: callable = str, default: Any | None = None):  # NO
             "and pass multiple values to the generate-dataset command:\n\n"
             f"\tgenerate-dataset {sys.argv[0]} -- --sex male female"
         )
+
+    if type is bool:
+        type = convert_string_to_bool  # NOQA: A001
 
     # We use nargs="+" and action="extend" so we can return either a single value or a list,
     # depending on what values have been provided

--- a/tests/unit/test_user_parameters.py
+++ b/tests/unit/test_user_parameters.py
@@ -79,3 +79,31 @@ def test_get_dataset_parameters_invalid_type():
 
     with pytest.raises(ParameterError, match="<class 'list'> is not a valid type\n\n"):
         assert get_parameter("foo", type=list)
+
+
+@pytest.mark.parametrize(
+    "falsey_string, truthy_string",
+    [
+        ("0", "1"),
+        ("false", "true"),
+        ("False", "True"),
+    ],
+)
+def test_get_bool_parameter(falsey_string, truthy_string):
+    sys.argv = [
+        "dataset_definition.py",
+        "--f_param",
+        falsey_string,
+        "--t_param",
+        truthy_string,
+    ]
+    assert get_parameter("f_param", type=bool) is False
+    assert get_parameter("t_param", type=bool) is True
+
+
+def test_get_bad_bool_parameter():
+    sys.argv = ["dataset_definition.py", "--foo", "trueish"]
+    with pytest.raises(
+        ParameterError, match="'trueish' is an invalid value for `bool` type parameter"
+    ):
+        get_parameter("foo", type=bool)


### PR DESCRIPTION
Convert acceptable strings (0/false/False and 1/true/True) to False/True.

Fixes #2504 

Plus drive by reminder about the -- syntax. If a parameter value is expected but missing, it _might_ be that a user has forgotten to provide a default, but it also might be that they've forgotten to put their custom user parameters last, and after a `--`