### PR TITLE
Update ehrql example for sorting on a field with null values

### DIFF
--- a/docs/how-to/examples.md
+++ b/docs/how-to/examples.md
@@ -437,6 +437,9 @@ dataset.define_population(patients.exists_for_patient())
 The `first_for_patient()` and `last_for_patient()` methods can only be used on a sorted frame.
 Frames can be sorted by calling the `sort_by()` method with the column to sort the frame by.
 
+Note that NULL is considered smaller than any other value, so if you are trying to find the
+first value in a column that contains NULLs, you may wish to filter out NULL values before sorting.
+
 #### What is the earliest/latest clinical event matching some criteria?
 
 ```ehrql
@@ -485,6 +488,9 @@ dataset = create_dataset()
 
 hba1c_events = clinical_events.where(
         clinical_events.snomedct_code.is_in(hba1c_codelist)
+).where(
+        # Note: filter out NULL numeric values before sorting
+        clinical_events.numeric_value.is_not_null()
 ).where(
         clinical_events.date.is_on_or_after("2022-07-01")
 )


### PR DESCRIPTION
As [docs for sort_by](https://docs.opensafely.org/ehrql/reference/language/#SortedEventFrame.sort_by) state, NULL is considered smaller than any other value, so users may wish to filter out NULL values before sorting. We have an example that sorts on clinical_events.numeric_value, which can contain nulls, so is one of those cases that we'd expect to need to filter out nulls first.

As raised by Andrea on [slack](https://bennettoxford.slack.com/archives/C01D7H9LYKB/p1776849185233669?thread_ts=1776849185.233669&cid=C01D7H9LYKB)