### PR TITLE
Handle missing initial lines in log files

### DIFF
--- a/scripts/parse_logs.py
+++ b/scripts/parse_logs.py
@@ -200,7 +200,7 @@ def group_log_records(records):
     group = defaultdict(list)
     for record in records:
         if record["type"] in ("query_start", "fetch_start"):
-            if group:
+            if group["type"]:
                 # Support peeking forward at the next record when handling a group
                 group["next_record"] = record
                 yield group


### PR DESCRIPTION
Where a log file is missing an initial segment we can get log records that aren't part of any "group" (i.e. there's no preceeding `query_start` or `fetch_start` record). In this case we just want to drop these records rather than creating a group with an empty `type`.

These partial log files are a consequence of this issue:
 * https://github.com/opensafely-core/job-runner/issues/1149