### PR TITLE
Remove NDOO feature flag

### DIFF
--- a/ehrql/backends/tpp.py
+++ b/ehrql/backends/tpp.py
@@ -132,10 +132,6 @@ class TPPBackend(SQLBackend):
         return parse.urlunparse(new_parts)
 
     def modify_dataset(self, dataset):
-        # This isn't really a permission, it's an indication of whether we should
-        # check for NDOO permissions and apply NDOO filtering at all
-        apply_ndoo = "apply_ndoo" in self.permissions
-
         # Check the explicitly set permissions to determine if we can include NDOOs
         include_ndoo = "include_ndoo" in self.permissions
 
@@ -169,7 +165,7 @@ class TPPBackend(SQLBackend):
                 )
             )
 
-        if apply_ndoo and not include_ndoo:
+        if not include_ndoo:
             # PLEASE NOTE: This logic is referenced in our public documentation, so if we
             # make any changes here we should ensure that the documentation is kept
             # up-to-date:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -354,11 +354,13 @@ def call_cli(capsys):
     Wrapper around the CLI entrypoint to make it easier to call from tests
     """
 
-    def call(*args, environ=None, permissions=("include_gp_unactivated",)):
-        # Most tests need to have the "include_gp_unactivated" permission so that
-        # they don't need to include test setup for practice registrations and organisations
-        # in order to include patients. To make test calls simpler, we add this
-        # permission in by default.
+    def call(
+        *args, environ=None, permissions=("include_gp_unactivated", "include_ndoo")
+    ):
+        # Most tests need to have the "include_gp_unactivated" and "include_ndoo" permissions so that
+        # they don't need to include test setup for practice registrations,  organisations and NDOO
+        # in order to include patients. To make test calls simpler, we add these
+        # permissions in by default.
         environ = environ or {}
         add_permissions_to_environment(environ, permissions)
 
@@ -381,7 +383,9 @@ def call_cli_docker(containers, ehrql_image):
 
     def call(*args, environ=None, workspace=None):
         environ = environ or {}
-        add_permissions_to_environment(environ, ("include_gp_unactivated",))
+        add_permissions_to_environment(
+            environ, ("include_gp_unactivated", "include_ndoo")
+        )
         args = [
             # Make any paths relative to the workspace directory so they still point to
             # the right place inside Docker. If you supply path arguments and no

--- a/tests/functional/test_generate_dataset.py
+++ b/tests/functional/test_generate_dataset.py
@@ -731,23 +731,13 @@ def test_generate_dataset_does_not_warn_when_permission_claimed(
     "environ,expected",
     [
         (
-            # no permissions, no feature flag - includes NDOO
+            # no permissions - excludes NDOO
             {},
             ["2001", "2002", "2003"],
         ),
-        # permission, but no feature flag - includes NDOO
+        # with permission - includes NDOO
         (
             {"EHRQL_PERMISSIONS": '["include_ndoo"]'},
-            ["2001", "2002", "2003"],
-        ),
-        # feature flag, no permission - excludes NDOO
-        (
-            {"EHRQL_PERMISSIONS": '["apply_ndoo"]'},
-            ["2002", "2003"],
-        ),
-        # feature flag, with permission - includes NDOO
-        (
-            {"EHRQL_PERMISSIONS": '["include_ndoo", "apply_ndoo"]'},
             ["2001", "2002", "2003"],
         ),
     ],
@@ -859,7 +849,7 @@ def test_generate_dataset_with_gp_unactivated_permissions(
         "--dsn",
         mssql_database.host_url(),
         environ=environ,
-        permissions=(),
+        permissions=("include_ndoo",),
     )
 
     results = read_file_as_dicts(output_path)

--- a/tests/integration/backends/test_tpp.py
+++ b/tests/integration/backends/test_tpp.py
@@ -3167,7 +3167,7 @@ def test_is_in_queries_on_columns_with_nonstandard_collation(
         "EHRQL_MAX_MULTIVALUE_PARAM_LENGTH": 1,
         "TEMP_DATABASE_NAME": "temp_tables",
     }
-    add_permissions_to_environment(environ, ("include_gp_unactivated",))
+    add_permissions_to_environment(environ, ("include_gp_unactivated", "include_ndoo"))
     results = mssql_engine.extract(
         dataset,
         # Configure query engine to always break out lists into temporary tables so we
@@ -3213,7 +3213,9 @@ def test_t1oo_patients_excluded_as_specified(mssql_database, suffix, expected):
     dataset.define_population(tpp.patients.date_of_birth.is_not_null())
     dataset.birth_year = tpp.patients.date_of_birth.year
     backend = TPPBackend(
-        environ=add_permissions_to_environment({}, ("include_gp_unactivated",))
+        environ=add_permissions_to_environment(
+            {}, ("include_gp_unactivated", "include_ndoo")
+        )
     )
     query_engine = backend.get_query_engine(mssql_database.host_url() + suffix)
     results = query_engine.get_results(dataset._compile())
@@ -3224,23 +3226,13 @@ def test_t1oo_patients_excluded_as_specified(mssql_database, suffix, expected):
 @pytest.mark.parametrize(
     "environ,expected",
     [
-        # apply_ndoo feature flag "permission" sent
-        (
-            {"EHRQL_PERMISSIONS": '["include_ndoo", "apply_ndoo"]'},
-            [(1, 2001), (2, 2002), (3, 2003), (4, 2004)],
-        ),
-        (
-            {"EHRQL_PERMISSIONS": '["apply_ndoo"]'},
-            [(1, 2001), (4, 2004)],
-        ),
-        # apply_ndoo feature flag "permission" not sent
         (
             {"EHRQL_PERMISSIONS": '["include_ndoo"]'},
             [(1, 2001), (2, 2002), (3, 2003), (4, 2004)],
         ),
         (
             {},
-            [(1, 2001), (2, 2002), (3, 2003), (4, 2004)],
+            [(1, 2001), (4, 2004)],
         ),
     ],
 )
@@ -3362,6 +3354,7 @@ def test_patients_from_non_activated_practices_excluded_as_specified(
     dataset.define_population(tpp.patients.date_of_birth.is_not_null())
     dataset.birth_year = tpp.patients.date_of_birth.year
 
+    add_permissions_to_environment(environ, ("include_ndoo",))
     backend = TPPBackend(environ=environ)
     query_engine = backend.get_query_engine(mssql_database.host_url())
     results = query_engine.get_results(dataset._compile())
@@ -3499,7 +3492,8 @@ def test_clinical_events_for_patients_from_non_activated_practices_excluded_as_s
     )
 
     # include_gp_unactivated permission not sent, GP filtering applied by default
-    backend = TPPBackend()
+    environ = add_permissions_to_environment({}, ("include_ndoo",))
+    backend = TPPBackend(environ=environ)
     query_engine = backend.get_query_engine(mssql_database.host_url())
     results = query_engine.get_results(dataset._compile())
 
@@ -3628,7 +3622,8 @@ def test_clinical_events_ranges_for_patients_from_non_activated_practices_exclud
     )
 
     # include_gp_unactivated permission not sent, GP filtering applied by default
-    backend = TPPBackend()
+    environ = add_permissions_to_environment({}, ("include_ndoo",))
+    backend = TPPBackend(environ=environ)
     query_engine = backend.get_query_engine(mssql_database.host_url())
     results = query_engine.get_results(dataset._compile())
 
@@ -3738,7 +3733,10 @@ def test_medications_for_patients_from_non_activated_practices_excluded_as_speci
     )
 
     # include_gp_unactivated permission not sent, GP filtering applied by default
-    backend = TPPBackend(environ={"TEMP_DATABASE_NAME": "temp_tables"})
+    environ = add_permissions_to_environment(
+        {"TEMP_DATABASE_NAME": "temp_tables"}, ("include_ndoo",)
+    )
+    backend = TPPBackend(environ=environ)
     query_engine = backend.get_query_engine(mssql_database.host_url())
     results = query_engine.get_results(dataset._compile())
 
@@ -3845,7 +3843,8 @@ def test_vaccinations_for_patients_from_non_activated_practices_excluded_as_spec
     )
 
     # include_gp_unactivated permission not sent, GP filtering applied by default
-    backend = TPPBackend()
+    environ = add_permissions_to_environment({}, ("include_ndoo",))
+    backend = TPPBackend(environ=environ)
     query_engine = backend.get_query_engine(mssql_database.host_url())
     results = query_engine.get_results(dataset._compile())
 
@@ -3954,7 +3953,8 @@ def test_appointments_for_patients_from_non_activated_practices_excluded_as_spec
     )
 
     # include_gp_unactivated permission not sent, GP filtering applied by default
-    backend = TPPBackend()
+    environ = add_permissions_to_environment({}, ("include_ndoo",))
+    backend = TPPBackend(environ=environ)
     query_engine = backend.get_query_engine(mssql_database.host_url())
     results = query_engine.get_results(dataset._compile())
 
@@ -4122,7 +4122,10 @@ def test_practice_registrations_non_activated_practices_excluded_as_specified(
     )
 
     # include_gp_unactivated permission not sent, GP filtering applied by default
-    backend = TPPBackend()
+    environ = add_permissions_to_environment(
+        {"TEMP_DATABASE_NAME": "temp_tables"}, ("include_ndoo",)
+    )
+    backend = TPPBackend(environ=environ)
     query_engine = backend.get_query_engine(mssql_database.host_url())
     results = query_engine.get_results(dataset._compile())
     assert list(results) == [
@@ -4299,7 +4302,10 @@ def test_practice_registrations_and_clinical_events_excluded_as_specified(
     dataset.clinical_event_count = tpp.clinical_events.count_for_patient()
 
     # include_gp_unactivated permission not sent, GP filtering applied by default
-    backend = TPPBackend()
+    environ = add_permissions_to_environment(
+        {"TEMP_DATABASE_NAME": "temp_tables"}, ("include_ndoo",)
+    )
+    backend = TPPBackend(environ=environ)
     query_engine = backend.get_query_engine(mssql_database.host_url())
     results = query_engine.get_results(dataset._compile())
     results = list(results)
@@ -4328,22 +4334,22 @@ def test_practice_registrations_and_clinical_events_excluded_as_specified(
     [
         (
             "?opensafely_include_t1oo=false",
-            {"EHRQL_PERMISSIONS": '["include_ndoo", "apply_ndoo"]'},
+            {"EHRQL_PERMISSIONS": '["include_ndoo"]'},
             [(1, 2001), (3, 2003)],
         ),
         (
             "?opensafely_include_t1oo=true",
-            {"EHRQL_PERMISSIONS": '["include_ndoo", "apply_ndoo"]'},
+            {"EHRQL_PERMISSIONS": '["include_ndoo"]'},
             [(1, 2001), (2, 2002), (3, 2003), (4, 2004)],
         ),
         (
             "?opensafely_include_t1oo=false",
-            {"EHRQL_PERMISSIONS": '["apply_ndoo"]'},
+            {},
             [(1, 2001)],
         ),
         (
             "?opensafely_include_t1oo=true",
-            {"EHRQL_PERMISSIONS": '["apply_ndoo"]'},
+            {},
             [(1, 2001), (4, 2004)],
         ),
     ],
@@ -4482,11 +4488,13 @@ def test_core_tables_filtered_as_specified(
     )
 
     # include_gp_unactivated permission not sent, GP filtering applied by default
-    backend = TPPBackend(
-        environ={
+    environ = add_permissions_to_environment(
+        {
             "TEMP_DATABASE_NAME": "temp_tables",
-        }
+        },
+        ("include_ndoo",),
     )
+    backend = TPPBackend(environ=environ)
     query_engine = backend.get_query_engine(mssql_database.host_url())
     results = query_engine.get_results(dataset._compile())
 


### PR DESCRIPTION
Permissions for NDOOs are now maintained in job-server and passed to the RAP controller when a job is requested.
https://github.com/opensafely-core/job-server/blob/bdf28d9ca76cb67277ace6027730fd5fe2da0329/jobserver/permissions/population_permissions/ndoo.py

All COVID projects are allowed to access NDOO, so, similarly to the GP activations, we can remove the feature flag. Although the DB changes haven't yet been made, any job that runs now is expected to be a COVID project that is in the permission list, and so won't need to use the NDOO table. Removing the feature flag now simplifies the work needed to test things when the new tables become available.