### PR TITLE
fix: Exit with non-zero code if assurance tests fail

### DIFF
--- a/ehrql/__main__.py
+++ b/ehrql/__main__.py
@@ -12,6 +12,7 @@ from argparse import (
 from pathlib import Path
 
 from ehrql import __version__
+from ehrql.assurance import AssuranceTestError
 from ehrql.file_formats import (
     FILE_FORMATS,
     FileValidationError,
@@ -132,6 +133,10 @@ def main(args, environ=None):
     except EHRQLPermissionError as exc:
         print(f"{exc.__class__.__name__}: {exc}", file=sys.stderr)
         sys.exit(12)
+    except AssuranceTestError as exc:
+        # Handle errors from failed assurarance tests
+        print(f"{exc.__class__.__name__}: {exc}", file=sys.stderr)
+        sys.exit(13)
     except Exception as exc:
         # For functions which take a `backend_class` give that class the chance to set
         # the appropriate exit status for any errors

--- a/ehrql/assurance.py
+++ b/ehrql/assurance.py
@@ -14,6 +14,9 @@ UNEXPECTED_NOT_IN_POPULATION = "unexpected-not-in-population"
 UNEXPECTED_OUTPUT_VALUE = "unexpected-output-value"
 
 
+class AssuranceTestError(Exception): ...
+
+
 def validate(dataset, test_data):
     """Validates that the given test data
     (1) meet the constraints in the tables and

--- a/ehrql/main.py
+++ b/ehrql/main.py
@@ -341,7 +341,10 @@ def read_measure_results(input_file, measure_definitions):
 def assure(test_data_file, environ, user_args):
     dataset, test_data = load_test_definition(test_data_file, user_args, environ)
     results = assurance.validate(dataset, test_data)
-    print(assurance.present(results))
+    formatted_results = assurance.present(results)
+    if any(results.values()):
+        raise assurance.AssuranceTestError("\n" + formatted_results)
+    print(formatted_results)
 
 
 def debug_dataset_definition(

--- a/tests/functional/test_assure.py
+++ b/tests/functional/test_assure.py
@@ -1,5 +1,9 @@
 from pathlib import Path
 
+import pytest
+
+from tests.lib.inspect_utils import function_body_as_string
+
 
 FIXTURES_PATH = Path(__file__).parents[1] / "fixtures" / "good_definition_files"
 
@@ -7,3 +11,31 @@ FIXTURES_PATH = Path(__file__).parents[1] / "fixtures" / "good_definition_files"
 def test_assure(call_cli):
     captured = call_cli("assure", FIXTURES_PATH / "assurance.py")
     assert "All OK" in captured.out
+
+
+def test_assure_with_test_failures(call_cli, tmp_path):
+    @function_body_as_string
+    def dataset_definition_with_tests():
+        from ehrql import create_dataset
+        from ehrql.tables.core import patients
+
+        dataset = create_dataset()
+        dataset.define_population(patients.sex == "female")
+
+        test_data = {  # noqa: F841
+            1: {
+                "patients": {"sex": "male"},
+                "expected_in_population": True,
+            },
+        }
+
+    test_data_file = tmp_path / "dataset_definition.py"
+    test_data_file.write_text(dataset_definition_with_tests)
+
+    with pytest.raises(SystemExit):
+        call_cli("assure", test_data_file)
+    output = call_cli.readouterr().err
+    # Assurance test results are written to stderr
+    assert "AssuranceTestError" in output
+    assert "Validate test data: All OK!" in output
+    assert "Validate results: Found errors with 1 patient" in output

--- a/tests/functional/test_generate_dataset.py
+++ b/tests/functional/test_generate_dataset.py
@@ -384,6 +384,45 @@ def test_generate_dataset_with_test_data_file(call_cli, tmp_path):
     assert len(output_file.read_text()) > 0
 
 
+def test_generate_dataset_with_test_data_file_with_test_failures(call_cli, tmp_path):
+    @function_body_as_string
+    def dataset_definition_with_tests():
+        from ehrql import create_dataset
+        from ehrql.tables.core import patients
+
+        dataset = create_dataset()
+        dataset.define_population(patients.sex == "female")
+
+        test_data = {  # noqa: F841
+            1: {
+                "patients": {"sex": "male"},
+                "expected_in_population": True,
+            },
+        }
+
+    test_data_file = tmp_path / "dataset_definition.py"
+    test_data_file.write_text(dataset_definition_with_tests)
+    output_file = tmp_path / "output.csv"
+
+    with pytest.raises(SystemExit):
+        call_cli(
+            "generate-dataset",
+            test_data_file,
+            "--output",
+            output_file,
+            "--test-data-file",
+            test_data_file,
+        )
+    output = call_cli.readouterr().err
+    # Assurance test results are written to stderr
+    assert "AssuranceTestError" in output
+    assert "Validate test data: All OK!" in output
+    assert "Validate results: Found errors with 1 patient" in output
+
+    # Output file was not generated
+    assert not output_file.exists()
+
+
 def test_generate_dataset_with_event_level_data(sqlite_engine, call_cli, tmp_path):
     engine = sqlite_engine
     extension = "csv"


### PR DESCRIPTION
Exit with a non-zero code if assurance tests fail; the test errors are still printed to the console as before, but the exit code will make a generate-dataset action fail when it is passed a --test-data-file and the tests do not pass. This means that when a user runs such an action with `opensafely run`, the action will fail and the logs will be tailed, so the test errors will be shown on the console. Previously, the action would pass, and the printed test errors would appear in the log file only, which wasn't immediately obvious to users.

Test errors exit with a new code 13; a subsequent job-runner PR will be needed to handle that code and report to the user that the job failure is due to test errors (in the event that a user runs a real job with broken tests).

Fixes #2643 