### PR TITLE
Handle COALESCE expressions with only one argument

### DIFF
--- a/docs/includes/generated_docs/specs.md
+++ b/docs/includes/generated_docs/specs.md
@@ -3556,6 +3556,58 @@ returns the following patient series:
 
 
 
+#### 11.1.6 Case pick first non null value
+
+This example makes use of a patient-level table named `p` containing the following data:
+
+| patient|i1|i2 |
+| - | - | - |
+| 1|| |
+| 2|5| |
+| 3||6 |
+| 4|7|8 |
+
+```python
+case(
+    when(p.i1.is_not_null()).then(p.i1),
+    when(p.i2.is_not_null()).then(p.i2),
+)
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1| |
+| 2|5 |
+| 3|6 |
+| 4|7 |
+
+
+
+#### 11.1.7 Case pick first non null value with only one value
+This is a fairly pointless operation, but ehrQL should handle it without error
+
+This example makes use of a patient-level table named `p` containing the following data:
+
+| patient|i1 |
+| - | - |
+| 1| |
+| 2|5 |
+
+```python
+case(
+    when(p.i1.is_not_null()).then(p.i1),
+)
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1| |
+| 2|5 |
+
+
+
 ### 11.2 Case expressions with single condition
 
 

--- a/ehrql/query_engines/base_sql.py
+++ b/ehrql/query_engines/base_sql.py
@@ -756,6 +756,8 @@ class BaseSQLQueryEngine(BaseQueryEngine):
     @get_sql.register(Coalesce)
     def get_sql_coalesce(self, node):
         sources = [self.get_expr(s) for s in node.sources]
+        # The query transform code should never give us these
+        assert len(sources) > 1, "COALESCE requires more than one argument"
         return sqlalchemy.func.coalesce(*sources)
 
     @get_sql.register(AggregateByPatient.Sum)

--- a/ehrql/query_model/transforms.py
+++ b/ehrql/query_model/transforms.py
@@ -321,7 +321,16 @@ def rewrite_case_to_coalesce(node):
         sources.append(then)
     if node.default is not None:
         sources.append(node.default)
-    return Coalesce(sources=tuple(sources))
+
+    if len(sources) > 1:
+        return Coalesce(sources=tuple(sources))
+    elif len(sources) == 1:
+        # If there's only one argument then remove the operation entirely as it is not
+        # doing anything. Some databases reject single-argument COALESCE so it's better
+        # not to have them at all.
+        return sources[0]
+    else:
+        assert False, "Empty Case expression should be impossible to build"
 
 
 def simplify_potential_coalesce_condition(condition, previous_sources):

--- a/tests/spec/case_expressions/test_case.py
+++ b/tests/spec/case_expressions/test_case.py
@@ -118,3 +118,55 @@ def test_case_evaluated_in_order(spec_test):
             5: None,
         },
     )
+
+
+def test_case_pick_first_non_null_value(spec_test):
+    table_data = {
+        p: """
+              | i1 | i2
+            --+----+----
+            1 |    |
+            2 | 5  |
+            3 |    | 6
+            4 | 7  | 8
+            """,
+    }
+
+    spec_test(
+        table_data,
+        case(
+            when(p.i1.is_not_null()).then(p.i1),
+            when(p.i2.is_not_null()).then(p.i2),
+        ),
+        {
+            1: None,
+            2: 5,
+            3: 6,
+            4: 7,
+        },
+    )
+
+
+def test_case_pick_first_non_null_value_with_only_one_value(spec_test):
+    """
+    This is a fairly pointless operation, but ehrQL should handle it without error
+    """
+    table_data = {
+        p: """
+              | i1
+            --+----
+            1 |
+            2 | 5
+            """,
+    }
+
+    spec_test(
+        table_data,
+        case(
+            when(p.i1.is_not_null()).then(p.i1),
+        ),
+        {
+            1: None,
+            2: 5,
+        },
+    )


### PR DESCRIPTION
Some databases accept `COALESCE` with only one argument but others don't.

MSSQL gives the error:

    Incorrect syntax near ')'.

And Trino gives the error

    wrong number of arguments to function coalesce()

These are logically pointless operations, but we should handle them gracefully rather than generating invalid SQL.

See related user error report:
https://bennettoxford.slack.com/archives/C069YDR4NCA/p1776090663033119