### PR TITLE
Serialize tables by reference

### DIFF
--- a/ehrql/query_language.py
+++ b/ehrql/query_language.py
@@ -8,6 +8,7 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Any, Generic, TypeVar, overload
 
+from ehrql import serializer_registry
 from ehrql.codes import BaseCode, BaseMultiCodeString
 from ehrql.file_formats import read_rows
 from ehrql.query_model import nodes as qm
@@ -2022,6 +2023,9 @@ def table(cls: type[T]) -> T:
         name=cls.__name__,
         schema=get_table_schema_from_class(cls),
     )
+    # Register this table node with the serialization mechanism so that queries which
+    # involve this table can be serialized.
+    serializer_registry.register_object(qm_node, cls.__module__, cls.__qualname__)
     return cls(qm_node)
 
 

--- a/ehrql/serializer_registry.py
+++ b/ehrql/serializer_registry.py
@@ -1,0 +1,35 @@
+"""
+Provides a simple mechanism for registering query model objects so that they can
+serialized by reference, rather than by serializing the entire object structure.
+"""
+
+
+class RegistryError(Exception):
+    pass
+
+
+REGISTRY_OBJ_TO_ID = {}
+REGISTRY_ID_TO_OBJ = {}
+
+
+def register_object(obj, module, name):
+    obj_id = (module, name)
+    if obj_id in REGISTRY_ID_TO_OBJ:
+        if REGISTRY_ID_TO_OBJ[obj_id] != obj:
+            raise RegistryError("Distinct object already registered with ID: {obj_id}")
+    REGISTRY_OBJ_TO_ID[obj] = obj_id
+    REGISTRY_ID_TO_OBJ[obj_id] = obj
+
+
+def get_id_for_object(obj):
+    try:
+        return REGISTRY_OBJ_TO_ID[obj]
+    except KeyError:
+        raise RegistryError("Object has not been registered: {obj}")
+
+
+def get_object_by_id(obj_id):
+    try:
+        return REGISTRY_ID_TO_OBJ[obj_id]
+    except KeyError:
+        raise RegistryError(f"No object registered with ID: {obj_id}")

--- a/tests/unit/test_query_language.py
+++ b/tests/unit/test_query_language.py
@@ -54,7 +54,6 @@ from ehrql.query_model.nodes import (
     Function,
     InlinePatientTable,
     SelectColumn,
-    SelectPatientTable,
     SelectTable,
     TableSchema,
     Value,
@@ -112,7 +111,7 @@ def test_dataset():
             lhs=Function.YearFromDate(
                 source=SelectColumn(
                     name="date_of_birth",
-                    source=SelectPatientTable("patients", patients_schema),
+                    source=patients._qm_node,
                 )
             ),
             rhs=Value(2000),
@@ -121,7 +120,7 @@ def test_dataset():
             "year_of_birth": Function.YearFromDate(
                 source=SelectColumn(
                     name="date_of_birth",
-                    source=SelectPatientTable("patients", patients_schema),
+                    source=patients._qm_node,
                 )
             ),
         },
@@ -299,24 +298,22 @@ def test_add_event_table():
     dataset.some_events.f_double = dataset.some_events.f * 2
 
     assert dataset._compile() == qm.Dataset(
-        population=qm.AggregateByPatient.Exists(
-            source=SelectTable(name="events", schema=events_schema)
-        ),
+        population=qm.AggregateByPatient.Exists(source=events._qm_node),
         variables={},
         events={
             "some_events": qm.SeriesCollectionFrame(
                 {
                     "date": SelectColumn(
-                        source=SelectTable(name="events", schema=events_schema),
+                        source=events._qm_node,
                         name="event_date",
                     ),
                     "f": SelectColumn(
-                        source=SelectTable(name="events", schema=events_schema),
+                        source=events._qm_node,
                         name="f",
                     ),
                     "f_double": Function.Multiply(
                         lhs=SelectColumn(
-                            source=SelectTable(name="events", schema=events_schema),
+                            source=events._qm_node,
                             name="f",
                         ),
                         rhs=Value(value=2.0),

--- a/tests/unit/test_serializer_registry.py
+++ b/tests/unit/test_serializer_registry.py
@@ -1,0 +1,41 @@
+import pytest
+
+from ehrql import serializer_registry
+from ehrql.query_model.nodes import Value
+
+
+def test_register_object():
+    node = Value(123)
+    serializer_registry.register_object(node, __name__, "test_register_object_1")
+    # Registering the same value again under the same name is fine
+    serializer_registry.register_object(node, __name__, "test_register_object_1")
+    # As is registering the same value under a different name
+    serializer_registry.register_object(node, __name__, "test_register_object_1_again")
+    # But registering a different object under the same name is an error
+    node_2 = Value(456)
+    with pytest.raises(
+        serializer_registry.RegistryError, match="object already registered with ID"
+    ):
+        serializer_registry.register_object(node_2, __name__, "test_register_object_1")
+
+
+def test_roundtrip():
+    node = Value(789)
+    serializer_registry.register_object(node, __name__, "test_roundtrip")
+    obj_id = serializer_registry.get_id_for_object(node)
+    obj = serializer_registry.get_object_by_id(obj_id)
+    assert obj is node
+
+
+def test_get_id_for_object_error():
+    with pytest.raises(
+        serializer_registry.RegistryError, match="Object has not been registered"
+    ):
+        serializer_registry.get_id_for_object(Value("hello"))
+
+
+def test_get_object_by_id_error():
+    with pytest.raises(
+        serializer_registry.RegistryError, match="No object registered with ID"
+    ):
+        serializer_registry.get_object_by_id((__name__, "missing_object"))


### PR DESCRIPTION
This modifies the serialization code so that rather than entire structure of the table being encoded in the serialized content we just encode a reference to the table. The primary driver for this is that it prevents user code from being able to modify the table definition prior to serialization. There is not _currently_ anything additional a malicious user could do by altering the definitions (the backend object fixes what tables and columns are available); but we want to start encoding fine-grained access permissions as part of the table definitions and when we do this it's important that the table definitions can be trusted.

As an example, where previously part of a serialized query might look like this:
```json
"10": {
    "SelectColumn": {"source": {"ref": "11"}, "name": "snomedct_code"}
},
"11": {
    "SelectTable": {
        "name": "clinical_events",
        "schema": {
            "TableSchema": {
                "date": {
                    "Column": {
                        "type_": {"type": "date"},
                        "constraints": {"tuple": []},
                    }
                },
                "snomedct_code": {
                    "Column": {
                        "type_": {"type": "SNOMEDCTCode"},
                        "constraints": {"tuple": []},
                    }
                },
                "numeric_value": {
                    "Column": {
                        "type_": {"type": "float"},
                        "constraints": {"tuple": []},
                    }
                },
            }
        },
    }
},
```

It would now look like this:
```json
"10": {
    "SelectColumn": {
        "source": {
            "external_ref": {
                "module": "ehrql.tables.core",
                "name": "clinical_events",
            }
        },
        "name": "snomedct_code",
    }
},
```

There's an additional benefit to this new approach in that we can now include elements in table definitions (e.g. custom dummy data generation methods) which might otherwise be hard to serialize. Note though that we still need to be able to serialize `InlinePatientTables` (i.e. the results of the `@table_from_file` decorator) so we can't altogether avoid handling table definitions. But we don't need to handle everything that any table definition might include, which gives us more freedom.

Closes #2513