### PR TITLE
Use preferred Slack token in workflow

### DIFF
--- a/.github/workflows/generative-tests.yml
+++ b/.github/workflows/generative-tests.yml
@@ -65,7 +65,7 @@ jobs:
         if: failure() && github.ref_name == 'main'
         uses: zuplo/github-action-slack-notify-build@cf8e7e66a21d76a8125ea9648979c30920195552 # v2
         env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          SLACK_BOT_TOKEN: ${{ secrets.BENNETTBOT_SLACK_BOT_TOKEN }}
         with:
           channel_id: C069YDR4NCA
           status: "Generative Test Failure"


### PR DESCRIPTION
This is already in use in this repository for the `update-dependencies` workflow so we know it's correctly configured.

The old token belongs to a bot we'd like to decommission.