### PR TITLE
Add dedicated exit code for MeasuresTimeout errors

### DIFF
--- a/ehrql/__main__.py
+++ b/ehrql/__main__.py
@@ -20,6 +20,7 @@ from ehrql.file_formats import (
     split_directory_and_extension,
 )
 from ehrql.loaders import DefinitionError
+from ehrql.measures import MeasuresTimeout
 from ehrql.permissions import EHRQLPermissionError
 from ehrql.renderers import DISPLAY_RENDERERS
 from ehrql.utils.string_utils import strip_indent
@@ -138,6 +139,10 @@ def main(args, environ=None):
         # Handle errors from failed assurarance tests
         print(f"{exc.__class__.__name__}: {exc}", file=sys.stderr)
         sys.exit(13)
+    except MeasuresTimeout as exc:
+        # Handle timeout errors
+        print(f"{exc.__class__.__name__}: {exc}", file=sys.stderr)
+        sys.exit(14)
     except Exception as exc:
         # For functions which take a `backend_class` give that class the chance to set
         # the appropriate exit status for any errors

--- a/ehrql/measures/__init__.py
+++ b/ehrql/measures/__init__.py
@@ -1,5 +1,6 @@
 from ehrql.dummy_data.measures import DummyMeasuresDataGenerator
 from ehrql.measures.calculate import (
+    MeasuresTimeout,
     combine_measure_tables_as_results,
     get_column_specs_for_measures,
     get_measure_results,
@@ -19,6 +20,7 @@ __all__ = [
     "DummyMeasuresDataGenerator",
     "INTERVAL",
     "Measures",
+    "MeasuresTimeout",
     "create_measures",
     "split_measure_results_into_tables",
 ]

--- a/tests/unit/test___main__.py
+++ b/tests/unit/test___main__.py
@@ -15,6 +15,7 @@ from ehrql.__main__ import (
     valid_output_path,
 )
 from ehrql.backends.base import SQLBackend
+from ehrql.measures import MeasuresTimeout
 from ehrql.query_engines.base import BaseQueryEngine
 from ehrql.query_engines.base_sql import BaseSQLQueryEngine
 from ehrql.query_engines.debug import DebugQueryEngine
@@ -136,6 +137,21 @@ def test_generate_measures(mocker):
     ]
     main(argv)
     patched.assert_called_once()
+
+
+def test_generate_measures_with_timeout(capsys, mocker):
+    patched = mocker.patch("ehrql.__main__.generate_measures")
+    patched.side_effect = MeasuresTimeout("Too slow")
+    argv = [
+        "generate-measures",
+        DATASET_DEFINITON_PATH,
+    ]
+    with pytest.raises(SystemExit) as exc:
+        main(argv)
+    captured = capsys.readouterr()
+    assert "Too slow" in captured.err
+    assert "Traceback" not in captured.err
+    assert exc.value.code == 14
 
 
 def test_existing_python_file_missing_file(capsys, tmp_path):


### PR DESCRIPTION
We've seen a few of these in the wild recently and we want to be able to provide a better error message to users in job server.

See Slack discussion:
https://bennettoxford.slack.com/archives/C069YDR4NCA/p1776151498356969