### PR TITLE
Fix gentest_example_simplify

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -173,8 +173,13 @@ nature of query model reprs. To help with this there is some tooling,
 and a process to follow:
 
  * Copy the `dataset` and `data` arguments from the example that
-   Hypothesis displays and paste them into a new file.  (Don't worry
-   about stripping indentation or trailing commas here.)
+   Hypothesis displays and paste them into a new file. Just copy the arguments as-is: don't worry about indendation, trailing commas or missing imports.
+
+   Your file should just look something like this:
+   ```
+   dataset=make_dataset(...),
+   data=[...]
+   ```
 
  * Run the command:
    ```

--- a/tests/lib/gentest_example_simplify.py
+++ b/tests/lib/gentest_example_simplify.py
@@ -4,7 +4,7 @@ variables.
 
 Usage looks like:
 
-    * Copy the query model example (the `population`, `variable` and `data` arguments)
+    * Copy the query model example (the `dataset` and `data` arguments)
       into a file. Just copy the arguments as-is: don't worry about indendation,
       trailing commas or missing imports.
 
@@ -111,6 +111,7 @@ def fix_up_module(contents):
     # Add imports (many of these will be unnecessary but that's fine)
     imports = [
         "import datetime",
+        "from tests.generative.variable_strategies import make_dataset",
         "from tests.generative.test_query_model import data_setup, schema",
         f"from ehrql.query_model.nodes import ({', '.join(ehrql.query_model.nodes.__all__)})",
     ]

--- a/tests/lib/test_gentest_example_simplify.py
+++ b/tests/lib/test_gentest_example_simplify.py
@@ -7,16 +7,15 @@ from hypothesis.vendor.pretty import pretty
 from ehrql.query_model.nodes import (
     AggregateByPatient,
     Case,
-    Dataset,
     Function,
     InlinePatientTable,
     SelectColumn,
     SelectPatientTable,
     SelectTable,
-    SeriesCollectionFrame,
     Value,
 )
 from tests.generative.test_query_model import data_setup, schema
+from tests.generative.variable_strategies import make_dataset
 from tests.lib.gentest_example_simplify import simplify
 
 
@@ -38,15 +37,10 @@ def test_gentest_example_simplify():
         ),
         Value(frozenset({1, 2, 3})),
     )
-    dataset = Dataset(
+    dataset = make_dataset(
         population=population,
-        variables={"v": variable},
-        events={
-            "event_table": SeriesCollectionFrame(
-                members={"e": SelectColumn(SelectTable("e0", schema), "i1")}
-            )
-        },
-        measures=None,
+        patient_variables=[variable],
+        event_series=SelectColumn(SelectTable("e0", schema), "i1"),
     )
     data = [
         {"type": data_setup.P0, "patient_id": 1},


### PR DESCRIPTION
Hypothesis tests now use a `make_dataset` function as the dataset argument, so we need to add the import when converting a copy/pasted hypothesis output.

Also updates tests to use `make_dataset`