### PR TITLE
Start the long-running generative test workflow earlier

### DIFF
--- a/.github/workflows/generative-tests.yml
+++ b/.github/workflows/generative-tests.yml
@@ -4,7 +4,7 @@ name: Long-running generative tests
 on:
   workflow_dispatch:
   schedule:
-    - cron:  "26 0 * * *"
+    - cron:  "26 22 * * *"
 
 jobs:
   gentests:


### PR DESCRIPTION
BennettBot reports on workflow status at 6am UK time; when we run the tests at 00:26 UTC, there's only 4.5 hrs for the gentest to complete, so occasionally we see an unknown workflow status reported, but the tests go on to complete successfully, which we don't care about. Occasionally the tests take too long and are cancelled, which we do care about. Starting them 2 hrs earlier should allow enough time for them to be cancelled if they go too long.