### PR TITLE
Update docs and tests for for_patient_on() methods

### DIFF
--- a/docs/includes/generated_docs/schemas/tpp.md
+++ b/docs/includes/generated_docs/schemas/tpp.md
@@ -53,6 +53,19 @@ from which other larger geographic representations can be derived
 
 [addresses_ukgeographies]: https://www.ons.gov.uk/methodology/geography/ukgeographies
 
+!!! warning
+
+    While questions such as "Where did a patient live at X date?" are straightforward,
+    obtaining the answer can be quite complex, as there can be multiple registered
+    addresses, which may not have clean start and end dates. E.g. Addresses may be overlapping,
+    or may have "floor" start dates (typically 1900-01-01), indicating that the start
+    date is unknown.
+
+    The [`for_patient_on` method](#addresses.for_patient_on) applies logic for determining
+    the most likely correct address for a patient on a specific date. However, studies
+    which may be particularly sensitive to this data should consider implementing
+    their own disambiguation logic.
+
 [Example ehrQL usage of addresses](../../how-to/examples.md#addresses)
 <div markdown="block" class="definition-list-wrapper">
   <div class="title">Columns</div>
@@ -327,8 +340,11 @@ to cross-reference other data associated with the address, such as the MSOA or
 index of multiple deprevation.
 
 Where there are multiple of these we prefer the most recently registered address
-and then, if there are multiple of these, the one with the longest duration. If
-there's stil an exact tie we choose arbitrarily based on the address ID.
+and then, if there are multiple of these, the one with the longest duration.
+(Note that we do not prefer addresses with null end dates; in the
+case of duplicate start dates, an address with an explicit end date is more
+likely to be the correct one.) If there's stil an exact tie we choose arbitrarily
+based on the address ID.
     <details markdown="block">
     <summary>View method definition</summary>
 ```py
@@ -3052,6 +3068,19 @@ Each record corresponds to a patient's registration with a practice.
 
 By default, only registrations with activated GP practices (practices that have acknowledged the new
 non-COVID directions) are included.
+
+!!! warning
+
+    While questions such as "Which practice was a patient registered at on X date?"
+    are straightforward, obtaining the answer can be quite complex, as there can be
+    multiple registrations for a patient, which may not have clean start and end dates.
+    E.g. Registrations may be overlapping, or may have "floor" start dates
+    (typically 1900-01-01), indicating that the start date is unknown.
+
+    The [`for_patient_on` method](#practice_registrations.for_patient_on) applies logic
+    for determining the most likely correct registration for a patient on a specific date.
+    However, studies which may be particularly sensitive to this data should consider
+    implementing their own disambiguation logic.
 
 ### TPP specific information
 

--- a/ehrql/tables/tpp.py
+++ b/ehrql/tables/tpp.py
@@ -65,6 +65,19 @@ class addresses(EventFrame):
 
     [addresses_ukgeographies]: https://www.ons.gov.uk/methodology/geography/ukgeographies
 
+    !!! warning
+
+        While questions such as "Where did a patient live at X date?" are straightforward,
+        obtaining the answer can be quite complex, as there can be multiple registered
+        addresses, which may not have clean start and end dates. E.g. Addresses may be overlapping,
+        or may have "floor" start dates (typically 1900-01-01), indicating that the start
+        date is unknown.
+
+        The [`for_patient_on` method](#addresses.for_patient_on) applies logic for determining
+        the most likely correct address for a patient on a specific date. However, studies
+        which may be particularly sensitive to this data should consider implementing
+        their own disambiguation logic.
+
     [Example ehrQL usage of addresses](../../how-to/examples.md#addresses)
     """
 
@@ -231,8 +244,12 @@ class addresses(EventFrame):
         index of multiple deprevation.
 
         Where there are multiple of these we prefer the most recently registered address
-        and then, if there are multiple of these, the one with the longest duration. If
-        there's stil an exact tie we choose arbitrarily based on the address ID.
+        and then, if there are multiple of these, the one with the longest duration.
+        (Note that we do not prefer addresses with null end dates; in the
+        case of duplicate start dates, an address with an explicit end date is more
+        likely to be the correct one.) If there's stil an exact tie we choose arbitrarily
+        based on the address ID.
+
         """
         spanning_addrs = self.where(self.start_date <= date).except_where(
             self.end_date < date
@@ -1682,6 +1699,19 @@ class practice_registrations(ehrql.tables.core.practice_registrations.__class__)
 
     By default, only registrations with activated GP practices (practices that have acknowledged the new
     non-COVID directions) are included.
+
+    !!! warning
+
+        While questions such as "Which practice was a patient registered at on X date?"
+        are straightforward, obtaining the answer can be quite complex, as there can be
+        multiple registrations for a patient, which may not have clean start and end dates.
+        E.g. Registrations may be overlapping, or may have "floor" start dates
+        (typically 1900-01-01), indicating that the start date is unknown.
+
+        The [`for_patient_on` method](#practice_registrations.for_patient_on) applies logic
+        for determining the most likely correct registration for a patient on a specific date.
+        However, studies which may be particularly sensitive to this data should consider
+        implementing their own disambiguation logic.
 
     ### TPP specific information
 

--- a/tests/integration/tables/test_core.py
+++ b/tests/integration/tables/test_core.py
@@ -162,7 +162,7 @@ def test_practice_registrations_for_patient_on(in_memory_engine):
                 ),
             ]
         },
-        # Overlapping: choose longest
+        # Overlapping: choose longest with non-null end date
         {
             core.practice_registrations: [
                 dict(
@@ -176,6 +176,12 @@ def test_practice_registrations_for_patient_on(in_memory_engine):
                     practice_pseudo_id=456,
                     start_date=date(2000, 1, 1),
                     end_date=date(2015, 1, 1),
+                ),
+                dict(
+                    patient_id=4,
+                    practice_pseudo_id=789,
+                    start_date=date(2000, 1, 1),
+                    end_date=None,
                 ),
             ]
         },

--- a/tests/integration/tables/test_tpp.py
+++ b/tests/integration/tables/test_tpp.py
@@ -76,7 +76,7 @@ def test_addresses_for_patient_on(in_memory_engine):
                 ),
             ]
         },
-        # Overlapping: choose longest
+        # Overlapping: choose longest with non-null end date
         {
             tpp.addresses: [
                 dict(
@@ -90,6 +90,12 @@ def test_addresses_for_patient_on(in_memory_engine):
                     address_id=109,
                     start_date=date(2000, 1, 1),
                     end_date=date(2015, 1, 1),
+                ),
+                dict(
+                    patient_id=5,
+                    address_id=112,
+                    start_date=date(2000, 1, 1),
+                    end_date=None,
                 ),
             ]
         },


### PR DESCRIPTION
Update the docs for `tpp.addresses.for_patient_on` to reflect the actual selection behaviour in the case of multiple addresses (i.e. that in the case of multiple identical start dates, we prefer the one with the longest duration with an explicit end date).
    
`core.practice_registrations.for_patient_on` had already been updated, but we add similar warnings to the tpp table about the complexity of identifying the registration on a specific date, and a warning to consider applying custom disambiguation logic. I added this to the table doc string with a link to the `for_patient_on` methods, because it seemed to fit best there in the displayed docs.
    
Also adds explicit test cases for null end dates in overlapping addresses/registrations with the same start date.

Closes #2540 
