### PR TITLE
Remove unused old t1oo permissions code

### DIFF
--- a/ehrql/backends/base.py
+++ b/ehrql/backends/base.py
@@ -17,13 +17,6 @@ class BaseBackend:
         self.environ = environ or {}
         self.permissions = parse_permissions(self.environ)
 
-    def modify_dsn(self, dsn: str | None) -> str | None:
-        """
-        This hook gives backends the option to modify the DSN before it's passed to the
-        query engine, including removing and storing any special-case config values
-        """
-        return dsn
-
     def modify_temp_table_schema(self, temp_table_schema, dsn, environ):
         """
         This hook gives backends the option to modify the name of the database schema in

--- a/ehrql/backends/tpp.py
+++ b/ehrql/backends/tpp.py
@@ -1,7 +1,6 @@
 import datetime
 import logging
 import re
-from urllib import parse
 
 import sqlalchemy
 
@@ -87,8 +86,6 @@ class TPPBackend(SQLBackend):
 
     DEFAULT_COLLATION = "Latin1_General_CI_AS"
 
-    include_t1oo = False
-
     def __init__(self, environ=None):
         super().__init__(environ)
         # "include_gp_unactivated" is a per-project permission defined in job-server
@@ -111,30 +108,10 @@ class TPPBackend(SQLBackend):
                 column_kwargs["type_"].collation = self.DEFAULT_COLLATION
             return column_kwargs
 
-    def modify_dsn(self, dsn):
-        """
-        Removes the `opensafely_include_t1oo` parameter if present and uses it to set
-        the `include_t1oo` attribute accordingly
-        """
-        parts = parse.urlparse(dsn)
-        params = parse.parse_qs(parts.query, keep_blank_values=True)
-
-        include_t1oo_values = params.pop("opensafely_include_t1oo", [])
-        if len(include_t1oo_values) == 1:
-            self.include_t1oo = include_t1oo_values[0].lower() == "true"
-        elif len(include_t1oo_values) != 0:
-            raise ValueError(
-                "`opensafely_include_t1oo` parameter must not be supplied more than once"
-            )
-
-        new_query = parse.urlencode(params, doseq=True)
-        new_parts = parts._replace(query=new_query)
-        return parse.urlunparse(new_parts)
-
     def modify_dataset(self, dataset):
         # Check the explicitly set permissions to determine if we can include NDOOs
         include_ndoo = "include_ndoo" in self.permissions
-        include_t1oo = self.include_t1oo or "include_t1oo" in self.permissions
+        include_t1oo = "include_t1oo" in self.permissions
 
         # Add extra condition(s) to the population definition to ensure that:
         # - Exclude T1OO unless explicitly flagged

--- a/ehrql/query_engines/base.py
+++ b/ehrql/query_engines/base.py
@@ -26,8 +26,6 @@ class BaseQueryEngine:
         `backend` is an optional Backend instance
         `environ` is an optional dictionary of environment values
         """
-        if backend is not None:
-            dsn = backend.modify_dsn(dsn)
         self.dsn = dsn
         self.backend = backend
         self.environ = environ or {}

--- a/tests/integration/backends/test_tpp.py
+++ b/tests/integration/backends/test_tpp.py
@@ -3187,27 +3187,19 @@ def test_is_in_queries_on_columns_with_nonstandard_collation(
 
 
 @pytest.mark.parametrize(
-    "suffix,environ,expected",
+    "environ,expected",
     [
         (
-            "?opensafely_include_t1oo=false",
             {},
             [(1, 2001), (4, 2004)],
         ),
         (
-            "?opensafely_include_t1oo=true",
-            {},
-            [(1, 2001), (2, 2002), (3, 2003), (4, 2004)],
-        ),
-        (
-            # no dsn suffix, but the permission string has been passed in the env
-            "",
             {"EHRQL_PERMISSIONS": '["include_t1oo"]'},
             [(1, 2001), (2, 2002), (3, 2003), (4, 2004)],
         ),
     ],
 )
-def test_t1oo_patients_excluded_as_specified(mssql_database, suffix, environ, expected):
+def test_t1oo_patients_excluded_as_specified(mssql_database, environ, expected):
     mssql_database.setup(
         Patient(Patient_ID=1, DateOfBirth=date(2001, 1, 1)),
         Patient(Patient_ID=2, DateOfBirth=date(2002, 1, 1)),
@@ -3225,7 +3217,7 @@ def test_t1oo_patients_excluded_as_specified(mssql_database, suffix, environ, ex
             environ, ("include_gp_unactivated", "include_ndoo")
         )
     )
-    query_engine = backend.get_query_engine(mssql_database.host_url() + suffix)
+    query_engine = backend.get_query_engine(mssql_database.host_url())
     results = query_engine.get_results(dataset._compile())
 
     assert list(results) == expected
@@ -4332,53 +4324,28 @@ def test_practice_registrations_and_clinical_events_excluded_as_specified(
 
 
 @pytest.mark.parametrize(
-    "suffix,environ,expected",
+    "environ,expected",
     [
         (
-            "?opensafely_include_t1oo=false",
             {"EHRQL_PERMISSIONS": '["include_ndoo"]'},
             [(1, 2001), (3, 2003)],
         ),
         (
-            "?opensafely_include_t1oo=true",
-            {"EHRQL_PERMISSIONS": '["include_ndoo"]'},
-            [(1, 2001), (2, 2002), (3, 2003), (4, 2004)],
-        ),
-        (
-            "?opensafely_include_t1oo=false",
-            {},
-            [(1, 2001)],
-        ),
-        (
-            "?opensafely_include_t1oo=true",
-            {},
-            [(1, 2001), (4, 2004)],
-        ),
-        # T1OO in EHRQL_PERMISSIONS
-        (
-            "",
-            {"EHRQL_PERMISSIONS": '["include_ndoo"]'},
-            [(1, 2001), (3, 2003)],
-        ),
-        (
-            "",
             {"EHRQL_PERMISSIONS": '["include_ndoo", "include_t1oo"]'},
             [(1, 2001), (2, 2002), (3, 2003), (4, 2004)],
         ),
         (
-            "",
             {},
             [(1, 2001)],
         ),
         (
-            "",
             {"EHRQL_PERMISSIONS": '["include_t1oo"]'},
             [(1, 2001), (4, 2004)],
         ),
     ],
 )
 def test_t1oo_and_ndoo_patients_excluded_as_specified(
-    mssql_database, suffix, environ, expected
+    mssql_database, environ, expected
 ):
     add_permissions_to_environment(environ, ("include_gp_unactivated",))
     mssql_database.setup(
@@ -4399,7 +4366,7 @@ def test_t1oo_and_ndoo_patients_excluded_as_specified(
     dataset.birth_year = tpp.patients.date_of_birth.year
 
     backend = TPPBackend(environ=environ)
-    query_engine = backend.get_query_engine(mssql_database.host_url() + suffix)
+    query_engine = backend.get_query_engine(mssql_database.host_url())
     results = query_engine.get_results(dataset._compile())
 
     assert list(results) == expected

--- a/tests/unit/backends/test_tpp.py
+++ b/tests/unit/backends/test_tpp.py
@@ -5,60 +5,6 @@ from ehrql.backends.tpp import TPPBackend
 
 
 @pytest.mark.parametrize(
-    "dsn_in,dsn_out,t1oo_status",
-    [
-        (
-            "mssql://user:pass@localhost:4321/db",
-            "mssql://user:pass@localhost:4321/db",
-            False,
-        ),
-        (
-            "mssql://user:pass@localhost:4321/db?param1=one&param2&param1=three",
-            "mssql://user:pass@localhost:4321/db?param1=one&param1=three&param2=",
-            False,
-        ),
-        (
-            "mssql://user:pass@localhost:4321/db?opensafely_include_t1oo&param2=two",
-            "mssql://user:pass@localhost:4321/db?param2=two",
-            False,
-        ),
-        (
-            "mssql://user:pass@localhost:4321/db?opensafely_include_t1oo=false",
-            "mssql://user:pass@localhost:4321/db",
-            False,
-        ),
-        (
-            "mssql://user:pass@localhost:4321/db?opensafely_include_t1oo=true",
-            "mssql://user:pass@localhost:4321/db",
-            True,
-        ),
-        (
-            "mssql://user:pass@localhost:4321/db?opensafely_include_t1oo=True",
-            "mssql://user:pass@localhost:4321/db",
-            True,
-        ),
-    ],
-)
-def test_tpp_backend_modify_dsn(dsn_in, dsn_out, t1oo_status):
-    backend = TPPBackend()
-    assert backend.modify_dsn(dsn_in) == dsn_out
-    assert backend.include_t1oo == t1oo_status
-
-
-@pytest.mark.parametrize(
-    "dsn",
-    [
-        "mssql://user:pass@localhost:4321/db?opensafely_include_t1oo=false&opensafely_include_t1oo=false",
-        "mssql://user:pass@localhost:4321/db?opensafely_include_t1oo=false&opensafely_include_t1oo",
-    ],
-)
-def test_tpp_backend_modify_dsn_rejects_duplicate_params(dsn):
-    backend = TPPBackend()
-    with pytest.raises(ValueError, match="must not be supplied more than once"):
-        backend.modify_dsn(dsn)
-
-
-@pytest.mark.parametrize(
     "exception,exit_code,custom_err",
     [
         (


### PR DESCRIPTION
t1oo permission now uses the new permissions system, and `include_t1oo` is passed in the EHRQL_PERMISSIONS environment variable (from job-server, via the RAP API and controller).  We can now remove the old code that parsed the database url (the Backend `modify_dsn` method).

Part 4 of https://github.com/opensafely-core/ehrql/issues/2801

(Note: the new code was added in parallel already for backwards compatibility - somewhat redundantly, as no active projects have t1oo permission at the moment. But just to confirm, no currently running or pending job requests have t1oo permission that could be affected by this change)