### PR TITLE
Define ORM objects for EMIS v2 observations and medications tables

### DIFF
--- a/tests/backend_schemas/emisv2/schema.py
+++ b/tests/backend_schemas/emisv2/schema.py
@@ -7,9 +7,28 @@ class Base(DeclarativeBase):
     "Common base class to signal that models below belong to the same database"
 
 
+class MedicationIssueRecord(Base):
+    __tablename__ = "medication_issue_record"
+    _pk = mapped_column(t.Integer, primary_key=True)
+
+    patient_id = mapped_column(t.VARBINARY())
+    dmd_product_code_id = mapped_column(t.BIGINT())
+    effective_datetime = mapped_column(trdt.TIMESTAMP(precision=6, timezone=True))
+
+
 class Patient(Base):
     __tablename__ = "patient"
     _pk = mapped_column(t.Integer, primary_key=True)
 
     patient_id = mapped_column(t.VARBINARY(), unique=True)
     date_of_birth = mapped_column(trdt.TIMESTAMP(precision=6))
+
+
+class Observation(Base):
+    __tablename__ = "observation"
+    _pk = mapped_column(t.Integer, primary_key=True)
+
+    patient_id = mapped_column(t.VARBINARY())
+    effective_datetime = mapped_column(trdt.TIMESTAMP(precision=6, timezone=True))
+    numeric_value = mapped_column(t.DECIMAL(precision=19, scale=3))
+    snomed_concept_id = mapped_column(t.BIGINT())

--- a/tests/backend_schemas/emisv2/schema.py
+++ b/tests/backend_schemas/emisv2/schema.py
@@ -1,5 +1,6 @@
 from sqlalchemy import types as t
 from sqlalchemy.orm import DeclarativeBase, mapped_column
+from trino.sqlalchemy import datatype as trdt
 
 
 class Base(DeclarativeBase):
@@ -10,5 +11,5 @@ class Patient(Base):
     __tablename__ = "patient"
     _pk = mapped_column(t.Integer, primary_key=True)
 
-    patient_id = mapped_column(t.VARBINARY(16), unique=True)
-    date_of_birth = mapped_column(t.DateTime)
+    patient_id = mapped_column(t.VARBINARY(), unique=True)
+    date_of_birth = mapped_column(trdt.TIMESTAMP(precision=6))

--- a/tests/backend_schemas/emisv2/schema.py
+++ b/tests/backend_schemas/emisv2/schema.py
@@ -7,11 +7,21 @@ class Base(DeclarativeBase):
     "Common base class to signal that models below belong to the same database"
 
 
+class Consultation(Base):
+    __tablename__ = "consultation"
+    _pk = mapped_column(t.Integer, primary_key=True)
+
+    patient_id = mapped_column(t.VARBINARY())
+    consultation_id = mapped_column(t.VARBINARY(), unique=True)
+    effective_datetime = mapped_column(trdt.TIMESTAMP(precision=6, timezone=True))
+
+
 class MedicationIssueRecord(Base):
     __tablename__ = "medication_issue_record"
     _pk = mapped_column(t.Integer, primary_key=True)
 
     patient_id = mapped_column(t.VARBINARY())
+    consultation_id = mapped_column(t.VARBINARY())
     dmd_product_code_id = mapped_column(t.BIGINT())
     effective_datetime = mapped_column(trdt.TIMESTAMP(precision=6, timezone=True))
 
@@ -29,6 +39,7 @@ class Observation(Base):
     _pk = mapped_column(t.Integer, primary_key=True)
 
     patient_id = mapped_column(t.VARBINARY())
+    consultation_id = mapped_column(t.VARBINARY())
     effective_datetime = mapped_column(trdt.TIMESTAMP(precision=6, timezone=True))
     numeric_value = mapped_column(t.DECIMAL(precision=19, scale=3))
     snomed_concept_id = mapped_column(t.BIGINT())

--- a/tests/unit/backend_schemas/test_emisv2.py
+++ b/tests/unit/backend_schemas/test_emisv2.py
@@ -15,19 +15,59 @@ def test_schema():
     engine = sqlalchemy.create_engine("sqlite+pysqlite:///:memory:")
     schema.Base.metadata.create_all(engine)
 
+    new_medication_issue_record = schema.MedicationIssueRecord(
+        patient_id=bytes(range(16)),
+        dmd_product_code_id=12354611500001104,
+        effective_datetime=datetime.datetime(
+            2023, 5, 12, 14, 30, 15, 0, tzinfo=datetime.UTC
+        ),
+    )
     new_patient = schema.Patient(
         patient_id=bytes(range(16)),
         date_of_birth=datetime.datetime(2023, 5, 1, 0, 0, 0, 0),
     )
+    new_observation = schema.Observation(
+        patient_id=bytes(range(16)),
+        effective_datetime=datetime.datetime(
+            2023, 5, 12, 14, 30, 15, 0, tzinfo=datetime.UTC
+        ),
+        numeric_value=80.0,
+        snomed_concept_id=123456789,
+    )
     with sqlalchemy.orm.Session(engine) as session:
+        session.add(new_medication_issue_record)
         session.add(new_patient)
+        session.add(new_observation)
         session.commit()
+        selected_medication_issue_record = session.execute(
+            sqlalchemy.select(schema.MedicationIssueRecord)
+        ).scalar_one()
         selected_patient = session.execute(
             sqlalchemy.select(schema.Patient)
         ).scalar_one()
+        selected_observation = session.execute(
+            sqlalchemy.select(schema.Observation)
+        ).scalar_one()
 
+    # SQLite does not support timezone-aware datetimes
+    # so in these assertions we have to ignore the timezone
     assert selected_patient._pk == 1
     assert selected_patient.patient_id == bytes(range(16))
     assert selected_patient.date_of_birth == datetime.datetime(2023, 5, 1, 0, 0, 0, 0)
+
+    assert selected_medication_issue_record._pk == 1
+    assert selected_medication_issue_record.patient_id == bytes(range(16))
+    assert selected_medication_issue_record.dmd_product_code_id == 12354611500001104
+    assert selected_medication_issue_record.effective_datetime == datetime.datetime(
+        2023, 5, 12, 14, 30, 15, 0
+    )
+
+    assert selected_observation._pk == 1
+    assert selected_observation.patient_id == bytes(range(16))
+    assert selected_observation.effective_datetime == datetime.datetime(
+        2023, 5, 12, 14, 30, 15, 0
+    )
+    assert selected_observation.numeric_value == 80.0
+    assert selected_observation.snomed_concept_id == 123456789
 
     engine.dispose()

--- a/tests/unit/backend_schemas/test_emisv2.py
+++ b/tests/unit/backend_schemas/test_emisv2.py
@@ -3,29 +3,31 @@ import datetime
 import sqlalchemy
 import sqlalchemy.orm
 
-from tests.backend_schemas.emisv2.schema import Base, Patient
+from tests.backend_schemas.emisv2 import schema
 
 
-def test_patient():
+def test_schema():
     """
     Validate that the patient table is correctly defined.
     This is a temporary test since we do not have a EMIS v2 backend yet;
     when we have one, this test can be removed.
     """
     engine = sqlalchemy.create_engine("sqlite+pysqlite:///:memory:")
-    Base.metadata.create_all(engine)
+    schema.Base.metadata.create_all(engine)
 
-    new_patient = Patient(
+    new_patient = schema.Patient(
         patient_id=bytes(range(16)),
         date_of_birth=datetime.datetime(2023, 5, 1, 0, 0, 0, 0),
     )
     with sqlalchemy.orm.Session(engine) as session:
         session.add(new_patient)
         session.commit()
-        result = session.execute(sqlalchemy.select(Patient)).scalar_one()
+        selected_patient = session.execute(
+            sqlalchemy.select(schema.Patient)
+        ).scalar_one()
 
-    assert result._pk == 1
-    assert result.patient_id == bytes(range(16))
-    assert result.date_of_birth == datetime.datetime(2023, 5, 1, 0, 0, 0, 0)
+    assert selected_patient._pk == 1
+    assert selected_patient.patient_id == bytes(range(16))
+    assert selected_patient.date_of_birth == datetime.datetime(2023, 5, 1, 0, 0, 0, 0)
 
     engine.dispose()

--- a/tests/unit/backend_schemas/test_emisv2.py
+++ b/tests/unit/backend_schemas/test_emisv2.py
@@ -15,8 +15,16 @@ def test_schema():
     engine = sqlalchemy.create_engine("sqlite+pysqlite:///:memory:")
     schema.Base.metadata.create_all(engine)
 
+    new_consultation = schema.Consultation(
+        patient_id=bytes(range(16)),
+        consultation_id=bytes(range(1, 17)),
+        effective_datetime=datetime.datetime(
+            2023, 5, 12, 14, 30, 15, 0, tzinfo=datetime.UTC
+        ),
+    )
     new_medication_issue_record = schema.MedicationIssueRecord(
         patient_id=bytes(range(16)),
+        consultation_id=bytes(range(1, 17)),
         dmd_product_code_id=12354611500001104,
         effective_datetime=datetime.datetime(
             2023, 5, 12, 14, 30, 15, 0, tzinfo=datetime.UTC
@@ -28,6 +36,7 @@ def test_schema():
     )
     new_observation = schema.Observation(
         patient_id=bytes(range(16)),
+        consultation_id=bytes(range(1, 17)),
         effective_datetime=datetime.datetime(
             2023, 5, 12, 14, 30, 15, 0, tzinfo=datetime.UTC
         ),
@@ -35,10 +44,14 @@ def test_schema():
         snomed_concept_id=123456789,
     )
     with sqlalchemy.orm.Session(engine) as session:
+        session.add(new_consultation)
         session.add(new_medication_issue_record)
         session.add(new_patient)
         session.add(new_observation)
         session.commit()
+        selected_consultation = session.execute(
+            sqlalchemy.select(schema.Consultation)
+        ).scalar_one()
         selected_medication_issue_record = session.execute(
             sqlalchemy.select(schema.MedicationIssueRecord)
         ).scalar_one()
@@ -55,8 +68,16 @@ def test_schema():
     assert selected_patient.patient_id == bytes(range(16))
     assert selected_patient.date_of_birth == datetime.datetime(2023, 5, 1, 0, 0, 0, 0)
 
+    assert selected_consultation._pk == 1
+    assert selected_consultation.patient_id == bytes(range(16))
+    assert selected_consultation.consultation_id == bytes(range(1, 17))
+    assert selected_consultation.effective_datetime == datetime.datetime(
+        2023, 5, 12, 14, 30, 15, 0
+    )
+
     assert selected_medication_issue_record._pk == 1
     assert selected_medication_issue_record.patient_id == bytes(range(16))
+    assert selected_medication_issue_record.consultation_id == bytes(range(1, 17))
     assert selected_medication_issue_record.dmd_product_code_id == 12354611500001104
     assert selected_medication_issue_record.effective_datetime == datetime.datetime(
         2023, 5, 12, 14, 30, 15, 0
@@ -64,6 +85,7 @@ def test_schema():
 
     assert selected_observation._pk == 1
     assert selected_observation.patient_id == bytes(range(16))
+    assert selected_observation.consultation_id == bytes(range(1, 17))
     assert selected_observation.effective_datetime == datetime.datetime(
         2023, 5, 12, 14, 30, 15, 0
     )


### PR DESCRIPTION
Closes #2725.

The schemas were added semi-manually in that column types were obtained via connecting to EMIS's staging environment, and cross-referenced with the spreadsheet provided by the Optum team.

The types were obtained by extending @rebkwok's [jupyter notebook](https://bennettoxford.slack.com/archives/C069YDR4NCA/p1774888903845419?thread_ts=1774888888.836169&cid=C069YDR4NCA) and adding a cell that pulls out the columns using `sqlalchemy.inspect(engine).get_columns(schema=schema, table_name=table_name)`. 

The cell's code is [here](https://gist.github.com/alarthast/92364358484e6f37adbdbb426c32342f), where the `schema` and `table_names` used for this extraction were `"explorer_open_safely"` and  `['patient','medication_issue_record', 'observation','consultation']` respectively.
I leave it up to the reviewer of this PR to decided whether to review the code snippet as well: I think it is reasonable to choose to only review the added schema definitions themselves, which I have checked to be consistent with the information in the spreadsheet linked in the ticket. 

Based on [this slack conversation](https://bennettoxford.slack.com/archives/C069YDR4NCA/p1774869984253079?thread_ts=1774609198.472489&cid=C069YDR4NCA) about the possibility that we might use consultation datetime for medications and observations instead of the `effective_datetime` values on the tables themselves, I have added a commit that defines the consultation ORM object as well.