### PR TITLE
Fold Event Level Data permissions into the generic permissions system

### DIFF
--- a/.env
+++ b/.env
@@ -13,6 +13,3 @@
 # is designed to protect against don't apply to ehrQL, and having consistent
 # output makes debugging much easier
 PYTHONHASHSEED=0
-
-# Enable event level queries for testing purposes, but not yet in production
-EHRQL_ENABLE_EVENT_LEVEL_QUERIES=True

--- a/ehrql/permissions.py
+++ b/ehrql/permissions.py
@@ -1,6 +1,7 @@
 import json
 import logging
 
+from ehrql.query_model import nodes as qm
 from ehrql.query_model.introspection import get_table_nodes
 from ehrql.serializer_registry import RegistryError, get_id_for_object
 from ehrql.utils.log_utils import indent
@@ -112,6 +113,11 @@ def get_required_permissions(dataset):
     for permission, tables in table_permissions.items():
         required_permissions[permission] = (
             f"required for access to the {format_table_list(tables)}"
+        )
+
+    if isinstance(dataset, qm.Dataset) and dataset.events:
+        required_permissions["event_level_data"] = (
+            "required in order to use the `dataset.add_event_table()` method"
         )
 
     return required_permissions

--- a/ehrql/query_engines/base_sql.py
+++ b/ehrql/query_engines/base_sql.py
@@ -1,7 +1,6 @@
 import datetime
 import enum
 import logging
-import os
 import secrets
 from functools import cached_property
 
@@ -192,17 +191,6 @@ class BaseSQLQueryEngine(BaseQueryEngine):
         dataset_query = self.replace_single_join_with_multiple(
             dataset_query, self.max_join_count
         )
-
-        # We want to be able to run tests for this behaviour without enabling it in
-        # production
-        if (
-            os.environ.get("EHRQL_ENABLE_EVENT_LEVEL_QUERIES") != "True"
-            and dataset.events
-        ):
-            raise RuntimeError(
-                "This dataset definition is not yet authorised to use the "
-                "experimental `add_event_table()` feature"
-            )
 
         other_queries = [
             self.add_variables_to_query(


### PR DESCRIPTION
This will require the tiny handful of users currently trialing this to claim the relevant permission locally. The error message they get will tell them exactly what to do so I don't think this is an issue.

The relevant RAP Controller changes have already been made. We just need to remove the unused environment variable after this ehrQL change has been deployed:
https://github.com/opensafely-core/job-runner/blob/a570da602c38fae08e5f79f60a91c029d9cbd7f4/controller/main.py#L349-L352