### PR TITLE
Avoid using self.rnd.choices() with weights

### DIFF
--- a/ehrql/dummy_data_nextgen/generator.py
+++ b/ehrql/dummy_data_nextgen/generator.py
@@ -595,20 +595,23 @@ class DummyPatientGenerator:
         if column_info.type is date:
             # If this date column is date of death, and None is a possible
             # value (but not the only one), we want to skew the dummy data towards
-            # producing None values most often.  The actual weights here are a bit arbitrary,
-            # but result in None being picked around 90% of the time
+            # producing None values most often.  We have arbitrarily chosen
+            # to result in None being picked 90% of the time
             if (
                 column_info.name == "date_of_death"
                 and values[0] is None
                 and len(values) > 1
             ):
-                # total weights are 10; None is given a weight of 9 and all other
-                # values get weightings that add up to 1
-                other_weights = [1 / (len(values) - 1)] * (len(values) - 1)
-                weights = [9, *other_weights]
+                # Using rnd.choices() with weights parameter takes 3x longer than
+                # without weights - so remove None from the list of possible values
+                # & handle it separately
+                values = values[1:]
+                if self.rnd.random() < 0.9:
+                    result = None
+                else:
+                    result = self.rnd.choices(values, k=1)[0]
             else:
-                weights = None
-            result = self.rnd.choices(values, weights=weights, k=1)[0]
+                result = self.rnd.choices(values, k=1)[0]
             if result is None:
                 return result
             if self.events_start <= result <= self.events_end:


### PR DESCRIPTION
* In an example dataset_definition, using weights took 3x longer for this block of code
* this led to a 10% speedup in the overall performance of the generation
* the ratio of matching patients was very similar to the previous code but not exactly the same
* see the source code for [choices()](https://github.com/python/cpython/blob/e733dc90f305441a5654d862da1e79b7d4fe889e/Lib/random.py#L460-L495)

Benchmarking was done with [covid_collateral_hf_update/dataset_definition_pandemic](https://github.com/opensafely/covid_collateral_hf_update/blob/main/analysis/dataset_definition_pandemic.py)

Here is a snakeviz of a profile run before these changes showing `choose_random_value` taking ~30sec with `choices` larger than `choice` (the green block in the centre):

<img width="2304" height="702" alt="Screenshot from 2025-10-31 11-03-29" src="https://github.com/user-attachments/assets/289586be-cd45-4bb0-945a-766e2600bb15" />

Here is a snakeviz of a profile run after these changes showing `choose_random_value` taking ~12sec with `choices` (the orange block in the centre) smaller than `choice`

<img width="2304" height="702" alt="Screenshot from 2025-10-31 11-03-38" src="https://github.com/user-attachments/assets/ca169e31-4aaa-4f96-a329-2f541a90affa" />

Here are counts of outputs for data showing that the matching patient ratio is comparable & the total number of patients is around 10% greater, and in this case the number of matching patients within the timeout was about 17% greater. This was generated with target sample 1000 and timeout 600sec, using the previous code:

```
...
[info   ] Using next generation dummy data generation
[info   ] Attempting to generate 10000 matching patients (random seed: BwRV3spP, timeout: 600s)
...
[info   ] Generated 270000 patients, found 1709 matching
[warning] Failed to find 10000 matching patients within 600 seconds — giving up
```

and using this code:

```
...
[info   ] Using next generation dummy data generation
[info   ] Attempting to generate 10000 matching patients (random seed: BwRV3spP, timeout: 600s)
...
[info   ] Generated 270000 patients, found 1713 matching
...
[info   ] Generated 315000 patients, found 2009 matching
[warning] Failed to find 10000 matching patients within 600 seconds — giving up
```

