### PR TITLE
Use appropriate exit code for CLI argument errors

### DIFF
--- a/ehrql/__main__.py
+++ b/ehrql/__main__.py
@@ -106,7 +106,7 @@ def main(args, environ=None):
             ),
             file=sys.stderr,
         )
-        sys.exit(1)
+        sys.exit(2)
 
     kwargs = vars(namespace)
 


### PR DESCRIPTION
Argparse will exit with status 2 on argument errors (see [docs](https://docs.python.org/3/library/argparse.html#exit-on-error)) and so for consistency we should do the same.

This makes it easier to provide feedback to users on why their job has failed in the secure environment where we can't export the error output itself.

See Slack thread:
https://bennettoxford.slack.com/archives/C0A8WAJMK0S/p1773064464856679