### PR TITLE
Implement `core.patients`,  `core.clinical_events` and  `core.medications` in EMIS v2 backend

### DIFF
--- a/ehrql/backends/emisv2.py
+++ b/ehrql/backends/emisv2.py
@@ -29,10 +29,19 @@ class EMISV2Backend(SQLBackend):
         return parts.username
 
     patients = QueryTable(
+        # Note: sex = 'U' (unknown) is a common value and
+        # is handled by the ELSE clause
         """
         SELECT
             patient_id AS patient_id,
-            CAST(date_of_birth AS date) AS date_of_birth
+            CAST(date_of_birth AS date) AS date_of_birth,
+            CASE
+                WHEN sex = 'M' THEN 'male'
+                WHEN sex = 'F' THEN 'female'
+                WHEN sex = 'I' THEN 'intersex'
+                ELSE 'unknown'
+            END AS sex,
+            CAST(date_of_death AS date) AS date_of_death
         FROM patient
         """
     )

--- a/ehrql/backends/emisv2.py
+++ b/ehrql/backends/emisv2.py
@@ -62,3 +62,17 @@ class EMISV2Backend(SQLBackend):
         FROM observation
         """
     )
+
+    medications = QueryTable(
+        # Note that we use the medical issue record's effective date here rather
+        # than the date of the linked consultation for the medical issue record
+        # (which is what we use in TPP). This is not a permanent decision -
+        # we may revise the implementation in the future.
+        """
+        SELECT
+            patient_id,
+            CAST(effective_datetime AS date) as date,
+            CAST(dmd_product_code_id AS varchar) AS dmd_code
+        FROM medication_issue_record
+        """
+    )

--- a/ehrql/backends/emisv2.py
+++ b/ehrql/backends/emisv2.py
@@ -32,7 +32,7 @@ class EMISV2Backend(SQLBackend):
         """
         SELECT
             patient_id AS patient_id,
-            date_of_birth
+            CAST(date_of_birth AS date) AS date_of_birth
         FROM patient
         """
     )

--- a/ehrql/backends/emisv2.py
+++ b/ehrql/backends/emisv2.py
@@ -1,5 +1,6 @@
 import urllib.parse
 
+import ehrql.tables.emisv2
 import ehrql.tables.smoketest
 from ehrql.backends.base import QueryTable, SQLBackend
 from ehrql.query_engines.trino import TrinoQueryEngine
@@ -19,6 +20,7 @@ class EMISV2Backend(SQLBackend):
     query_engine_class = TrinoQueryEngine
     patient_join_column = "patient_id"
     implements = [
+        ehrql.tables.emisv2,
         ehrql.tables.smoketest,
     ]
 

--- a/ehrql/backends/emisv2.py
+++ b/ehrql/backends/emisv2.py
@@ -47,3 +47,18 @@ class EMISV2Backend(SQLBackend):
         FROM patient
         """
     )
+
+    clinical_events = QueryTable(
+        # Note that we use the observation's effective date here rather than
+        # the date of the linked consultation for the observation (which is what
+        # we use in TPP). This is not a permanent decision - we may revise the
+        # implementation in the future.
+        """
+        SELECT
+            patient_id,
+            CAST(effective_datetime AS date) as date,
+            CAST(snomed_concept_id AS varchar) AS snomedct_code,
+            CAST(numeric_value AS real) AS numeric_value
+        FROM observation
+        """
+    )

--- a/ehrql/docs/schemas.py
+++ b/ehrql/docs/schemas.py
@@ -30,6 +30,8 @@ def build_schemas(backends=()):
 
     schemas = []
     for module in get_submodules(tables):
+        if getattr(module, "exclude_from_docs", False):
+            continue
         module_tables = list(build_tables(module))
         if not module_tables:
             continue

--- a/ehrql/tables/emisv2.py
+++ b/ehrql/tables/emisv2.py
@@ -1,0 +1,9 @@
+from ehrql.tables.core import patients
+
+
+# Exclude emisv2 tables from docs for now to avoid user confusion
+exclude_from_docs = True
+
+__all__ = [
+    "patients",
+]

--- a/ehrql/tables/emisv2.py
+++ b/ehrql/tables/emisv2.py
@@ -1,9 +1,10 @@
-from ehrql.tables.core import patients
+from ehrql.tables.core import clinical_events, patients
 
 
 # Exclude emisv2 tables from docs for now to avoid user confusion
 exclude_from_docs = True
 
 __all__ = [
+    "clinical_events",
     "patients",
 ]

--- a/ehrql/tables/emisv2.py
+++ b/ehrql/tables/emisv2.py
@@ -1,4 +1,4 @@
-from ehrql.tables.core import clinical_events, patients
+from ehrql.tables.core import clinical_events, medications, patients
 
 
 # Exclude emisv2 tables from docs for now to avoid user confusion
@@ -6,5 +6,6 @@ exclude_from_docs = True
 
 __all__ = [
     "clinical_events",
+    "medications",
     "patients",
 ]

--- a/tests/autocomplete/autocomplete_definition.py
+++ b/tests/autocomplete/autocomplete_definition.py
@@ -1,5 +1,5 @@
 from ehrql import days, maximum_of, minimum_of, weeks
-from ehrql.tables import core, emis, tpp
+from ehrql.tables import core, emis, emisv2, tpp
 
 
 # A file to keep track of things where we get good autocomplete behaviour.
@@ -267,6 +267,8 @@ tpp.practice_registrations.spanning_with_systmone(
 emis.patients.has_practice_registration_spanning(
     date_str, date_str
 )  ## type:BoolPatientSeries
+emisv2.patients.is_alive_on(date_str)  ## type:BoolPatientSeries
+emisv2.patients.is_dead_on(date_str)  ## type:BoolPatientSeries
 core.patients.is_alive_on(date_str)  ## type:BoolPatientSeries
 core.patients.is_dead_on(date_str)  ## type:BoolPatientSeries
 core.practice_registrations.exists_for_patient_on(date_str)  ## type:BoolPatientSeries

--- a/tests/autocomplete/test_autocomplete.py
+++ b/tests/autocomplete/test_autocomplete.py
@@ -17,7 +17,7 @@ from ehrql.query_language import (
     get_tables_from_namespace,
     int_property,
 )
-from ehrql.tables import core, emis, tpp
+from ehrql.tables import core, emis, emisv2, tpp
 from ehrql.utils.module_utils import get_submodules
 
 from .language_server import LanguageServer
@@ -406,6 +406,7 @@ def test_all_table_methods():
         "ehrql.tables.smoketest.patients.count_for_patient",
         "ehrql.tables.smoketest.patients.exists_for_patient",
         "ehrql.tables.emis.patients.age_on",  # requires DateDifference
+        "ehrql.tables.emisv2.patients.age_on",  # requires DateDifference
         "ehrql.tables.tpp.addresses.for_patient_on",  # Needs last_for_patient
         "ehrql.tables.core.practice_registrations.for_patient_on",  # Needs last_for_patient
         "ehrql.tables.tpp.patients.age_on",  # requires DateDifference
@@ -562,6 +563,7 @@ def test_all_query_model_series_methods(query_language_methods):
                 "tpp": tpp,
                 "core": core,
                 "emis": emis,
+                "emisv2": emisv2,
                 "days": days,
                 "query_language": query_language,
             },
@@ -635,6 +637,7 @@ def test_all_query_model_non_series_methods(query_language_methods):
                 "tpp": tpp,
                 "core": core,
                 "emis": emis,
+                "emisv2": emisv2,
                 "days": days,
                 "query_language": query_language,
             },

--- a/tests/backend_schemas/emisv2/schema.py
+++ b/tests/backend_schemas/emisv2/schema.py
@@ -7,6 +7,15 @@ class Base(DeclarativeBase):
     "Common base class to signal that models below belong to the same database"
 
 
+class MedicationIssueRecord(Base):
+    __tablename__ = "medication_issue_record"
+    _pk = mapped_column(t.Integer, primary_key=True)
+
+    patient_id = mapped_column(t.VARBINARY())
+    dmd_product_code_id = mapped_column(t.BIGINT())
+    effective_datetime = mapped_column(trdt.TIMESTAMP(precision=6, timezone=True))
+
+
 class Patient(Base):
     __tablename__ = "patient"
     _pk = mapped_column(t.Integer, primary_key=True)

--- a/tests/backend_schemas/emisv2/schema.py
+++ b/tests/backend_schemas/emisv2/schema.py
@@ -15,3 +15,13 @@ class Patient(Base):
     date_of_birth = mapped_column(trdt.TIMESTAMP(precision=6))
     date_of_death = mapped_column(trdt.TIMESTAMP(precision=6))
     sex = mapped_column(t.VARCHAR())
+
+
+class Observation(Base):
+    __tablename__ = "observation"
+    _pk = mapped_column(t.Integer, primary_key=True)
+
+    patient_id = mapped_column(t.VARBINARY())
+    effective_datetime = mapped_column(trdt.TIMESTAMP(precision=6, timezone=True))
+    numeric_value = mapped_column(t.DECIMAL(precision=19, scale=3))
+    snomed_concept_id = mapped_column(t.BIGINT())

--- a/tests/backend_schemas/emisv2/schema.py
+++ b/tests/backend_schemas/emisv2/schema.py
@@ -13,3 +13,5 @@ class Patient(Base):
 
     patient_id = mapped_column(t.VARBINARY())
     date_of_birth = mapped_column(trdt.TIMESTAMP(precision=6))
+    date_of_death = mapped_column(trdt.TIMESTAMP(precision=6))
+    sex = mapped_column(t.VARCHAR())

--- a/tests/integration/backends/conftest.py
+++ b/tests/integration/backends/conftest.py
@@ -2,6 +2,7 @@ import pytest
 import sqlalchemy
 
 from ehrql.backends.emis import EMISBackend
+from ehrql.backends.emisv2 import EMISV2Backend
 from ehrql.backends.tpp import TPPBackend
 from ehrql.utils.sqlalchemy_query_utils import add_setup_and_cleanup_queries
 
@@ -48,6 +49,13 @@ def _select_all_fn(select_all_query, database):
 @pytest.fixture
 def select_all_emis(request, trino_database):
     backend = EMISBackend()
+    select_all_query = _get_select_all_query(request, backend, trino_database)
+    return _select_all_fn(select_all_query, trino_database)
+
+
+@pytest.fixture
+def select_all_emisv2(request, trino_database):
+    backend = EMISV2Backend()
     select_all_query = _get_select_all_query(request, backend, trino_database)
     return _select_all_fn(select_all_query, trino_database)
 

--- a/tests/integration/backends/helpers.py
+++ b/tests/integration/backends/helpers.py
@@ -1,7 +1,7 @@
 import sqlalchemy
 
 from ehrql.query_language import get_tables_from_namespace
-from ehrql.tables import emis, tpp
+from ehrql.tables import emis, emisv2, tpp
 from ehrql.tables.raw import emis as emis_raw
 from ehrql.tables.raw import tpp as tpp_raw
 
@@ -73,7 +73,11 @@ def get_all_backend_columns(backend, database):
 
 
 def get_all_tables(backend):
-    table_modules_by_backend = {"emis": [emis, emis_raw], "tpp": [tpp, tpp_raw]}
+    table_modules_by_backend = {
+        "emis": [emis, emis_raw],
+        "emisv2": [emisv2],
+        "tpp": [tpp, tpp_raw],
+    }
     modules = table_modules_by_backend[backend.display_name.lower()]
     for module in modules:
         for name, table in get_tables_from_namespace(module):

--- a/tests/integration/backends/test_emisv2.py
+++ b/tests/integration/backends/test_emisv2.py
@@ -1,7 +1,7 @@
 from datetime import date, datetime
 
 from ehrql.backends.emisv2 import EMISV2Backend
-from ehrql.tables import core
+from ehrql.tables import emisv2
 from tests.backend_schemas.emisv2.schema import Patient
 
 from .helpers import (
@@ -45,7 +45,7 @@ def test_extract_smoketest_dataset_definition(trino_engine):
     assert results == [{"patient_id": bytes(range(16)), "age": 22}]
 
 
-@register_test_for(core.patients)
+@register_test_for(emisv2.patients)
 def test_patients(select_all_emisv2):
     results = select_all_emisv2(
         Patient(

--- a/tests/integration/backends/test_emisv2.py
+++ b/tests/integration/backends/test_emisv2.py
@@ -1,7 +1,12 @@
-from datetime import datetime
+from datetime import date, datetime
 
 from ehrql.backends.emisv2 import EMISV2Backend
+from ehrql.tables import smoketest
 from tests.backend_schemas.emisv2.schema import Patient
+
+from .helpers import (
+    register_test_for,
+)
 
 
 def test_extract_smoketest_dataset_definition(trino_engine):
@@ -38,3 +43,17 @@ def test_extract_smoketest_dataset_definition(trino_engine):
     results = trino_engine.extract(dataset, backend=EMISV2Backend())
 
     assert results == [{"patient_id": bytes(range(16)), "age": 22}]
+
+
+@register_test_for(smoketest.patients)
+def test_patients(select_all_emisv2):
+    results = select_all_emisv2(
+        Patient(
+            _pk=1,
+            patient_id=bytes(range(16)).decode("utf-8"),
+            date_of_birth=datetime(2000, 1, 1, 0, 0, 0, 0),
+        ),
+    )
+    assert results == [
+        {"patient_id": bytes(range(16)), "date_of_birth": date(2000, 1, 1)}
+    ]

--- a/tests/integration/backends/test_emisv2.py
+++ b/tests/integration/backends/test_emisv2.py
@@ -6,6 +6,7 @@ from ehrql.backends.emisv2 import EMISV2Backend
 from ehrql.tables import emisv2
 from ehrql.utils.sqlalchemy_query_utils import CreateTableAs, GeneratedTable
 from tests.backend_schemas.emisv2.schema import (
+    MedicationIssueRecord,
     Observation,
     Patient,
 )
@@ -149,5 +150,23 @@ def test_clinical_events(select_all_emisv2):
             "date": date(2023, 5, 12),
             "snomedct_code": "123456789",
             "numeric_value": 80.0,
+        }
+    ]
+
+
+@register_test_for(emisv2.medications)
+def test_medications(select_all_emisv2):
+    results = select_all_emisv2(
+        MedicationIssueRecord(
+            patient_id=bytes(range(16)).decode("utf-8"),
+            dmd_product_code_id=12354611500001104,
+            effective_datetime=datetime(2023, 5, 12, 14, 30, 15, 0, tzinfo=UTC),
+        )
+    )
+    assert results == [
+        {
+            "patient_id": bytes(range(16)),
+            "date": date(2023, 5, 12),
+            "dmd_code": "12354611500001104",
         }
     ]

--- a/tests/integration/backends/test_emisv2.py
+++ b/tests/integration/backends/test_emisv2.py
@@ -1,10 +1,17 @@
 from datetime import date, datetime
 
+import sqlalchemy
+
 from ehrql.backends.emisv2 import EMISV2Backend
 from ehrql.tables import emisv2
-from tests.backend_schemas.emisv2.schema import Patient
+from ehrql.utils.sqlalchemy_query_utils import CreateTableAs, GeneratedTable
+from tests.backend_schemas.emisv2.schema import (
+    Patient,
+)
 
 from .helpers import (
+    assert_types_correct,
+    get_all_backend_columns,
     register_test_for,
 )
 
@@ -43,6 +50,65 @@ def test_extract_smoketest_dataset_definition(trino_engine):
     results = trino_engine.extract(dataset, backend=EMISV2Backend())
 
     assert results == [{"patient_id": bytes(range(16)), "age": 22}]
+
+
+def test_backend_columns_have_correct_types(trino_database):
+    columns_with_types = get_all_backend_columns_with_types(trino_database)
+    assert_types_correct(columns_with_types, trino_database)
+
+
+def get_all_backend_columns_with_types(trino_database):
+    """
+    For every column on every table we expose in the backend, yield the SQLAlchemy type
+    instance we expect to use for that column together with the type information that
+    database has for that column so we can check they're compatible
+    """
+    table_names = set()
+    column_types = {}
+    queries = []
+    for table, columns in get_all_backend_columns(EMISV2Backend(), trino_database):
+        table_names.add(table)
+        column_types.update({(table, c.key): c.type for c in columns})
+        # Construct a query which selects every column in the table
+        select_query = sqlalchemy.select(*[c.label(c.key) for c in columns])
+        # Write the results of that query into a temporary table (it will be empty but
+        # that's fine, we just want the types)
+        # Trino doesn't support actual temporary tables, so really this temp table is
+        # a real table that we drop after the test
+        temp_table_name = f"temp_{table}"
+        temp_table = GeneratedTable.from_query(temp_table_name, select_query)
+        queries.append(
+            (temp_table_name, temp_table, CreateTableAs(temp_table, select_query))
+        )
+    # Create all the underlying tables in the database without populating them
+    trino_database.setup(metadata=Patient.metadata)
+    # Note: we really ought to have something like the setup/cleanup call below to
+    # handle materialized query tables (which we happen not to have any of in the EMIS
+    # backend at present). But the structure of the `queries` list doesn't currently
+    # allow for this and I think there's a wider refactor here which would make this
+    # problem go away so I'm going to punt on it for now.
+    # queries = add_setup_and_cleanup_queries(queries)
+    with trino_database.engine().connect() as connection:
+        # Create our "temporary" tables
+        for temp_table_name, temp_table, query in queries:
+            connection.execute(query)
+            # Get the column names, types and collations for all columns in those tables
+            query = sqlalchemy.text(
+                """
+                SELECT column_name, data_type
+                FROM information_schema.columns
+                WHERE table_name=:t
+                """
+            )
+            results = list(connection.execute(query, {"t": temp_table_name}))
+            table_name = temp_table_name.replace("temp_", "")
+            for column, type_name in results:
+                column_type = column_types[table_name, column]
+                column_args = {"type": type_name}
+                yield table_name, column, column_type, column_args
+
+            # Drop the temp table
+            temp_table.drop(trino_database.engine())
 
 
 @register_test_for(emisv2.patients)

--- a/tests/integration/backends/test_emisv2.py
+++ b/tests/integration/backends/test_emisv2.py
@@ -1,7 +1,7 @@
 from datetime import date, datetime
 
 from ehrql.backends.emisv2 import EMISV2Backend
-from ehrql.tables import smoketest
+from ehrql.tables import core
 from tests.backend_schemas.emisv2.schema import Patient
 
 from .helpers import (
@@ -45,15 +45,22 @@ def test_extract_smoketest_dataset_definition(trino_engine):
     assert results == [{"patient_id": bytes(range(16)), "age": 22}]
 
 
-@register_test_for(smoketest.patients)
+@register_test_for(core.patients)
 def test_patients(select_all_emisv2):
     results = select_all_emisv2(
         Patient(
             _pk=1,
             patient_id=bytes(range(16)).decode("utf-8"),
             date_of_birth=datetime(2000, 1, 1, 0, 0, 0, 0),
+            date_of_death=datetime(2023, 5, 12, 0, 0, 0, 0),
+            sex="M",
         ),
     )
     assert results == [
-        {"patient_id": bytes(range(16)), "date_of_birth": date(2000, 1, 1)}
+        {
+            "patient_id": bytes(range(16)),
+            "date_of_birth": date(2000, 1, 1),
+            "date_of_death": date(2023, 5, 12),
+            "sex": "male",
+        }
     ]

--- a/tests/integration/backends/test_emisv2.py
+++ b/tests/integration/backends/test_emisv2.py
@@ -1,4 +1,4 @@
-from datetime import date, datetime
+from datetime import UTC, date, datetime
 
 import sqlalchemy
 
@@ -6,6 +6,7 @@ from ehrql.backends.emisv2 import EMISV2Backend
 from ehrql.tables import emisv2
 from ehrql.utils.sqlalchemy_query_utils import CreateTableAs, GeneratedTable
 from tests.backend_schemas.emisv2.schema import (
+    Observation,
     Patient,
 )
 
@@ -128,5 +129,25 @@ def test_patients(select_all_emisv2):
             "date_of_birth": date(2000, 1, 1),
             "date_of_death": date(2023, 5, 12),
             "sex": "male",
+        }
+    ]
+
+
+@register_test_for(emisv2.clinical_events)
+def test_clinical_events(select_all_emisv2):
+    results = select_all_emisv2(
+        Observation(
+            patient_id=bytes(range(16)).decode("utf-8"),
+            effective_datetime=datetime(2023, 5, 12, 14, 30, 15, 0, tzinfo=UTC),
+            numeric_value=80.0,
+            snomed_concept_id=123456789,
+        )
+    )
+    assert results == [
+        {
+            "patient_id": bytes(range(16)),
+            "date": date(2023, 5, 12),
+            "snomedct_code": "123456789",
+            "numeric_value": 80.0,
         }
     ]


### PR DESCRIPTION
Closes #2725. Replaces #2736.

Following the discussion in [this Slack thread](https://bennettoxford.slack.com/archives/C080S7W2ZPX/p1775144942900229?thread_ts=1775124493.243089&cid=C080S7W2ZPX), here we:
- Add ORM object definitions for EMIS v2 observations and medications in the test schema
- Implement the core `patients`, `clinical_events` and `medications` tables on the EMIS v2 backend
- Add integration tests for the EMIS v2 backend that validate the implemented tables using the test schema objects

I think I do not need a `feat:` prefix for these changes? Please correct me if I'm wrong!

### ORM object definitions
As done in #2739, use column types obtained by connecting to EMIS's staging environment using a SQLAlchemy session. (See PR description of #2739 for details on how this was done.)

### Query tables
These were mostly straightforward mappings with some `CAST`ing to appropriate types that ehrQL expects. The exception is that the `patients.sex` column requires a case statement. As noted in the commit message, I have written the case statement based on values found in the staging environment (`M`,`F`,`I`,`U` plus some random varchars). Here's the relevant Explorer screenshot for information:
<img width="537" height="303" alt="Screenshot from 2026-04-10 13-36-46" src="https://github.com/user-attachments/assets/78a315a2-85d9-4c44-9d44-333c9cf105f4" />

