### PR TITLE
Add EC table to list of potentially missing tables

### DIFF
--- a/ehrql/backends/tpp.py
+++ b/ehrql/backends/tpp.py
@@ -160,12 +160,13 @@ class TPPBackend(SQLBackend):
             exception.add_note(f"\nIntermittent database error: {exception}")
             return 3
 
-        if "Invalid object name 'CodedEvent_SNOMED'" in exception_messages:
-            exception.add_note(
-                "\nCodedEvent_SNOMED table is currently not available.\n"
-                "This is likely due to regular database maintenance."
-            )
-            return 4
+        for table in ["CodedEvent_SNOMED", "EC"]:
+            if f"Invalid object name '{table}'" in exception_messages:
+                exception.add_note(
+                    f"\n{table} table is currently not available.\n"
+                    f"This is likely due to regular database maintenance."
+                )
+                return 4
 
         exception.add_note(f"\nDatabase error: {exception}")
         return 5


### PR DESCRIPTION
We occasionally get errors shortly before the TPP database goes into maintenance where some tables disappear. Usually this is the `CodedEvent_SNOMED` table, but very rarely we've seen this happen with the `EC` table as well.

To avoid user confusion and unnecessary support requests we want to make it clear than these are transient errors.

Related Slack thread:
https://bennettoxford.slack.com/archives/C069YDR4NCA/p1759229538433909