### PR TITLE
Remind about user args syntax if there are unknown cli args

### DIFF
--- a/ehrql/__main__.py
+++ b/ehrql/__main__.py
@@ -4,7 +4,11 @@ import os
 import sys
 import traceback
 import warnings
-from argparse import ArgumentParser, ArgumentTypeError, RawTextHelpFormatter
+from argparse import (
+    ArgumentParser,
+    ArgumentTypeError,
+    RawTextHelpFormatter,
+)
 from pathlib import Path
 
 from ehrql import __version__
@@ -90,8 +94,20 @@ def main(args, environ=None):
         user_args = []
 
     parser = create_parser(user_args, environ)
+    namespace, unknown_args = parser.parse_known_args(args)
 
-    kwargs = vars(parser.parse_args(args))
+    if unknown_args:
+        print(
+            (
+                f"error: unknown arguments: {' '.join(unknown_args)}\n\n"
+                "If you are trying to provide custom parameters, note that these MUST be provided last, and must follow a double-dash `--`."
+            ),
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    kwargs = vars(namespace)
+
     function = kwargs.pop("function")
 
     # Set log level to INFO, if it isn't lower already
@@ -137,6 +153,7 @@ def create_parser(user_args, environ):
             """
         ),
         formatter_class=RawTextHelpFormatter,
+        allow_abbrev=False,
     )
 
     def show_help(**kwargs):

--- a/tests/functional/test_generate_dataset.py
+++ b/tests/functional/test_generate_dataset.py
@@ -147,6 +147,24 @@ def test_parameterised_dataset_definition_with_bad_param(tmp_path, call_cli):
     )
 
 
+def test_parameterised_dataset_definition_with_bad_param_syntax(tmp_path, call_cli):
+    dataset_definition_path = tmp_path / "dataset_definition.py"
+    dataset_definition_path.write_text(parameterised_dataset_definition)
+
+    # Call the cli with user args, but without the required -- separator
+    with pytest.raises(SystemExit):
+        call_cli(
+            "generate-dataset",
+            dataset_definition_path,
+            "--year",
+            "1940",
+        )
+
+    error = call_cli.readouterr().err
+    assert "unknown arguments: --year 1940" in error
+    assert "If you are trying to provide custom parameters" in error
+
+
 def test_generate_dataset_with_database_error(tmp_path, call_cli, mssql_database):
     mssql_database.setup(
         Patient(Patient_ID=1, DateOfBirth=datetime(1934, 5, 5)),


### PR DESCRIPTION
It's easy to forget that you need to put custom user args at the end, and separate them with a --. And if you do, you get a not-very-helpful "unrecognised arguments" error from argparse.

We can use parse_known_args to identify unknown args and show a more helpful error message. Note that we also need to turn off prefix matching, which should be fine, I think.