### PR TITLE
Increase number of dummy data events generated for required tables

### DIFF
--- a/ehrql/dummy_data_nextgen/generator.py
+++ b/ehrql/dummy_data_nextgen/generator.py
@@ -446,11 +446,17 @@ class DummyPatientGenerator:
         if table_info.has_one_row_per_patient:
             row_count = self.rnd.randint(0, 1)
         else:
-            # Geometric distribution with parameter 0.2. Will average 4 (=1/0.2 - 1) events
-            # per patient.
-            row_count = math.floor(math.log(self.rnd.random()) / math.log(1 - 0.2))
             if self.required_tables and table_info.name in self.required_tables:
+                # if a matching event is required, average about 40 events
+                # per patient.
+                row_count = math.floor(
+                    math.log(self.rnd.random()) / math.log(1 - 0.025)
+                )
                 row_count += 1
+            else:
+                # Geometric distribution with parameter 0.2. Will average 4 (=1/0.2 - 1) events
+                # per patient.
+                row_count = math.floor(math.log(self.rnd.random()) / math.log(1 - 0.2))
         return [{} for _ in range(row_count)]
 
     def populate_row(self, patient_id, table_info, row):


### PR DESCRIPTION
* One way in which the current nextgen dummy data generator can struggle is when a patient needs to have a matching event and the generator fails to generate such a matching event
* We can easily improve our chances by increasing the number of events generated.
* I don't know how the old value was decided on
* The new value was picked arbitrarily. We could finesse it, but I think the trade-off at the moment is between the best performance for datasets with good dummy data & making datasets that struggle to generate dummy data viable - and I think we should prioritise the latter.
* This PR only increases the number of events if the event is required for a patient to be in the population, to reduce the performance impact of generating many more events
* nb. this means this change does not affect batch0 (the first batch), only batch1 and subsequent batches
* for a "worst case" dataset definition I was looking it (in which the generated events needed to match some specific criteria), it increased the number of "found" patients when generating a dummy dataset from ~30 per 5000 to ~400 per 5000.
* @bloodearnest ran this branch against 700+ dataset definitions
* looking at the "found" value, most of the worst-performing 200 dataset definitions performed significantly better, often finding 1000 more matching patients in each batch of 5000 generated patients - for example `covid_collateral_hf_update`, `measures_2019.log` which found 1130 patients in batch1 compared to 179 patients before.
* here is a graph showing the number of found patients in batch1 for each dataset definition, sorted by the number of found patients before this pr. Red shows the number of patients found before this PR, blue shows the number of patients found after this PR.
<img width="1902" height="1074" alt="Screenshot from 2025-12-17 15-41-18" src="https://github.com/user-attachments/assets/69a5b419-a0ea-494c-b6c9-9a8670db05d9" />
* the performance as measured by dps is less clear - on average the dps is ~7% higher, although there is a lot of variation depending on the particular dataset definition. In general it seems that better performing datasets may be slower & worse performing datasets may be faster.
<img width="2078" height="1032" alt="Screenshot from 2025-12-17 15-50-12" src="https://github.com/user-attachments/assets/2131cc92-698d-4cff-b490-e82721c137ca" />
* extracted relevant data from tests:
[tom dummy data changes moar events.ods](https://github.com/user-attachments/files/24217183/tom.dummy.data.changes.moar.events.ods)

