### PR TITLE
Link to OpenSAFELY data page from TPP backend docs

### DIFF
--- a/docs/includes/generated_docs/backends.md
+++ b/docs/includes/generated_docs/backends.md
@@ -29,6 +29,12 @@ A patient can be registered with zero, one, or more than one practices at a give
 time. For instance, students are often registered with a practice at home and a
 practice at university.
 
+Patients with [Type 1 Opt Outs](https://docs.opensafely.org/type-one-opt-outs/) or
+[National Data Opt Outs](https://docs.opensafely.org/national-data-opt-outs/) are
+excluded unless an OpenSAFELY project has permission to access these data. For further
+information, see the [OpenSAFELY data](https://docs.opensafely.org/opensafely-data/)
+documentation.
+
 !!! warning
     Refer to the [discussion of selecting populations for studies](../explanation/selecting-populations-for-study.md).
 

--- a/ehrql/backends/tpp.py
+++ b/ehrql/backends/tpp.py
@@ -47,6 +47,12 @@ class TPPBackend(SQLBackend):
     time. For instance, students are often registered with a practice at home and a
     practice at university.
 
+    Patients with [Type 1 Opt Outs](https://docs.opensafely.org/type-one-opt-outs/) or
+    [National Data Opt Outs](https://docs.opensafely.org/national-data-opt-outs/) are
+    excluded unless an OpenSAFELY project has permission to access these data. For further
+    information, see the [OpenSAFELY data](https://docs.opensafely.org/opensafely-data/)
+    documentation.
+
     !!! warning
         Refer to the [discussion of selecting populations for studies](../explanation/selecting-populations-for-study.md).
     """


### PR DESCRIPTION
The data page is currently a placeholder. I've linked also to the existing T1OO and NDOO pages; these may end up in the new data page/section, but should have redirects when they do. Presumably these pages will also apply to the Emis backend in some way, but currently we don't have details about exactly how, so I'm leaving that for later.

Closes #2694 