### PR TITLE
Use temporary tables in SQLite engine

### DIFF
--- a/ehrql/query_engines/base_sql.py
+++ b/ehrql/query_engines/base_sql.py
@@ -946,16 +946,7 @@ class BaseSQLQueryEngine(BaseQueryEngine):
         e.g. using `.alias()` to make a sub-query, using `.cte()` to make a Common Table
         Expression, or writing the results of the query to a temporary table.
         """
-        cte = query.cte(name=f"cte_{self.get_next_id()}")
-        # We mark these CTEs as being non-traversible by our
-        # `replace_placeholder_references()` function. There's never a need to traverse
-        # them (reified queries are already processes and in their final form) and it
-        # can create problems with cloned, duplicate CTEs. See:
-        #
-        #   tests/integration/test_query_engines.py::test_sqlalchemy_compilation_edge_case
-        #
-        cte._no_replacement_traverse = True
-        return cte
+        raise NotImplementedError()
 
     def get_select_query_for_node_domain(self, node):
         """
@@ -1156,11 +1147,6 @@ def replace_placeholder_references(query):
     def replace(obj):
         if obj is PLACEHOLDER_PATIENT_ID:
             return patient_id_column
-        # Avoid cloning objects which aren't safe to be cloned
-        if getattr(obj, "_no_replacement_traverse", False):
-            return obj
-        else:
-            return None
 
     return replacement_traverse(query, {}, replace=replace)
 

--- a/ehrql/utils/sqlalchemy_query_utils.py
+++ b/ehrql/utils/sqlalchemy_query_utils.py
@@ -299,9 +299,10 @@ class InsertMany:
 class CreateTableAs(Executable, ClauseElement):
     inherit_cache = True
 
-    def __init__(self, table, selectable):
+    def __init__(self, table, selectable, temporary=False):
         self.table = table
         self.selectable = selectable
+        self.temporary = temporary
 
     def get_children(self):
         return (self.table, self.selectable)
@@ -309,7 +310,8 @@ class CreateTableAs(Executable, ClauseElement):
 
 @compiles(CreateTableAs)
 def visit_create_table_as(element, compiler, **kw):
-    return "CREATE TABLE {} AS {}".format(
+    return "CREATE {}TABLE {} AS {}".format(
+        "TEMPORARY " if element.temporary else "",
         compiler.process(element.table, asfrom=True, **kw),
         compiler.process(element.selectable, asfrom=True, **kw),
     )

--- a/tests/integration/test_query_engines.py
+++ b/tests/integration/test_query_engines.py
@@ -263,6 +263,9 @@ def test_sqlalchemy_compilation_edge_case(engine):
     #
     # Naturally, this was discovered by the gentests. Below is the simplest example I
     # can construct which triggers the bug.
+    #
+    # Note: now that the SQLite engine no longer uses CTEs this no longer requires a
+    # workaround, but we leave the test in place to avoid regressions.
 
     dataset = create_dataset()
     # Weird as it seems, we need at least three references below to create the

--- a/tests/integration/test_query_engines.py
+++ b/tests/integration/test_query_engines.py
@@ -512,14 +512,8 @@ def test_max_join_count(engine, in_memory_engine):
     assert results_split == expected_results
     assert results_nosplit == expected_results
 
-    if engine.name != "sqlite":
-        # Check that splitting the joins results in more queries
-        assert len(queries_split) > len(queries_nosplit)
-    else:
-        # Because the SQLite engine currently uses CTEs rather than temporary tables
-        # it's joins can't be split. I think it would be worth changing this but it's
-        # out of scope for now.
-        assert len(queries_split) == len(queries_nosplit)
+    # Check that splitting the joins results in more queries
+    assert len(queries_split) > len(queries_nosplit)
 
 
 def build_dataset(*, population, variables=None, events=None):


### PR DESCRIPTION
Previously the SQLite engine used CTEs (I think just because that was the first thing I tried when building the first version of what become ehrQL). That added some complexity and made the SQLite engine less useful for testing purposes.