### PR TITLE
Use correct temporary schema for EMISV2 backend

### DIFF
--- a/ehrql/backends/base.py
+++ b/ehrql/backends/base.py
@@ -24,6 +24,13 @@ class BaseBackend:
         """
         return dsn
 
+    def modify_temp_table_schema(self, temp_table_schema, dsn, environ):
+        """
+        This hook gives backends the option to modify the name of the database schema in
+        which temporary tables get created
+        """
+        return temp_table_schema
+
     def modify_dataset(self, dataset: qm.Dataset) -> qm.Dataset:
         """
         This hook gives backends the option to modify the dataset before running it

--- a/ehrql/backends/emisv2.py
+++ b/ehrql/backends/emisv2.py
@@ -1,3 +1,5 @@
+import urllib.parse
+
 import ehrql.tables.smoketest
 from ehrql.backends.base import QueryTable, SQLBackend
 from ehrql.query_engines.trino import TrinoQueryEngine
@@ -19,6 +21,12 @@ class EMISV2Backend(SQLBackend):
     implements = [
         ehrql.tables.smoketest,
     ]
+
+    def modify_temp_table_schema(self, temp_table_schema, dsn, environ):
+        # EMIS have configured things such that each user has a writable schema whose
+        # name matches the username
+        parts = urllib.parse.urlparse(dsn)
+        return parts.username
 
     patients = QueryTable(
         """

--- a/ehrql/query_engines/base_sql.py
+++ b/ehrql/query_engines/base_sql.py
@@ -86,6 +86,9 @@ class BaseSQLQueryEngine(BaseQueryEngine):
     # seems to result in a massive performance improvement in some cases. The current
     # value was picked as being sort-of-vaguely-sensible-looking.
     max_join_count = 16
+    # Name of the database schema in which to create temporary tables (may not be
+    # relevant to all query engines)
+    temp_table_schema = None
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -103,6 +106,9 @@ class BaseSQLQueryEngine(BaseQueryEngine):
         )
         self.max_join_count = int(
             self.environ.get("EHRQL_MAX_JOIN_COUNT", self.max_join_count)
+        )
+        self.temp_table_schema = self.backend.modify_temp_table_schema(
+            self.temp_table_schema, self.dsn, self.environ
         )
 
     def get_next_id(self):
@@ -1010,6 +1016,7 @@ class BaseSQLQueryEngine(BaseQueryEngine):
             sqlalchemy.MetaData(),
             *columns,
             prefixes=["TEMPORARY"],
+            schema=self.temp_table_schema,
         )
         table.setup_queries = [
             sqlalchemy.schema.CreateTable(table),

--- a/ehrql/query_engines/sqlite.py
+++ b/ehrql/query_engines/sqlite.py
@@ -171,7 +171,9 @@ class SQLiteQueryEngine(BaseSQLQueryEngine):
 
     def reify_query(self, query):
         table_name = f"tmp_{self.get_next_id()}"
-        table = GeneratedTable.from_query(table_name, query)
+        table = GeneratedTable.from_query(
+            table_name, query, schema=self.temp_table_schema
+        )
         table.setup_queries = [
             CreateTableAs(table, query, temporary=True),
         ]

--- a/ehrql/query_engines/trino.py
+++ b/ehrql/query_engines/trino.py
@@ -128,6 +128,7 @@ class TrinoQueryEngine(BaseSQLQueryEngine):
             table_name,
             sqlalchemy.MetaData(),
             *columns,
+            schema=self.temp_table_schema,
         )
         table.setup_queries = [
             sqlalchemy.schema.CreateTable(table),
@@ -141,7 +142,9 @@ class TrinoQueryEngine(BaseSQLQueryEngine):
     def reify_query(self, query):
         table_name = f"ehrql_{self.global_unique_id}_tmp_{self.get_next_id()}"
         query = self.backend.modify_query_pre_reify(query)
-        table = GeneratedTable.from_query(table_name, query)
+        table = GeneratedTable.from_query(
+            table_name, query, schema=self.temp_table_schema
+        )
         table.setup_queries = [
             CreateTableAs(table, query),
         ]

--- a/tests/lib/databases.py
+++ b/tests/lib/databases.py
@@ -46,6 +46,7 @@ class DbDetails:
         query=None,
         temp_db=None,
         engine_kwargs=None,
+        test_query="SELECT 1",
     ):
         self.protocol = protocol
         self.driver = driver
@@ -59,6 +60,8 @@ class DbDetails:
         self.query = query
         self.temp_db = temp_db
         self.engine_kwargs = engine_kwargs or {}
+        self.test_query = test_query
+
         self.metadata = None
 
     def container_url(self):
@@ -130,7 +133,7 @@ def wait_for_database(database, timeout=20):
     while True:
         try:
             with engine.connect() as connection:
-                connection.execute(sqlalchemy.text("SELECT 'hello'"))
+                connection.execute(sqlalchemy.text(database.test_query))
             break
         except (
             sqlalchemy.exc.OperationalError,
@@ -297,6 +300,9 @@ def make_trino_database(containers):
         # Disable automatic retries for the test client: it's pointless and creates log
         # noise
         engine_kwargs={"connect_args": {"max_attempts": 1}},
+        # This schema doesn't exist by default, so if it does then we know our setup SQL
+        # has finished running
+        test_query="SHOW CREATE SCHEMA trino",
     )
 
 

--- a/tests/support/trino/entrypoint.sh
+++ b/tests/support/trino/entrypoint.sh
@@ -16,6 +16,12 @@ if [ "$1" = '/usr/lib/trino/bin/run-trino' ]; then
         timeout=20
         limit="$((SECONDS + timeout))"
 
+        until trino --execute "SELECT 1" >/dev/null 2>&1; do
+          sleep 1
+        done
+
+        trino --file /trino/setup.sql
+
         # Note that the container has been initialized so future
         # starts won't wipe changes to the data
         touch /tmp/app-initialized

--- a/tests/support/trino/setup.sql
+++ b/tests/support/trino/setup.sql
@@ -1,1 +1,4 @@
--- SQL to setup the database goes here
+-- In production each user has a writable schema named with their username in which to
+-- create temporary tables; we want to mirror that set up here so we create a "trino"
+-- schema (named after the default user) in the default "trino" catalog.
+CREATE SCHEMA trino.trino;

--- a/tests/support/trino/setup.sql
+++ b/tests/support/trino/setup.sql
@@ -1,0 +1,1 @@
+-- SQL to setup the database goes here

--- a/tests/unit/backends/test_emisv2.py
+++ b/tests/unit/backends/test_emisv2.py
@@ -1,0 +1,10 @@
+from ehrql.backends.emisv2 import EMISV2Backend
+
+
+def test_emisv2_backend_modify_temp_table_schema():
+    username = "my_test_user"
+    backend = EMISV2Backend()
+    query_engine = backend.get_query_engine(
+        f"trino://{username}:password@example.com:443/some_database"
+    )
+    assert query_engine.temp_table_schema == username


### PR DESCRIPTION
EMIS have configured things such that each user has a writable schema whose name matches the username.

With this PR in place we can successfully run queries against the staging database using:
```
ehrql generate-dataset \
  tests/acceptance/external_studies/test-age-distribution/analysis/dataset_definition.py \
  --backend emisv2 \
  --dsn trino://USERNAME:TOKEN@explorerplus.stagingemisinsights.co.uk:443/hive/explorer_open_safely
```