### PR TITLE
Make practice_registrations.spanning use inclusive bounds

### DIFF
--- a/docs/includes/generated_docs/schemas/core.md
+++ b/docs/includes/generated_docs/schemas/core.md
@@ -645,15 +645,14 @@ Return each patient's practice registration as it was on the supplied date.
 
 Where a patient is registered with multiple practices we prefer the most recent
 registration and then, if there are multiple of these, the one with the longest
-duration. If there's still an exact tie we choose arbitrarily based on the
-practice ID.
+duration. (Note that we do not prefer registrations with null end dates; in the
+case of duplicate start dates, a registration with an explicit end date is more
+likely to be the correct one.) If there's still an exact tie we choose arbitrarily
+based on the practice ID.
     <details markdown="block">
     <summary>View method definition</summary>
 ```py
-spanning_regs = practice_registrations.where(practice_registrations.start_date <= date).except_where(
-    practice_registrations.end_date < date
-)
-ordered_regs = spanning_regs.sort_by(
+ordered_regs = practice_registrations.spanning(date, date).sort_by(
     practice_registrations.start_date,
     practice_registrations.end_date,
     practice_registrations.practice_pseudo_id,
@@ -696,13 +695,13 @@ return practice_registrations.spanning(date, date).exists_for_patient()
   </dt>
   <dd markdown="block">
 Filter registrations to just those spanning the entire period between
-`start_date` and `end_date`.
+`start_date` and `end_date` (inclusive).
     <details markdown="block">
     <summary>View method definition</summary>
 ```py
 return practice_registrations.where(
     practice_registrations.start_date.is_on_or_before(start_date)
-    & (practice_registrations.end_date.is_after(end_date) | practice_registrations.end_date.is_null())
+    & (practice_registrations.end_date.is_on_or_after(end_date) | practice_registrations.end_date.is_null())
 )
 
 ```

--- a/docs/includes/generated_docs/schemas/emis.md
+++ b/docs/includes/generated_docs/schemas/emis.md
@@ -688,15 +688,14 @@ Return each patient's practice registration as it was on the supplied date.
 
 Where a patient is registered with multiple practices we prefer the most recent
 registration and then, if there are multiple of these, the one with the longest
-duration. If there's still an exact tie we choose arbitrarily based on the
-practice ID.
+duration. (Note that we do not prefer registrations with null end dates; in the
+case of duplicate start dates, a registration with an explicit end date is more
+likely to be the correct one.) If there's still an exact tie we choose arbitrarily
+based on the practice ID.
     <details markdown="block">
     <summary>View method definition</summary>
 ```py
-spanning_regs = practice_registrations.where(practice_registrations.start_date <= date).except_where(
-    practice_registrations.end_date < date
-)
-ordered_regs = spanning_regs.sort_by(
+ordered_regs = practice_registrations.spanning(date, date).sort_by(
     practice_registrations.start_date,
     practice_registrations.end_date,
     practice_registrations.practice_pseudo_id,
@@ -739,13 +738,13 @@ return practice_registrations.spanning(date, date).exists_for_patient()
   </dt>
   <dd markdown="block">
 Filter registrations to just those spanning the entire period between
-`start_date` and `end_date`.
+`start_date` and `end_date` (inclusive).
     <details markdown="block">
     <summary>View method definition</summary>
 ```py
 return practice_registrations.where(
     practice_registrations.start_date.is_on_or_before(start_date)
-    & (practice_registrations.end_date.is_after(end_date) | practice_registrations.end_date.is_null())
+    & (practice_registrations.end_date.is_on_or_after(end_date) | practice_registrations.end_date.is_null())
 )
 
 ```

--- a/docs/includes/generated_docs/schemas/tpp.md
+++ b/docs/includes/generated_docs/schemas/tpp.md
@@ -3163,15 +3163,14 @@ Return each patient's practice registration as it was on the supplied date.
 
 Where a patient is registered with multiple practices we prefer the most recent
 registration and then, if there are multiple of these, the one with the longest
-duration. If there's still an exact tie we choose arbitrarily based on the
-practice ID.
+duration. (Note that we do not prefer registrations with null end dates; in the
+case of duplicate start dates, a registration with an explicit end date is more
+likely to be the correct one.) If there's still an exact tie we choose arbitrarily
+based on the practice ID.
     <details markdown="block">
     <summary>View method definition</summary>
 ```py
-spanning_regs = practice_registrations.where(practice_registrations.start_date <= date).except_where(
-    practice_registrations.end_date < date
-)
-ordered_regs = spanning_regs.sort_by(
+ordered_regs = practice_registrations.spanning(date, date).sort_by(
     practice_registrations.start_date,
     practice_registrations.end_date,
     practice_registrations.practice_pseudo_id,
@@ -3214,13 +3213,13 @@ return practice_registrations.spanning(date, date).exists_for_patient()
   </dt>
   <dd markdown="block">
 Filter registrations to just those spanning the entire period between
-`start_date` and `end_date`.
+`start_date` and `end_date` (inclusive).
     <details markdown="block">
     <summary>View method definition</summary>
 ```py
 return practice_registrations.where(
     practice_registrations.start_date.is_on_or_before(start_date)
-    & (practice_registrations.end_date.is_after(end_date) | practice_registrations.end_date.is_null())
+    & (practice_registrations.end_date.is_on_or_after(end_date) | practice_registrations.end_date.is_null())
 )
 
 ```

--- a/ehrql/tables/core.py
+++ b/ehrql/tables/core.py
@@ -159,13 +159,12 @@ class practice_registrations(EventFrame):
 
         Where a patient is registered with multiple practices we prefer the most recent
         registration and then, if there are multiple of these, the one with the longest
-        duration. If there's still an exact tie we choose arbitrarily based on the
-        practice ID.
+        duration. (Note that we do not prefer registrations with null end dates; in the
+        case of duplicate start dates, a registration with an explicit end date is more
+        likely to be the correct one.) If there's still an exact tie we choose arbitrarily
+        based on the practice ID.
         """
-        spanning_regs = self.where(self.start_date <= date).except_where(
-            self.end_date < date
-        )
-        ordered_regs = spanning_regs.sort_by(
+        ordered_regs = self.spanning(date, date).sort_by(
             self.start_date,
             self.end_date,
             self.practice_pseudo_id,
@@ -187,11 +186,11 @@ class practice_registrations(EventFrame):
     def spanning(self, start_date, end_date):
         """
         Filter registrations to just those spanning the entire period between
-        `start_date` and `end_date`.
+        `start_date` and `end_date` (inclusive).
         """
         return self.where(
             self.start_date.is_on_or_before(start_date)
-            & (self.end_date.is_after(end_date) | self.end_date.is_null())
+            & (self.end_date.is_on_or_after(end_date) | self.end_date.is_null())
         )
 
 

--- a/tests/integration/tables/test_core.py
+++ b/tests/integration/tables/test_core.py
@@ -281,7 +281,7 @@ def test_practice_registrations_spanning(
                     patient_id=5,
                     practice_pseudo_id=123,
                     start_date=date(2010, 2, 1),
-                    end_date=date(2010, 12, 1),
+                    end_date=date(2010, 12, 31),
                 ),
             ]
         },
@@ -302,6 +302,28 @@ def test_practice_registrations_spanning(
                 ),
             ]
         },
+        # Registration with start date and end date on bounds (spanning is inclusive)
+        {
+            core.practice_registrations: [
+                dict(
+                    patient_id=7,
+                    practice_pseudo_id=123,
+                    start_date=date(2010, 1, 1),
+                    end_date=date(2011, 1, 1),
+                ),
+            ]
+        },
+        # Registration with end date before upper bound
+        {
+            core.practice_registrations: [
+                dict(
+                    patient_id=8,
+                    practice_pseudo_id=123,
+                    start_date=date(2010, 1, 1),
+                    end_date=date(2010, 12, 31),
+                ),
+            ]
+        },
     )
 
     dataset = Dataset()
@@ -318,6 +340,8 @@ def test_practice_registrations_spanning(
         {"patient_id": 4, "has_spanning_practice_registration": False},
         {"patient_id": 5, "has_spanning_practice_registration": False},
         {"patient_id": 6, "has_spanning_practice_registration": False},
+        {"patient_id": 7, "has_spanning_practice_registration": True},
+        {"patient_id": 8, "has_spanning_practice_registration": False},
     ]
 
 
@@ -375,6 +399,42 @@ def test_practice_registrations_exists_for_patient_on(
             "is_registered_2015_01_01": False,
         },
     ]
+
+
+def test_practice_registrations_for_patient_on_and_exists_for_patient_on_are_consistent(
+    in_memory_engine,
+):
+    in_memory_engine.populate(
+        {
+            core.practice_registrations: [
+                dict(
+                    patient_id=1, start_date=date(2005, 1, 1), end_date=date(2010, 1, 1)
+                ),
+                dict(
+                    patient_id=2, start_date=date(2010, 1, 1), end_date=date(2011, 1, 1)
+                ),
+                dict(patient_id=3, start_date=date(2015, 1, 1)),
+                dict(
+                    patient_id=4,
+                    start_date=date(2010, 1, 1),
+                    end_date=date(2009, 12, 31),
+                ),
+            ],
+        },
+    )
+
+    dataset = Dataset()
+    dataset.define_population(core.practice_registrations.exists_for_patient())
+    dataset.for_patient_on_exists = core.practice_registrations.for_patient_on(
+        "2010-01-01"
+    ).exists_for_patient()
+    dataset.exists_for_patient_on = core.practice_registrations.exists_for_patient_on(
+        "2010-01-01"
+    )
+
+    results = in_memory_engine.extract(dataset)
+    for result in results:
+        assert result["for_patient_on_exists"] == result["exists_for_patient_on"]
 
 
 def test_ons_deaths_cause_of_death_is_in(in_memory_engine):

--- a/tests/integration/tables/test_core.py
+++ b/tests/integration/tables/test_core.py
@@ -280,7 +280,7 @@ def test_practice_registrations_spanning(
                 dict(
                     patient_id=5,
                     practice_pseudo_id=123,
-                    start_date=date(2010, 2, 1),
+                    start_date=date(2010, 1, 2),
                     end_date=date(2010, 12, 31),
                 ),
             ]


### PR DESCRIPTION
Closes #2690 

i.e. `practice_registrations.spanning("2001-01-01", "2010-12-31")` now requires a patient to have a registration that continuously spans 2010-01-01 to 2010-12-31 _inclusive_.  This also means that `practice_registrations.exists_for_patient_on("2010-12-31")` and `practice_registrations.for_patient_on("2010-12-31").exists_for_patient()` return consistent results