### PR TITLE
Generate date values in the same row in expected chronological order

### DIFF
--- a/ehrql/dummy_data_nextgen/generator.py
+++ b/ehrql/dummy_data_nextgen/generator.py
@@ -468,6 +468,9 @@ class DummyPatientGenerator:
             if name not in row:
                 row[name] = self.get_random_value_for_patient(patient_id, column_info)
 
+        if table_info.chronological_date_columns:
+            reorder_dates(row, table_info.chronological_date_columns)
+
     def __check_values(self, column_info, result):
         if not result:
             raise CannotGenerate(
@@ -670,3 +673,17 @@ def merge_table_data(*dicts):
     target = {}
     extend_table_data(target, *dicts)
     return target
+
+
+def reorder_dates(row, chronological_date_columns):
+    # Swap dates around to give chronologically ordered values
+    # `None`s are left in place: this still produces valid data,
+    # and prevents us from swapping a `None` onto a non-nullable column
+    dates = [
+        (col, row[col]) for col in chronological_date_columns if row[col] is not None
+    ]
+    if dates:
+        cols, vals = zip(*dates)
+        vals = sorted(vals)
+        for col, val in zip(cols, vals):
+            row[col] = val

--- a/ehrql/dummy_data_nextgen/query_info.py
+++ b/ehrql/dummy_data_nextgen/query_info.py
@@ -66,14 +66,6 @@ class ColumnInfo:
     def get_constraint(self, type_):
         return self._constraints_by_type.get(type_)
 
-    def pop_constraint(self, type_):
-        try:
-            constraint = self._constraints_by_type.pop(type_)
-            self.constraints = tuple(self._constraints_by_type.values())
-            return constraint
-        except KeyError:
-            return None
-
 
 @dataclasses.dataclass
 class TableInfo:
@@ -444,13 +436,9 @@ def filter_values(query, values):
 
 
 def set_chronological_dates_from_constraints(table_info):
-    """
-    Removes `DateAfter` constraints from columns in table_info and uses
-    them to populate `table_info.chronological_date_columns`
-    """
     graph = {}
     for name, col in table_info.columns.items():
-        if date_after := col.pop_constraint(Constraint.DateAfter):
+        if date_after := col.get_constraint(Constraint.DateAfter):
             graph[name] = {
                 c for c in date_after.column_names if c in table_info.columns
             }

--- a/ehrql/dummy_data_nextgen/query_info.py
+++ b/ehrql/dummy_data_nextgen/query_info.py
@@ -46,7 +46,7 @@ class ColumnInfo:
             name,
             type_,
             query=query,
-            constraints=tuple(column.constraints),
+            constraints=tuple([*column.constraints, *column.dummy_data_constraints]),
         )
 
     def __post_init__(self):

--- a/ehrql/dummy_data_nextgen/query_info.py
+++ b/ehrql/dummy_data_nextgen/query_info.py
@@ -47,7 +47,7 @@ class ColumnInfo:
             name,
             type_,
             query=query,
-            constraints=tuple([*column.constraints, *column.dummy_data_constraints]),
+            constraints=column.column_and_dummy_data_constraints,
         )
 
     def __post_init__(self):
@@ -445,7 +445,7 @@ def filter_values(query, values):
 def set_chronological_dates_from_constraints(table_info):
     """
     Removes `DateAfter` constraints from columns in table_info and uses
-    them to populate `table_infochronological_date_columns`
+    them to populate `table_info.chronological_date_columns`
     """
     chronological_date_columns = []
     for name, col in table_info.columns.items():

--- a/ehrql/query_language.py
+++ b/ehrql/query_language.py
@@ -2123,7 +2123,11 @@ def validate_inner_metadata_class(cls):
 def get_table_schema_from_class(cls):
     # Get all `Series` objects on the class and determine the schema from them
     schema = {
-        series.name: qm.Column(series.type_, constraints=series.constraints)
+        series.name: qm.Column(
+            series.type_,
+            constraints=series.constraints,
+            dummy_data_constraints=series.dummy_data_constraints,
+        )
         for series in get_all_series_from_class(cls).values()
     }
     return qm.TableSchema(**schema)
@@ -2287,6 +2291,7 @@ class Series[T]:
         *,
         description="",
         constraints=(),
+        dummy_data_constraints=(),
         required=True,
         implementation_notes_to_add_to_description="",
         notes_for_implementors="",
@@ -2294,6 +2299,7 @@ class Series[T]:
         self.type_ = type_
         self.description = strip_indent(description)
         self.constraints = constraints
+        self.dummy_data_constraints = dummy_data_constraints
         self.required = required
         self.implementation_notes_to_add_to_description = strip_indent(
             implementation_notes_to_add_to_description

--- a/ehrql/query_model/table_schema.py
+++ b/ehrql/query_model/table_schema.py
@@ -305,7 +305,7 @@ class TableSchema:
                 f"'Constraint.DateAfter' dependencies form a cycle: {' -> '.join(e.args[1])}"
             )
         for i, name in enumerate(static_order):
-            declared = dependency_graph.get(name, [])
+            declared = dependency_graph[name]
             if declared != static_order[:i]:
                 raise ValueError(
                     f"The transitive dependencies of column '{name}' are not all declared "

--- a/ehrql/query_model/table_schema.py
+++ b/ehrql/query_model/table_schema.py
@@ -202,6 +202,10 @@ class Column:
                 f"'{constraint.__qualname__}()' not '{constraint.__qualname__}'"
             )
 
+    @property
+    def column_and_dummy_data_constraints(self):
+        return self.constraints + self.dummy_data_constraints
+
 
 class TableSchema:
     "Defines a mapping of column names to column definitions"
@@ -290,6 +294,18 @@ class TableSchema:
                     raise ValueError(
                         f"Column '{name}' cannot be a date after '{dep_name}' "
                         f"as '{dep_name}' is not a date column"
+                    )
+                constraints_diff = set(
+                    column.column_and_dummy_data_constraints
+                ).symmetric_difference(set(dep_col.column_and_dummy_data_constraints))
+                if not all(
+                    isinstance(c, Constraint.DateAfter)
+                    or isinstance(c, Constraint.NotNull)
+                    for c in constraints_diff
+                ):
+                    raise ValueError(
+                        f"Columns '{name}' and '{dep_name}' have incompatible constraints "
+                        f"for a 'Constraint.DateAfter' relationship"
                     )
 
             # Check for cycles and undeclared transitive dependencies

--- a/ehrql/query_model/table_schema.py
+++ b/ehrql/query_model/table_schema.py
@@ -118,6 +118,7 @@ class Constraint:
 class Column:
     type_: type
     constraints: tuple[BaseConstraint] = ()
+    dummy_data_constraints: tuple[BaseConstraint] = ()
 
     def __post_init__(self):
         _setattrs(
@@ -125,23 +126,31 @@ class Column:
             # Accept constraints as list rather than a tuple as they don't suffer from
             # the trailing comma problem
             constraints=tuple(self.constraints),
+            dummy_data_constraints=tuple(self.dummy_data_constraints),
             # We build an internal lookup table of constraints by their type
             _constraints_by_type={},
+            _dummy_data_constraints_by_type={},
         )
         # Enforce that we get only one instance of each type of constraint and populate
         # the lookup table
         for constraint in self.constraints:
             cls = type(constraint)
-            # Supplying the class rather than the instance seems like an easy mistake to
-            # make so we'll guard against that here
-            if cls is type:
-                raise ValueError(
-                    f"Constraint should be instance not class e.g. "
-                    f"'{constraint.__qualname__}()' not '{constraint.__qualname__}'"
-                )
+            self._validate_constraint_is_instance(constraint, cls)
             if cls in self._constraints_by_type:
                 raise ValueError(f"'{cls.__qualname__}' specified more than once")
             self._constraints_by_type[cls] = constraint
+
+        for constraint in self.dummy_data_constraints:
+            cls = type(constraint)
+            self._validate_constraint_is_instance(constraint, cls)
+            if cls in self._constraints_by_type:
+                raise ValueError(
+                    f"'{cls.__qualname__}' cannot be specified as a dummy data "
+                    "constraint as a column constraint of the same type already exists"
+                )
+            if cls in self._dummy_data_constraints_by_type:
+                raise ValueError(f"'{cls.__qualname__}' specified more than once")
+            self._dummy_data_constraints_by_type[cls] = constraint
 
     def get_constraint_by_type(self, cls):
         return self._constraints_by_type.get(cls)
@@ -152,8 +161,19 @@ class Column:
         prefix = f"{module}." if module != "builtins" else ""
         type_repr = f"{prefix}{self.type_.__name__}"
         return (
-            f"{self.__class__.__name__}({type_repr}, constraints={self.constraints!r})"
+            f"{self.__class__.__name__}({type_repr}, constraints={self.constraints!r}, "
+            f"dummy_data_constraints={self.dummy_data_constraints!r})"
         )
+
+    @staticmethod
+    def _validate_constraint_is_instance(constraint, constraint_cls):
+        # Supplying the class rather than the instance seems like an easy mistake to
+        # make so we'll guard against that here
+        if constraint_cls is type:
+            raise ValueError(
+                f"Constraint should be instance not class e.g. "
+                f"'{constraint.__qualname__}()' not '{constraint.__qualname__}'"
+            )
 
 
 class TableSchema:

--- a/ehrql/query_model/table_schema.py
+++ b/ehrql/query_model/table_schema.py
@@ -133,7 +133,7 @@ class Column:
         for constraint in self.constraints:
             cls = type(constraint)
             # Supplying the class rather than the instance seems like an easy mistake to
-            # make so we'll guard againt that here
+            # make so we'll guard against that here
             if cls is type:
                 raise ValueError(
                     f"Constraint should be instance not class e.g. "

--- a/ehrql/query_model/table_schema.py
+++ b/ehrql/query_model/table_schema.py
@@ -65,6 +65,10 @@ class Constraint:
         def description(self):
             return f"Date must be on or after the date value in column(s) {', '.join(self.column_names)}"
 
+        def validate(self, value):
+            # We can't validate without the value(s) of the other column(s)
+            return True
+
     class Regex(BaseConstraint):
         regex: str
 
@@ -157,10 +161,6 @@ class Column:
         self._dummy_data_constraints_by_type.update(
             self._build_constraints_by_type(self.dummy_data_constraints)
         )
-        if self.get_constraint_by_type(Constraint.DateAfter):
-            raise ValueError(
-                "'Constraint.DateAfter' can only be specified as a dummy data constraint."
-            )
 
     def get_constraint_by_type(self, cls):
         return self._constraints_by_type.get(cls)

--- a/ehrql/tables/core.py
+++ b/ehrql/tables/core.py
@@ -140,6 +140,7 @@ class practice_registrations(EventFrame):
         int,
         constraints=[Constraint.NotNull()],
         description="Pseudonymised practice identifier.",
+        dummy_data_constraints=[Constraint.ClosedRange(0, 999)],
     )
 
     def for_patient_on(self, date):

--- a/ehrql/tables/tpp.py
+++ b/ehrql/tables/tpp.py
@@ -79,6 +79,7 @@ class addresses(EventFrame):
     end_date = Series(
         datetime.date,
         description="Date patient moved out of address.",
+        dummy_data_constraints=[Constraint.DateAfter(["start_date"])],
     )
     address_type = Series(
         int,
@@ -272,6 +273,7 @@ class apcs(EventFrame):
     discharge_date = Series(
         datetime.date,
         description="The date of discharge from a hospital provider spell.",
+        dummy_data_constraints=[Constraint.DateAfter(["admission_date"])],
     )
     discharge_destination = Series(
         str,
@@ -474,6 +476,7 @@ class apcs_cost(EventFrame):
     discharge_date = Series(
         datetime.date,
         description="The date of discharge from a hospital provider spell.",
+        dummy_data_constraints=[Constraint.DateAfter(["admission_date"])],
     )
 
 
@@ -573,10 +576,12 @@ class appointments(EventFrame):
     start_date = Series(
         datetime.date,
         description="The date the appointment was due to start",
+        dummy_data_constraints=[Constraint.DateAfter(["booked_date"])],
     )
     seen_date = Series(
         datetime.date,
         description="The date the patient was seen",
+        dummy_data_constraints=[Constraint.DateAfter(["booked_date", "start_date"])],
     )
     status = Series(
         str,
@@ -937,10 +942,14 @@ class ec_cost(EventFrame):
             "The date the patient self presented at the accident & emergency department, "
             "or arrived in an ambulance at the accident & emergency department."
         ),
+        dummy_data_constraints=[Constraint.DateAfter(["ec_injury_date"])],
     )
     ec_decision_to_admit_date = Series(
         datetime.date,
         description="The date a decision to admit was made (if applicable).",
+        dummy_data_constraints=[
+            Constraint.DateAfter(["ec_injury_date", "arrival_date"])
+        ],
     )
     ec_injury_date = Series(
         datetime.date,
@@ -1174,6 +1183,9 @@ class opa(EventFrame):
     appointment_date = Series(
         datetime.date,
         description="The date of an appointment.",
+        dummy_data_constraints=[
+            Constraint.DateAfter(["referral_request_received_date"])
+        ],
     )
     attendance_status = Series(
         str,
@@ -1291,6 +1303,9 @@ class opa_cost(EventFrame):
     appointment_date = Series(
         datetime.date,
         description="The date of an appointment.",
+        dummy_data_constraints=[
+            Constraint.DateAfter(["referral_request_received_date"])
+        ],
     )
     referral_request_received_date = Series(
         datetime.date,
@@ -1344,6 +1359,9 @@ class opa_diag(EventFrame):
     appointment_date = Series(
         datetime.date,
         description="The date of an appointment.",
+        dummy_data_constraints=[
+            Constraint.DateAfter(["referral_request_received_date"])
+        ],
     )
     referral_request_received_date = Series(
         datetime.date,
@@ -1391,6 +1409,9 @@ class opa_proc(EventFrame):
     appointment_date = Series(
         datetime.date,
         description="The date of an appointment.",
+        dummy_data_constraints=[
+            Constraint.DateAfter(["referral_request_received_date"])
+        ],
     )
     referral_request_received_date = Series(
         datetime.date,
@@ -1603,6 +1624,7 @@ class sgss_covid_all_tests(EventFrame):
         description="""
             Date on which the labaratory reported the result.
         """,
+        dummy_data_constraints=[Constraint.DateAfter(["specimen_taken_date"])],
     )
     was_symptomatic = Series(
         bool,
@@ -1851,6 +1873,9 @@ class wl_clockstops(EventFrame):
     referral_to_treatment_period_end_date = Series(
         datetime.date,
         description="Clock stop for the completed pathway",
+        dummy_data_constraints=[
+            Constraint.DateAfter(["referral_to_treatment_period_start_date"])
+        ],
     )
     referral_to_treatment_period_start_date = Series(
         datetime.date,
@@ -1948,6 +1973,9 @@ class wl_openpathways(EventFrame):
     referral_to_treatment_period_end_date = Series(
         datetime.date,
         description="If the pathway is open, then `NULL`",
+        dummy_data_constraints=[
+            Constraint.DateAfter(["referral_to_treatment_period_start_date"])
+        ],
     )
     referral_to_treatment_period_start_date = Series(
         datetime.date,

--- a/tests/unit/dummy_data_nextgen/test_edge_cases_for_coverage.py
+++ b/tests/unit/dummy_data_nextgen/test_edge_cases_for_coverage.py
@@ -4,10 +4,7 @@ import pytest
 
 from ehrql.dummy_data_nextgen.generator import DummyDataGenerator
 from ehrql.dummy_data_nextgen.query_info import QueryInfo, is_value, specialize
-from ehrql.query_language import (
-    Series,
-    create_dataset,
-)
+from ehrql.query_language import create_dataset
 from ehrql.query_model.nodes import (
     Case,
     Dataset,
@@ -24,11 +21,11 @@ def test_check_is_value():
     assert is_value(Function.GT(lhs=Value(value=0.0), rhs=Value(value=0.0)))
 
 
-schema = TableSchema(
-    i1=Series(int),
-    b0=Series(bool),
-    b1=Series(bool),
-    d1=Series(date),
+schema = TableSchema.from_primitives(
+    i1=int,
+    b0=bool,
+    b1=bool,
+    d1=date,
 )
 p0 = SelectPatientTable(name="p0", schema=schema)
 

--- a/tests/unit/dummy_data_nextgen/test_query_info.py
+++ b/tests/unit/dummy_data_nextgen/test_query_info.py
@@ -37,24 +37,6 @@ class events(EventFrame):
     code = Series(CTV3Code)
 
 
-def test_column_info_pop_constraint():
-    column = ColumnInfo(
-        name="code",
-        type=str,
-        constraints=[Constraint.NotNull(), Constraint.Categorical(["a", "b", "c"])],
-    )
-    constraint = column.pop_constraint(Constraint.Categorical)
-    assert constraint == Constraint.Categorical(["a", "b", "c"])
-    assert column.constraints == (Constraint.NotNull(),)
-    assert column._constraints_by_type == {Constraint.NotNull: Constraint.NotNull()}
-
-
-def test_column_info_pop_constraint_when_nonexistent():
-    column = ColumnInfo(name="code", type=str)
-    constraint = column.pop_constraint(Constraint.Categorical)
-    assert constraint is None
-
-
 def test_query_info_from_dataset():
     dataset = Dataset()
     dataset.define_population(events.exists_for_patient())
@@ -244,10 +226,10 @@ def test_query_info_includes_dummy_data_constraints():
     table_info = query_info.tables["some_events"]
 
     assert table_info.chronological_date_columns == ("date", "another_date")
-    assert (
-        table_info.columns["date"].constraints
-        == table_info.columns["another_date"].constraints
-        == (Constraint.FirstOfMonth(),)
+    assert table_info.columns["date"].constraints == (Constraint.FirstOfMonth(),)
+    assert table_info.columns["another_date"].constraints == (
+        Constraint.FirstOfMonth(),
+        Constraint.DateAfter(["date"]),
     )
 
 
@@ -280,9 +262,6 @@ def test_set_chronological_dates_from_constraints():
         "middle_date",
         "latest_date",
     )
-    assert table_info.columns["earliest_date"].constraints == ()
-    assert table_info.columns["middle_date"].constraints == ()
-    assert table_info.columns["latest_date"].constraints == ()
 
 
 def test_set_chronological_dates_from_constraints_does_not_include_unused_columns():

--- a/tests/unit/query_model/test_constraints.py
+++ b/tests/unit/query_model/test_constraints.py
@@ -72,3 +72,7 @@ def test_date_after_instantiation_with_string_raises_error():
         match="'column_names' must be a tuple or list of column names",
     ):
         Constraint.DateAfter("some_date")
+
+
+def test_date_after_validation():
+    assert Constraint.DateAfter(["date"]).validate(date(2024, 1, 1))

--- a/tests/unit/query_model/test_constraints.py
+++ b/tests/unit/query_model/test_constraints.py
@@ -1,5 +1,7 @@
 from datetime import date
 
+import pytest
+
 from ehrql.tables import Constraint
 
 
@@ -57,3 +59,16 @@ def test_general_range_validation():
     assert Constraint.GeneralRange(minimum=-1, maximum=1).validate(None)
     assert not Constraint.GeneralRange(minimum=-1, maximum=1).validate(2)
     assert not Constraint.GeneralRange(minimum=-1, maximum=1).validate(-2)
+
+
+def test_date_after_instantiation():
+    assert Constraint.DateAfter(["some_date"]).column_names == ("some_date",)
+    assert Constraint.DateAfter(("some_date",)).column_names == ("some_date",)
+
+
+def test_date_after_instantiation_with_string_raises_error():
+    with pytest.raises(
+        TypeError,
+        match="'column_names' must be a tuple or list of column names",
+    ):
+        Constraint.DateAfter("some_date")

--- a/tests/unit/query_model/test_constraints.py
+++ b/tests/unit/query_model/test_constraints.py
@@ -43,3 +43,17 @@ def test_closed_range_validation():
     assert c.validate(None)
     assert not c.validate(0)
     assert not c.validate(4)
+
+
+def test_general_range_validation():
+    assert Constraint.GeneralRange(minimum=1, includes_minimum=True).validate(1)
+    assert Constraint.GeneralRange(includes_minimum=True).validate(1)
+    assert not Constraint.GeneralRange(minimum=1, includes_minimum=False).validate(1)
+    assert Constraint.GeneralRange(maximum=1, includes_maximum=True).validate(1)
+    assert Constraint.GeneralRange(includes_maximum=True).validate(1)
+    assert not Constraint.GeneralRange(maximum=1, includes_maximum=False).validate(1)
+
+    assert Constraint.GeneralRange(minimum=-1, maximum=1).validate(0)
+    assert Constraint.GeneralRange(minimum=-1, maximum=1).validate(None)
+    assert not Constraint.GeneralRange(minimum=-1, maximum=1).validate(2)
+    assert not Constraint.GeneralRange(minimum=-1, maximum=1).validate(-2)

--- a/tests/unit/query_model/test_table_schema.py
+++ b/tests/unit/query_model/test_table_schema.py
@@ -234,8 +234,7 @@ def test__validate_date_after_constraints_with_cyclic_dependency():
     with pytest.raises(
         ValueError,
         match=(
-            "Column 'c1' has a cyclic dependency in its 'Constraint.DateAfter' "
-            "dummy data constraints"
+            "'Constraint.DateAfter' dependencies form a cycle: c1 -> c2 -> c3 -> c1"
         ),
     ):
         TableSchema(
@@ -258,8 +257,8 @@ def test__validate_date_after_constraints_with_transitive_dependency():
     with pytest.raises(
         ValueError,
         match=(
-            "Column 'c1' is not declared in column 'c3's 'Constraint.DateAfter', "
-            "but is transitively required to be before 'c3'"
+            "The transitive dependencies of column 'c3' are not all "
+            "declared in its 'Constraint.DateAfter'. Expected: c1, c2, got: c2"
         ),
     ):
         TableSchema(

--- a/tests/unit/query_model/test_table_schema.py
+++ b/tests/unit/query_model/test_table_schema.py
@@ -284,6 +284,27 @@ def test__validate_date_after_constraints_with_transitive_dependency():
         )
 
 
+def test__validate_date_after_constraints_with_mismatched_constraints():
+    c1 = Column(
+        datetime.date,
+        constraints=[Constraint.GeneralRange(minimum=datetime.date(2000, 1, 1))],
+        dummy_data_constraints=[Constraint.DateAfter(["c2"])],
+    )
+    c2 = Column(
+        datetime.date,
+        constraints=[Constraint.GeneralRange(minimum=datetime.date(1990, 1, 1))],
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            "Columns 'c1' and 'c2' have incompatible constraints "
+            "for a 'Constraint.DateAfter' relationship"
+        ),
+    ):
+        TableSchema(c1=c1, c2=c2)
+
+
 def test_range_constraint_description():
     assert (
         Constraint.ClosedRange(0, 10, 2).description

--- a/tests/unit/query_model/test_table_schema.py
+++ b/tests/unit/query_model/test_table_schema.py
@@ -159,16 +159,6 @@ def test_supplying_multiple_instances_of_same_constraint_raises_error(
         Column(int, constraints, dummy_data_constraints)
 
 
-def test_supplying_date_after_as_a_column_constraint_raises_error():
-    with pytest.raises(
-        ValueError,
-        match=(
-            "'Constraint.DateAfter' can only be specified as a dummy data constraint."
-        ),
-    ):
-        Column(datetime.date, constraints=[Constraint.DateAfter(["other_date"])])
-
-
 def test_supplying_date_after_on_a_non_date_column_raises_error():
     with pytest.raises(
         ValueError,

--- a/tests/unit/query_model/test_table_schema.py
+++ b/tests/unit/query_model/test_table_schema.py
@@ -168,6 +168,26 @@ def test_supplying_multiple_instances_of_same_dummy_data_constraint_raises_error
         )
 
 
+def test_supplying_date_after_as_a_column_constraint_raises_error():
+    with pytest.raises(
+        ValueError,
+        match=(
+            "'Constraint.DateAfter' can only be specified as a dummy data constraint."
+        ),
+    ):
+        Column(datetime.date, constraints=[Constraint.DateAfter(["other_date"])])
+
+
+def test_supplying_date_after_on_a_non_date_column_raises_error():
+    with pytest.raises(
+        ValueError,
+        match=re.escape(
+            "'Constraint.DateAfter' cannot be specified on a column with type 'int'."
+        ),
+    ):
+        Column(int, dummy_data_constraints=[Constraint.DateAfter(["other_date"])])
+
+
 def test_supplying_class_instead_of_instance_raises_error():
     with pytest.raises(
         ValueError,
@@ -207,3 +227,14 @@ def test_table_schema_general_range_constraint_description():
     )
 
     assert Constraint.GeneralRange().description == "Any value"
+
+
+def test_date_after_constraint_description():
+    assert (
+        Constraint.DateAfter(["date_1"]).description
+        == "Date must be on or after the date value in column(s) date_1"
+    )
+    assert (
+        Constraint.DateAfter(["date_1", "date_2"]).description
+        == "Date must be on or after the date value in column(s) date_1, date_2"
+    )

--- a/tests/unit/query_model/test_table_schema.py
+++ b/tests/unit/query_model/test_table_schema.py
@@ -162,20 +162,6 @@ def test_range_constraint_description_step_1():
     assert Constraint.ClosedRange(0, 10).description == "Always >= 0 and <= 10"
 
 
-def test_table_schema_general_range_constraint_validate():
-    assert Constraint.GeneralRange(minimum=1, includes_minimum=True).validate(1)
-    assert Constraint.GeneralRange(includes_minimum=True).validate(1)
-    assert not Constraint.GeneralRange(minimum=1, includes_minimum=False).validate(1)
-    assert Constraint.GeneralRange(maximum=1, includes_maximum=True).validate(1)
-    assert Constraint.GeneralRange(includes_maximum=True).validate(1)
-    assert not Constraint.GeneralRange(maximum=1, includes_maximum=False).validate(1)
-
-    assert Constraint.GeneralRange(minimum=-1, maximum=1).validate(0)
-    assert Constraint.GeneralRange(minimum=-1, maximum=1).validate(None)
-    assert not Constraint.GeneralRange(minimum=-1, maximum=1).validate(2)
-    assert not Constraint.GeneralRange(minimum=-1, maximum=1).validate(-2)
-
-
 def test_table_schema_general_range_constraint_description():
     assert Constraint.GeneralRange(minimum=1).description == "Always >= 1"
     assert (

--- a/tests/unit/query_model/test_table_schema.py
+++ b/tests/unit/query_model/test_table_schema.py
@@ -140,6 +140,34 @@ def test_supplying_multiple_instances_of_same_constraint_raises_error():
         )
 
 
+def test_supplying_dummy_data_constraint_of_same_type_as_existing_constraint_raises_error():
+    with pytest.raises(
+        ValueError,
+        match=(
+            "'Constraint.Categorical' cannot be specified as a dummy data "
+            "constraint as a column constraint of the same type already exists"
+        ),
+    ):
+        Column(
+            int,
+            constraints=[Constraint.Categorical([1, 2])],
+            dummy_data_constraints=[Constraint.Categorical([3, 4])],
+        )
+
+
+def test_supplying_multiple_instances_of_same_dummy_data_constraint_raises_error():
+    with pytest.raises(
+        ValueError, match="'Constraint.Categorical' specified more than once"
+    ):
+        Column(
+            int,
+            dummy_data_constraints=[
+                Constraint.Categorical([1, 2]),
+                Constraint.Categorical([3, 4]),
+            ],
+        )
+
+
 def test_supplying_class_instead_of_instance_raises_error():
     with pytest.raises(
         ValueError,

--- a/tests/unit/query_model/test_table_schema.py
+++ b/tests/unit/query_model/test_table_schema.py
@@ -127,45 +127,36 @@ def test_column_casts_constraint_lists_to_tuple():
     assert column.constraints == (Constraint.NotNull(), Constraint.Unique())
 
 
-def test_supplying_multiple_instances_of_same_constraint_raises_error():
-    with pytest.raises(
-        ValueError, match="'Constraint.Categorical' specified more than once"
-    ):
-        Column(
-            int,
-            constraints=[
+@pytest.mark.parametrize(
+    "constraints,dummy_data_constraints",
+    [
+        (
+            [
                 Constraint.Categorical([1, 2]),
                 Constraint.Categorical([3, 4]),
             ],
-        )
-
-
-def test_supplying_dummy_data_constraint_of_same_type_as_existing_constraint_raises_error():
-    with pytest.raises(
-        ValueError,
-        match=(
-            "'Constraint.Categorical' cannot be specified as a dummy data "
-            "constraint as a column constraint of the same type already exists"
+            [],
         ),
-    ):
-        Column(
-            int,
-            constraints=[Constraint.Categorical([1, 2])],
-            dummy_data_constraints=[Constraint.Categorical([3, 4])],
-        )
-
-
-def test_supplying_multiple_instances_of_same_dummy_data_constraint_raises_error():
-    with pytest.raises(
-        ValueError, match="'Constraint.Categorical' specified more than once"
-    ):
-        Column(
-            int,
-            dummy_data_constraints=[
+        (
+            [],
+            [
                 Constraint.Categorical([1, 2]),
                 Constraint.Categorical([3, 4]),
             ],
-        )
+        ),
+        (
+            [Constraint.Categorical([1, 2])],
+            [Constraint.Categorical([3, 4])],
+        ),
+    ],
+)
+def test_supplying_multiple_instances_of_same_constraint_raises_error(
+    constraints, dummy_data_constraints
+):
+    with pytest.raises(
+        ValueError, match="'Constraint.Categorical' specified more than once"
+    ):
+        Column(int, constraints, dummy_data_constraints)
 
 
 def test_supplying_date_after_as_a_column_constraint_raises_error():


### PR DESCRIPTION
Partial implementation of #2595 to collect feedback.

This PR focuses on this part of the ticket:

> For example, the hospital admissions tables should “know” not to generate discharge dates before admission dates ...

Having related date columns (e.g. a `start_date` and an `end_date`) being "out of order" is [something that has been brought up by a user](https://bennettoxford.slack.com/archives/C01D7H9LYKB/p1755010408886709), so hopefully eliminating out of order dates might make dummy data and dummy tables easier to use.

The implementation in this PR is tailored to date ordering - we swap values around post-generation until dates are in the order we expect. 

Following reviewer feedback, here we add a `dummy_data_constraints` field to `Series`. We also add a new type of constraint (`Constraint.DateAfter`), which allows us to store information about the expected chronological order of columns. ~Information about which columns are chronological dates are inserted into the `QueryInfo` via reading from a dictionary in a `metadata.py` file - we may wish to move the metadata into `tables/`, but I am not sure if the benefit outweighs the trade-off of leaking dummy data-specific attributes into the query model.~ 


### Profiling
Manual profiling done with the repos highlighted in yellow in [this spreadsheet](https://docs.google.com/spreadsheets/d/1WOqgBBuB0nAhasygD-N6biPE3YHsw2933KvdBRXPY54/edit?gid=191444011#gid=191444011). 
None of the runs showed significant decrease in the cumulative time per call of the `get_patient_data` method. 
Eyeballing, it seems like the number of patients generated is also around the same, i.e. there is no improvement.