### PR TITLE
Add hints for errors which look like "accidental tuples" caused by trailing commas

### DIFF
--- a/ehrql/query_language.py
+++ b/ehrql/query_language.py
@@ -548,6 +548,9 @@ class BoolFunctions:
         other = self._cast(other)
         return _apply(qm.Function.And, self, other)
 
+    def __rand__(self: T, other: T) -> T:
+        return self.__and__(other)
+
     def __or__(self: T, other: T) -> T:
         """
         Logical OR
@@ -563,6 +566,9 @@ class BoolFunctions:
         """
         other = self._cast(other)
         return _apply(qm.Function.Or, self, other)
+
+    def __ror__(self: T, other: T) -> T:
+        return self.__or__(other)
 
     def __invert__(self: T) -> T:
         """

--- a/ehrql/query_model/nodes.py
+++ b/ehrql/query_model/nodes.py
@@ -535,6 +535,7 @@ def validate_node(node):
         if not is_sorted(node.source):
             raise TypeValidationError(
                 node=node,
+                value=node.source,
                 field_name="source",
                 expected="SortedFrame",
                 received="UnsortedFrame",
@@ -771,16 +772,17 @@ def is_sorted_filter(frame):
 
 
 class TypeValidationError(ValidationError):
-    def __init__(self, node, field_name, expected, received):
+    def __init__(self, node, field_name, value, expected, received):
         self.node = node
         self.field_name = field_name
+        self.value = value
         self.expected = expected
         self.received = received
 
     def __str__(self):
         return (
             f"{self.node.__class__.__name__}.{self.field_name} requires "
-            f"'{self.expected}' but received '{self.received}'"
+            f"'{self.expected}' but received '{self.received}': {self.value!r}"
         )
 
 
@@ -806,6 +808,7 @@ def validate_types(node):
             raise TypeValidationError(
                 node=node,
                 field_name=field.name,
+                value=value,
                 expected=resolved_typespec,
                 received=typespec,
             )

--- a/tests/unit/test_query_language.py
+++ b/tests/unit/test_query_language.py
@@ -284,6 +284,11 @@ def test_dataset_setattr_rejects_invalid_variables(variable, error):
         Dataset().v = variable
 
 
+def test_dataset_setattr_gives_hint_for_accidental_tuple():
+    with pytest.raises(TypeError, match="trailing comma"):
+        Dataset().d = patients.date_of_birth,  # fmt: skip
+
+
 def test_accessing_unassigned_variable_gives_helpful_error():
     with pytest.raises(AttributeError, match="'foo' has not been defined"):
         Dataset().foo

--- a/tests/unit/test_query_language.py
+++ b/tests/unit/test_query_language.py
@@ -1124,7 +1124,17 @@ def test_query_model_type_errors():
             "WARNING: The `|` operator has surprising precedence rules",
         ),
         (
+            lambda: patients.i == 1 | (patients.i == 2),
+            TypeError,
+            "WARNING: The `|` operator has surprising precedence rules",
+        ),
+        (
             lambda: patients.i == 1 & patients.i == 2,
+            TypeError,
+            "WARNING: The `&` operator has surprising precedence rules",
+        ),
+        (
+            lambda: patients.i == 1 & (patients.i == 2),
             TypeError,
             "WARNING: The `&` operator has surprising precedence rules",
         ),

--- a/tests/unit/test_query_language.py
+++ b/tests/unit/test_query_language.py
@@ -1089,6 +1089,12 @@ def test_accidental_tuple_errors():
     with pytest.raises(TypeError, match=match):
         patients.i.is_not_null() | has_dob_BAD
 
+    with pytest.raises(TypeError, match=match):
+        has_dob_BAD & patients.i.is_not_null()
+
+    with pytest.raises(TypeError, match=match):
+        has_dob_BAD | patients.i.is_not_null()
+
 
 def test_query_model_type_errors():
     with pytest.raises(

--- a/tests/unit/test_query_language.py
+++ b/tests/unit/test_query_language.py
@@ -1073,6 +1073,23 @@ def test_type_errors(value, error):
         when(patients.exists_for_patient()).then(value).otherwise(None)
 
 
+def test_accidental_tuple_errors():
+    # Define some incorrect expressions (note the trailing comma)
+    year_of_birth_BAD = patients.date_of_birth.to_first_of_year(),  # fmt: skip
+    has_dob_BAD = patients.date_of_birth.is_not_null(),  # fmt: skip
+
+    match = "trailing comma"
+
+    with pytest.raises(TypeError, match=match):
+        events.event_date > year_of_birth_BAD
+
+    with pytest.raises(TypeError, match=match):
+        patients.i.is_not_null() & has_dob_BAD
+
+    with pytest.raises(TypeError, match=match):
+        patients.i.is_not_null() | has_dob_BAD
+
+
 def test_query_model_type_errors():
     with pytest.raises(
         TypeError,


### PR DESCRIPTION
This has bitten more than one user in the past (see linked ticket) and feels like the sort of thing it's worth having in place before lots of new users start.

Closes #2532