### PR TITLE
Minimal emisv2 backend

### DIFF
--- a/ehrql/__main__.py
+++ b/ehrql/__main__.py
@@ -51,6 +51,7 @@ QUERY_ENGINE_ALIASES = {
 
 BACKEND_ALIASES = {
     "emis": "ehrql.backends.emis.EMISBackend",
+    "emisv2": "ehrql.backends.emisv2.EMISV2Backend",
     "tpp": "ehrql.backends.tpp.TPPBackend",
 }
 

--- a/ehrql/backends/emisv2.py
+++ b/ehrql/backends/emisv2.py
@@ -1,0 +1,28 @@
+import ehrql.tables.smoketest
+from ehrql.backends.base import QueryTable, SQLBackend
+from ehrql.query_engines.trino import TrinoQueryEngine
+
+
+class EMISV2Backend(SQLBackend):
+    """
+    [Optum](https://www.optum.co.uk/) are the developers and operators of the [EMIS
+    Web](https://www.emishealth.com/emis-web) EHR platform. The ehrQL EMIS backend
+    provides access to primary care data from EMIS Web, plus data linked from other
+    sources.
+    """
+
+    display_name = "EMISV2"
+    query_engine_class = TrinoQueryEngine
+    patient_join_column = "patient_id"
+    implements = [
+        ehrql.tables.smoketest,
+    ]
+
+    patients = QueryTable(
+        """
+        SELECT
+            patient_id AS patient_id,
+            date_of_birth
+        FROM patient
+        """
+    )

--- a/ehrql/query_engines/trino.py
+++ b/ehrql/query_engines/trino.py
@@ -139,6 +139,10 @@ class TrinoQueryEngine(BaseSQLQueryEngine):
         return table
 
     def reify_query(self, query):
+        # We currently don't have permission to create tables in the EMIS
+        # staging db.
+        if self.backend.display_name == "EMISV2":
+            return query.alias()
         table_name = f"ehrql_{self.global_unique_id}_tmp_{self.get_next_id()}"
         query = self.backend.modify_query_pre_reify(query)
         table = GeneratedTable.from_query(table_name, query)


### PR DESCRIPTION
The absolute minimum needed to create an EMIS V2 backend that can be used to run the smoketest dataset definition against the EMIS test database.

To test the connection:
```
ehrql test-connection --backend emisv2 --url trino://<username>:<token>@explorerplus.stagingemisinsights.co.uk:443/hive/explorer_open_safely
```

To run the smoketest dataset definition:
```
ehrql generate-dataset tests/acceptance/external_studies/test-age-distribution/analysis/dataset_definition.py --backend emisv2 --query-engine trino --dsn trino://<username>:<token>@explorerplus.stagingemisinsights.co.uk:443/hive/explorer_open_safely
```

We don't have permission to create tables in the test db, hence the change to the Trino query engine; we should assume we will have that permission eventually, so that's just a workaround to get it working.

The patient table in the test db also has no date_of_birth values (it's null for every patient), so if you want to see it return anything from the smoketest dataset definition, you'll need to modify the population definition there.