### PR TITLE
Add `emisv2.practice_registrations`

### DIFF
--- a/ehrql/backends/emisv2.py
+++ b/ehrql/backends/emisv2.py
@@ -77,6 +77,16 @@ class EMISV2Backend(SQLBackend):
         """
     )
 
+    practice_registrations = QueryTable(
+        """
+        SELECT
+            patient_id AS patient_id,
+            CAST(registration_start_datetime AS date) AS start_date,
+            CAST(registration_end_datetime AS date) AS end_date
+        FROM patient
+        """
+    )
+
     addresses = QueryTable(
         """
         SELECT

--- a/ehrql/tables/emisv2.py
+++ b/ehrql/tables/emisv2.py
@@ -12,6 +12,7 @@ __all__ = [
     "clinical_events",
     "medications",
     "patients",
+    "practice_registrations",
 ]
 
 
@@ -74,3 +75,52 @@ class addresses(EventFrame):
             self.end_date.is_not_null() & (self.end_date < date)
         )
         return spanning_addrs.sort_by(self.start_date).last_for_patient()
+
+
+@table
+class practice_registrations(EventFrame):
+    """
+    Each record corresponds to a patient's registration with a practice.
+    """
+
+    start_date = Series(
+        datetime.date,
+        constraints=[Constraint.NotNull()],
+        description="Date patient joined practice.",
+    )
+    end_date = Series(
+        datetime.date,
+        description="Date patient left practice.",
+        dummy_data_constraints=[Constraint.Categorical([None])],
+    )
+
+    def for_patient_on(self, date):
+        """
+        Return each patient's practice registration as it was on the supplied date.
+        """
+        # Note that practice_registrations is an event-level table, but for EMISv2, it is
+        # derived from the patient table, so we know that there can only be at most one
+        # matching registration per patient
+        return self.spanning(date, date).sort_by(self.start_date).last_for_patient()
+
+    def exists_for_patient_on(self, date):
+        """
+        Returns whether a person was registered with a practice on the supplied date.
+
+        NB. The implementation currently uses `spanning()`. It would also have been
+        valid to implement as
+        `practice_registrations.for_patient_on(date).exists_for_patient()`, but for
+        internal reasons that is less efficient.
+
+        """
+        return self.spanning(date, date).exists_for_patient()
+
+    def spanning(self, start_date, end_date):
+        """
+        Filter registrations to just those spanning the entire period between
+        `start_date` and `end_date`.
+        """
+        return self.where(
+            self.start_date.is_on_or_before(start_date)
+            & (self.end_date.is_on_or_after(end_date) | self.end_date.is_null())
+        )

--- a/tests/autocomplete/autocomplete_definition.py
+++ b/tests/autocomplete/autocomplete_definition.py
@@ -271,6 +271,10 @@ emis.patients.has_practice_registration_spanning(
 )  ## type:BoolPatientSeries
 emisv2.patients.is_alive_on(date_str)  ## type:BoolPatientSeries
 emisv2.patients.is_dead_on(date_str)  ## type:BoolPatientSeries
+emisv2.practice_registrations.exists_for_patient_on(date_str)  ## type:BoolPatientSeries
+emisv2.practice_registrations.spanning(
+    date_str, date_str
+)  ## type:practice_registrations
 core.patients.is_alive_on(date_str)  ## type:BoolPatientSeries
 core.patients.is_dead_on(date_str)  ## type:BoolPatientSeries
 core.practice_registrations.exists_for_patient_on(date_str)  ## type:BoolPatientSeries

--- a/tests/autocomplete/test_autocomplete.py
+++ b/tests/autocomplete/test_autocomplete.py
@@ -410,6 +410,7 @@ def test_all_table_methods():
         "ehrql.tables.emisv2.addresses.for_patient_on",  # Needs last_for_patient
         "ehrql.tables.tpp.addresses.for_patient_on",  # Needs last_for_patient
         "ehrql.tables.core.practice_registrations.for_patient_on",  # Needs last_for_patient
+        "ehrql.tables.emisv2.practice_registrations.for_patient_on",  # Needs last_for_patient
         "ehrql.tables.tpp.patients.age_on",  # requires DateDifference
         "ehrql.tables.core.patients.age_on",  # requires DateDifference
         "ehrql.tables.emis.ons_deaths.cause_of_death_is_in",  # need refactor of method

--- a/tests/integration/backends/test_emisv2.py
+++ b/tests/integration/backends/test_emisv2.py
@@ -177,6 +177,24 @@ def test_medications(select_all_emisv2):
     ]
 
 
+@register_test_for(emisv2.practice_registrations)
+def test_practice_registrations(select_all_emisv2):
+    results = select_all_emisv2(
+        Patient(
+            patient_id=bytes(range(16)).decode("utf-8"),
+            registration_start_datetime=datetime(2000, 2, 1, 0, 0, 0, 0),
+            registration_end_datetime=None,
+        ),
+    )
+    assert results == [
+        {
+            "patient_id": bytes(range(16)),
+            "start_date": date(2000, 2, 1),
+            "end_date": None,
+        }
+    ]
+
+
 @register_test_for(emisv2.addresses)
 def test_addresses(select_all_emisv2):
     results = select_all_emisv2(

--- a/tests/integration/tables/test_emisv2.py
+++ b/tests/integration/tables/test_emisv2.py
@@ -29,6 +29,158 @@ def test_patients_age_on(in_memory_engine):
     ]
 
 
+def test_practice_registrations_for_patient_on(in_memory_engine):
+    in_memory_engine.populate(
+        # There will only ever be one registration per patient, because
+        # practice registrations are derived from the patients table.
+        {
+            emisv2.practice_registrations: [
+                # registered on 2010-01-01
+                dict(
+                    patient_id=1, start_date=date(2005, 1, 1), end_date=date(2015, 1, 1)
+                ),
+                # registration starts on 2010-01-01, null end date
+                dict(patient_id=2, start_date=date(2010, 1, 1), end_date=None),
+                # registration ends on 2010-01-01
+                dict(
+                    patient_id=3, start_date=date(2000, 1, 1), end_date=date(2010, 1, 1)
+                ),
+                # registered after 2010-01-01, not included
+                dict(
+                    patient_id=4, start_date=date(2011, 1, 1), end_date=date(2015, 1, 1)
+                ),
+                # deregistered before 2010-01-01, not included
+                dict(
+                    patient_id=5, start_date=date(2000, 1, 1), end_date=date(2009, 1, 1)
+                ),
+            ]
+        },
+    )
+
+    reg = emisv2.practice_registrations.for_patient_on("2010-01-01")
+
+    dataset = Dataset()
+    dataset.define_population(emisv2.practice_registrations.exists_for_patient())
+    dataset.start_date = reg.start_date
+    dataset.end_date = reg.end_date
+    results = in_memory_engine.extract(dataset)
+
+    assert results == [
+        {"patient_id": 1, "start_date": date(2005, 1, 1), "end_date": date(2015, 1, 1)},
+        {"patient_id": 2, "start_date": date(2010, 1, 1), "end_date": None},
+        {"patient_id": 3, "start_date": date(2000, 1, 1), "end_date": date(2010, 1, 1)},
+        {"patient_id": 4, "start_date": None, "end_date": None},
+        {"patient_id": 5, "start_date": None, "end_date": None},
+    ]
+
+
+def test_practice_registrations_exists_for_patient_on(
+    in_memory_engine,
+):
+    in_memory_engine.populate(
+        # There will only ever be one registration per patient, because
+        # practice registrations are derived from the patients table.
+        {
+            emisv2.practice_registrations: [
+                # registration covers both 2010-01-01 and 2015-01-01
+                dict(
+                    patient_id=1, start_date=date(2005, 1, 1), end_date=date(2015, 1, 1)
+                ),
+                # registration covers 2010-01-01 only as deregistered before 2015-01-01
+                dict(
+                    patient_id=2, start_date=date(2010, 1, 1), end_date=date(2011, 1, 1)
+                ),
+                # registration covers 2015-01-01 only, NULL end date
+                dict(patient_id=3, start_date=date(2015, 1, 1), end_date=None),
+                # registered after both dates
+                dict(patient_id=4, start_date=date(2016, 1, 1), end_date=None),
+            ]
+        },
+    )
+
+    dataset = Dataset()
+    dataset.define_population(emisv2.practice_registrations.exists_for_patient())
+    dataset.is_registered_2010_01_01 = (
+        emisv2.practice_registrations.exists_for_patient_on("2010-01-01")
+    )
+    dataset.is_registered_2015_01_01 = (
+        emisv2.practice_registrations.exists_for_patient_on("2015-01-01")
+    )
+
+    results = in_memory_engine.extract(dataset)
+
+    assert results == [
+        {
+            "patient_id": 1,
+            "is_registered_2010_01_01": True,
+            "is_registered_2015_01_01": True,
+        },
+        {
+            "patient_id": 2,
+            "is_registered_2010_01_01": True,
+            "is_registered_2015_01_01": False,
+        },
+        {
+            "patient_id": 3,
+            "is_registered_2010_01_01": False,
+            "is_registered_2015_01_01": True,
+        },
+        {
+            "patient_id": 4,
+            "is_registered_2010_01_01": False,
+            "is_registered_2015_01_01": False,
+        },
+    ]
+
+
+def test_practice_registrations_spanning(
+    in_memory_engine,
+):
+    in_memory_engine.populate(
+        # There will only ever be one registration per patient, because
+        # practice registrations are derived from the patients table.
+        {
+            emisv2.practice_registrations: [
+                # Registration covers time period
+                dict(
+                    patient_id=1, start_date=date(2005, 1, 1), end_date=date(2015, 1, 1)
+                ),
+                # Registration with NULL end date
+                dict(patient_id=2, start_date=date(2000, 1, 1), end_date=None),
+                # Registration is exactly the same as time period
+                dict(
+                    patient_id=3, start_date=date(2010, 1, 1), end_date=date(2011, 1, 1)
+                ),
+                # Registration with start date after time period starts
+                dict(
+                    patient_id=4, start_date=date(2010, 2, 1), end_date=date(2020, 1, 1)
+                ),
+                # Registration with start date and end date inside time period
+                dict(
+                    patient_id=5,
+                    start_date=date(2010, 2, 1),
+                    end_date=date(2010, 12, 1),
+                ),
+            ]
+        },
+    )
+
+    dataset = Dataset()
+    dataset.define_population(emisv2.practice_registrations.exists_for_patient())
+    dataset.has_spanning_practice_registration = (
+        emisv2.practice_registrations.spanning("2010-01-01", "2011-01-01")
+    ).exists_for_patient()
+    results = in_memory_engine.extract(dataset)
+
+    assert results == [
+        {"patient_id": 1, "has_spanning_practice_registration": True},
+        {"patient_id": 2, "has_spanning_practice_registration": True},
+        {"patient_id": 3, "has_spanning_practice_registration": True},
+        {"patient_id": 4, "has_spanning_practice_registration": False},
+        {"patient_id": 5, "has_spanning_practice_registration": False},
+    ]
+
+
 def test_addresses_for_patient_on(in_memory_engine):
     in_memory_engine.populate(
         # There will only ever be one address per patient, because


### PR DESCRIPTION
Closes #2786. This unblocks running a test study on the EMISv2 backend.

Similar to `emisv2.addresses`, we add `practice_registrations` as a event table even though it comes from the one-row-per-patient raw `patient` table in EMIS v2.

We do not implement the `practice_pseudo_id` column, and it is on the `core` table, so the EMIS `practice_registrations` has to be standalone.

Implementing `practice_pseudo_id` such that the table matches the core spec will be tackled separately in the future (see #2794).