### PR TITLE
Return None for overflow errors in power() function

### DIFF
--- a/ehrql/utils/math_utils.py
+++ b/ehrql/utils/math_utils.py
@@ -20,13 +20,22 @@ def floordiv(lhs, rhs):
 
 def power(lhs, rhs):
     """
-    Implement Python power behaviour but return None when either zero is raised to a negative
-    power or when a negative base is raised to a non-integer exponent (which would produce a complex number in Python).
+    Implement Python power behaviour but return None when:
+    - zero is raised to a negative power
+    - a negative base is raised to a non-integer exponent (which would produce a complex number in Python)
+    - we encounter an OverflowError for a complex exponentiation
     """
     try:
         value = lhs**rhs
     except ZeroDivisionError:
         return None
+    except OverflowError as e:
+        # Return None if the OverflowError was for a complex exponentiation;
+        # Note SQL engines return NULL for complex exponentiations before computing
+        # them and so don't raise overflow errors.
+        if "complex exponentiation" in str(e):
+            return None
+        raise
     return value if not isinstance(value, complex) else None
 
 

--- a/tests/unit/utils/test_math_utils.py
+++ b/tests/unit/utils/test_math_utils.py
@@ -1,6 +1,6 @@
 import pytest
 
-from ehrql.utils.math_utils import get_grouping_level_as_int
+from ehrql.utils.math_utils import get_grouping_level_as_int, power
 
 
 @pytest.mark.parametrize(
@@ -19,3 +19,28 @@ from ehrql.utils.math_utils import get_grouping_level_as_int
 )
 def test_get_grouping_level_as_int(all_groups, group_subset, expected):
     assert get_grouping_level_as_int(all_groups, group_subset) == expected
+
+
+@pytest.mark.parametrize(
+    "lhs,rhs,expected",
+    [
+        (2, 2, 4),
+        (-5, 2, 25),
+        (0, 2, 0),
+        # zerodivision error
+        (0, -2, None),
+        # results in complex number
+        (-5, 2.5, None),
+    ],
+)
+def test_power(lhs, rhs, expected):
+    assert power(lhs, rhs) == expected
+
+
+def test_power_raises_overflow_error():
+    # results in raised OverflowError
+    with pytest.raises(OverflowError, match="result out of range"):
+        power(10, 500.5)
+
+    # results in overflow error for complex exponentiation, returns None
+    assert power(-10, 500.5) is None


### PR DESCRIPTION
Identified by [hypothesis](https://bennettoxford.slack.com/archives/C069YDR4NCA/p1777339444442999)

In the power() function, we return None for power calculations that result in complex values, to align with SQL (which returns NULL without calculating the result). We also need to return None for OverflowErrors that result from a complex exponentiation.