### PR TITLE
fix: Extend ICD-10 regex to allow X-padded codes

### DIFF
--- a/ehrql/codes.py
+++ b/ehrql/codes.py
@@ -91,7 +91,17 @@ class CTV3Code(BaseCode):
 class ICD10Code(BaseCode):
     "ICD-10"
 
-    regex = re.compile(r"[A-Z][0-9]{2,3}")
+    # ICD-10 codes consist of a letter followed by 2 or 3 numbers
+    # However, in SUS tables, 3 character codes are padded to 4 characters
+    # with an X (as per NHS coding guidelines)
+    regex = re.compile(
+        r"""
+        [A-Z] # uppercase character
+        [0-9]{2} # 2 digits
+        [0-9X]? # (optional) 3rd digit OR an X
+        """,
+        re.VERBOSE,
+    )
 
 
 class OPCS4Code(BaseCode):

--- a/tests/unit/test_codes.py
+++ b/tests/unit/test_codes.py
@@ -113,6 +113,7 @@ def test_codelist_from_csv_lines_with_missing_category_column():
         (CTV3Code, "De4.."),
         (ICD10Code, "A01"),
         (ICD10Code, "A012"),
+        (ICD10Code, "A01X"),
         (OPCS4Code, "B23"),
         (OPCS4Code, "B234"),
         (SNOMEDCTCode, "1234567890"),
@@ -137,6 +138,10 @@ def test_valid_codes(cls, value):
         (ICD10Code, "AA1"),
         # Wrong length
         (ICD10Code, "A0124"),
+        # Letter other than X as 4th character
+        (ICD10Code, "A01Y"),
+        # X as 3rd character
+        (ICD10Code, "A1X"),
         # I is not an allowed first character
         (OPCS4Code, "I00"),
         # Too short


### PR DESCRIPTION
In SUS tables, 3 character ICD-10 codes are padded with an X as the 4th character. Extend the validation regex to allow for this.