### PR TITLE
Add `workflow_dispatch` trigger to CI workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,6 +2,7 @@
 name: CI
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main


### PR DESCRIPTION
This allows us to run the workflow on a branch manually, which is useful if we would like to make sure CI passes before opening a PR.