### PR TITLE
Increase number of dummy data events generated for required tables

### DIFF
--- a/ehrql/dummy_data_nextgen/generator.py
+++ b/ehrql/dummy_data_nextgen/generator.py
@@ -446,11 +446,17 @@ class DummyPatientGenerator:
         if table_info.has_one_row_per_patient:
             row_count = self.rnd.randint(0, 1)
         else:
-            # Geometric distribution with parameter 0.2. Will average 4 (=1/0.2 - 1) events
-            # per patient.
-            row_count = math.floor(math.log(self.rnd.random()) / math.log(1 - 0.2))
             if self.required_tables and table_info.name in self.required_tables:
+                # if a matching event is required, average about 40 events
+                # per patient.
+                row_count = math.floor(
+                    math.log(self.rnd.random()) / math.log(1 - 0.025)
+                )
                 row_count += 1
+            else:
+                # Geometric distribution with parameter 0.2. Will average 4 (=1/0.2 - 1) events
+                # per patient.
+                row_count = math.floor(math.log(self.rnd.random()) / math.log(1 - 0.2))
         return [{} for _ in range(row_count)]
 
     def populate_row(self, patient_id, table_info, row):


### PR DESCRIPTION
* I don't know how the old value was decided on
* this new value was picked arbitrarily
* for a "worst case" dataset definition I was looking it (in which the generated events needed to match some specific criteria), it increased the number of "found" patients when generating a dummy dataset from ~30 per 5000 to ~400 per 5000.