### PR TITLE
Fix death date calculation in ehrQL tutorial

### DIFF
--- a/docs/tutorial/building-a-dataset/index.md
+++ b/docs/tutorial/building-a-dataset/index.md
@@ -89,7 +89,7 @@ previous_events = clinical_events.where(clinical_events.date.is_on_or_before(ind
 recent_meds = medications.where(medications.date.is_on_or_between(index_date - days(180), index_date))
 
 aged_17_or_older = (index_date - patients.date_of_birth).years >= 17
-was_alive = patients.date_of_death.is_null() | (patients.date_of_death < index_date)
+was_alive = patients.date_of_death.is_null() | (patients.date_of_death > index_date)
 was_registered = (
     practice_registrations.where(practice_registrations.start_date <= index_date)
     .except_where(practice_registrations.end_date < index_date)


### PR DESCRIPTION
A patient is alive on the index date if their date of death is _after_ the index date.

This didn't affect the tutorial output, because of a quirk of the dummy tables: all the patients with a non-null death date also had a practice registration end date which was before the index date. But that might not always be true of real patient data.

Bug reported [here](https://bennettoxford.slack.com/archives/C33TWNQ1J/p1761668398891409).