### PR TITLE
Exit with specific code for over-complex SQL

### DIFF
--- a/ehrql/backends/tpp.py
+++ b/ehrql/backends/tpp.py
@@ -196,6 +196,18 @@ class TPPBackend(SQLBackend):
                 )
                 return 4
 
+        overcomplex_errors = [
+            r"query processor ran out of internal resources",
+            r"expression services limit has been reached",
+            r"query processor ran out of stack space",
+            r"exceeds the maximum of \d+ columns",
+        ]
+        if any(
+            re.search(message, exception_messages) for message in overcomplex_errors
+        ):
+            exception.add_note(f"\nOver-complex SQL error: {exception}")
+            return 6
+
         exception.add_note(f"\nDatabase error: {exception}")
         return 5
 

--- a/tests/unit/backends/test_tpp.py
+++ b/tests/unit/backends/test_tpp.py
@@ -79,6 +79,20 @@ def test_tpp_backend_modify_dsn_rejects_duplicate_params(dsn):
             "CodedEvent_SNOMED table is currently not available",
         ),
         (
+            pymssql_exceptions.OperationalError(
+                "The query processor ran out of stack space"
+            ),
+            6,
+            "Over-complex SQL error",
+        ),
+        (
+            pymssql_exceptions.OperationalError(
+                "column 'foo' in table 'bar' exceeds the maximum of 1024 columns"
+            ),
+            6,
+            "Over-complex SQL error",
+        ),
+        (
             pymssql_exceptions.DataError("Database data error"),
             5,
             "Database error",


### PR DESCRIPTION
This should hopefully slightly reduce the confusion these errors produce.

Corresponding Controller PR is here:
 * https://github.com/opensafely-core/job-runner/pull/1297

Closes #2577