### PR TITLE
fix: Set include_t1oo permission from environment

### DIFF
--- a/ehrql/backends/tpp.py
+++ b/ehrql/backends/tpp.py
@@ -134,6 +134,7 @@ class TPPBackend(SQLBackend):
     def modify_dataset(self, dataset):
         # Check the explicitly set permissions to determine if we can include NDOOs
         include_ndoo = "include_ndoo" in self.permissions
+        include_t1oo = self.include_t1oo or "include_t1oo" in self.permissions
 
         # Add extra condition(s) to the population definition to ensure that:
         # - Exclude T1OO unless explicitly flagged
@@ -149,7 +150,7 @@ class TPPBackend(SQLBackend):
         #   registration at an activated practice.
 
         modification_queries = []
-        if not self.include_t1oo:
+        if not include_t1oo:
             logger.info("Applying T1OO filtering")
             # PLEASE NOTE: This logic is referenced in our public documentation, so if we
             # make any changes here we should ensure that the documentation is kept

--- a/tests/integration/backends/test_tpp.py
+++ b/tests/integration/backends/test_tpp.py
@@ -3167,16 +3167,16 @@ def test_is_in_queries_on_columns_with_nonstandard_collation(
         "EHRQL_MAX_MULTIVALUE_PARAM_LENGTH": 1,
         "TEMP_DATABASE_NAME": "temp_tables",
     }
-    add_permissions_to_environment(environ, ("include_gp_unactivated", "include_ndoo"))
+    add_permissions_to_environment(
+        environ, ("include_gp_unactivated", "include_ndoo", "include_t1oo")
+    )
     results = mssql_engine.extract(
         dataset,
         # Configure query engine to always break out lists into temporary tables so we
         # exercise that code path
         environ=environ,
         backend=TPPBackend(environ=environ),
-        # Disable T1OO filter for test so we don't need to worry about creating
-        # registration histories
-        dsn=mssql_engine.database.host_url() + "?opensafely_include_t1oo=true",
+        dsn=mssql_engine.database.host_url(),
     )
 
     # Check that the expected patients match
@@ -3187,19 +3187,27 @@ def test_is_in_queries_on_columns_with_nonstandard_collation(
 
 
 @pytest.mark.parametrize(
-    "suffix,expected",
+    "suffix,environ,expected",
     [
         (
             "?opensafely_include_t1oo=false",
+            {},
             [(1, 2001), (4, 2004)],
         ),
         (
             "?opensafely_include_t1oo=true",
+            {},
+            [(1, 2001), (2, 2002), (3, 2003), (4, 2004)],
+        ),
+        (
+            # no dsn suffix, but the permission string has been passed in the env
+            "",
+            {"EHRQL_PERMISSIONS": '["include_t1oo"]'},
             [(1, 2001), (2, 2002), (3, 2003), (4, 2004)],
         ),
     ],
 )
-def test_t1oo_patients_excluded_as_specified(mssql_database, suffix, expected):
+def test_t1oo_patients_excluded_as_specified(mssql_database, suffix, environ, expected):
     mssql_database.setup(
         Patient(Patient_ID=1, DateOfBirth=date(2001, 1, 1)),
         Patient(Patient_ID=2, DateOfBirth=date(2002, 1, 1)),
@@ -3214,7 +3222,7 @@ def test_t1oo_patients_excluded_as_specified(mssql_database, suffix, expected):
     dataset.birth_year = tpp.patients.date_of_birth.year
     backend = TPPBackend(
         environ=add_permissions_to_environment(
-            {}, ("include_gp_unactivated", "include_ndoo")
+            environ, ("include_gp_unactivated", "include_ndoo")
         )
     )
     query_engine = backend.get_query_engine(mssql_database.host_url() + suffix)
@@ -4344,6 +4352,27 @@ def test_practice_registrations_and_clinical_events_excluded_as_specified(
         (
             "?opensafely_include_t1oo=true",
             {},
+            [(1, 2001), (4, 2004)],
+        ),
+        # T1OO in EHRQL_PERMISSIONS
+        (
+            "",
+            {"EHRQL_PERMISSIONS": '["include_ndoo"]'},
+            [(1, 2001), (3, 2003)],
+        ),
+        (
+            "",
+            {"EHRQL_PERMISSIONS": '["include_ndoo", "include_t1oo"]'},
+            [(1, 2001), (2, 2002), (3, 2003), (4, 2004)],
+        ),
+        (
+            "",
+            {},
+            [(1, 2001)],
+        ),
+        (
+            "",
+            {"EHRQL_PERMISSIONS": '["include_t1oo"]'},
             [(1, 2001), (4, 2004)],
         ),
     ],


### PR DESCRIPTION
This will be passed to ehrql from job-server (via the controller) soon, along with other permission strings.

For now, we continue to set the permission via the dsn suffix as well. This can be removed once job-server has been updated, and the t1oo permission is being passed through from the controller.

Note: in practice, we could just switch over now, as only completed Covid projects approved under the initial directive have permission, so currently running jobs should not be affected at all - include_t1oo will always be False.

Part of #2801 