### PR TITLE
Use preferred method to get container IP address

### DIFF
--- a/tests/lib/docker.py
+++ b/tests/lib/docker.py
@@ -41,10 +41,11 @@ class Containers:
 
     def get_container_ip(self, name):
         """
-        Given a container name, return it IP address
+        Given a container name, return its IP address
         """
         container = self.get_container(name)
-        return container.attrs["NetworkSettings"]["IPAddress"]
+        networks = container.attrs["NetworkSettings"]["Networks"].values()
+        return list(networks)[0]["IPAddress"]
 
     # All available arguments documented here:
     # https://docker-py.readthedocs.io/en/stable/containers.html#docker.models.containers.ContainerCollection.run


### PR DESCRIPTION
Tests have just started failing in CI because `NetworkSettings.IPAddress` is no longer available. Apparently we shouldn't have been using this anyway and the correct way is to walk the networks in `NetworkSettings.Networks`. See:
https://github.com/moby/moby/issues/21658#issuecomment-203527083