### PR TITLE
Use `CastToInt` rather than `Case` expression

### DIFF
--- a/ehrql/query_model/transforms.py
+++ b/ehrql/query_model/transforms.py
@@ -20,7 +20,6 @@ from typing import Any
 
 from ehrql.query_model.introspection import all_unique_nodes
 from ehrql.query_model.nodes import (
-    Case,
     Function,
     Parameter,
     PickOneRowPerPatient,
@@ -173,10 +172,9 @@ def calculate_sorts_to_add(all_sorts, selected_column_names):
 
 def make_sortable(col):
     if get_series_type(col) is bool:
-        # Some databases can't sort booleans (including SQL Server), so we map them to integers
-        return Case(
-            cases={col: Value(2), Function.Not(col): Value(1)}, default=Value(0)
-        )
+        # Some databases can't sort booleans (including SQL Server), so we cast them to
+        # integers
+        return Function.CastToInt(col)
     return col
 
 

--- a/tests/unit/query_model/test_transforms.py
+++ b/tests/unit/query_model/test_transforms.py
@@ -1,7 +1,6 @@
 import datetime
 
 from ehrql.query_model.nodes import (
-    Case,
     Column,
     Dataset,
     Filter,
@@ -262,9 +261,7 @@ def test_maps_booleans_to_a_sortable_type():
     )
 
     b = SelectColumn(events, "b")
-    by_b = Sort(
-        events, Case({b: Value(2), Function.Not(b): Value(1)}, default=Value(0))
-    )
+    by_b = Sort(events, Function.CastToInt(b))
     by_b_then_i = Sort(by_b, SelectColumn(events, "i"))
     expected = SelectColumn(
         PickOneRowPerPatientWithColumns(


### PR DESCRIPTION
This cast operation didn't exist when this code was originally written, but it does now and should be faster.

Casting gives us:

    NULL  -> NULL
    FALSE -> 0
    TRUE  -> 1

And given that NULLs are specified as sorting first in ehrQL, this gives us exactly the same sort order as we had previously.