### PR TITLE
Filter T1OO with `WHERE` clause on `patients`

### DIFF
--- a/ehrql/backends/emisv2.py
+++ b/ehrql/backends/emisv2.py
@@ -1,10 +1,16 @@
+import logging
 import urllib.parse
 
 import ehrql.tables.emisv2
 import ehrql.tables.smoketest
 from ehrql.backends.base import QueryTable, SQLBackend
 from ehrql.query_engines.trino import TrinoQueryEngine
+from ehrql.query_model import nodes as qm
+from ehrql.query_model.introspection import get_table_nodes
 from ehrql.utils.docs_utils import exclude_from_docs
+
+
+logger = logging.getLogger(__name__)
 
 
 @exclude_from_docs
@@ -30,11 +36,46 @@ class EMISV2Backend(SQLBackend):
         parts = urllib.parse.urlparse(dsn)
         return parts.username
 
-    patients = QueryTable(
+    def modify_dataset(self, dataset):
+
+        if "include_t1oo" in self.permissions:
+            return dataset
+
+        # The patients table will be filtered to include only patients with T1OO data,
+        # so we need to ensure patients in the dataset exist in the patients table.
+        # Find the patients table node, or create one if it doesn't exist.
+        patients_table = None
+        for table in get_table_nodes(dataset):
+            if isinstance(table, qm.SelectPatientTable) and table.name == "patients":
+                patients_table = table
+                break
+
+        if not patients_table:
+            patients_table = qm.SelectPatientTable(
+                name="patients", schema=qm.TableSchema()
+            )
+
+        # Only include patients in the patients table
+        new_population = qm.Function.And(
+            dataset.population, qm.AggregateByPatient.Exists(patients_table)
+        )
+
+        return qm.Dataset(
+            population=new_population,
+            variables=dataset.variables,
+            events=dataset.events,
+            measures=dataset.measures,
+        )
+
+    @QueryTable.from_function
+    def patients(self):
+        filter_condition = ""
+        if "include_t1oo" not in self.permissions:
+            logger.info("Applying T1OO filtering")
+            filter_condition = "WHERE is_consent_93c1 IS NULL OR is_consent_93c1 = true"
         # Note: sex = 'U' (unknown) is a common value and
         # is handled by the ELSE clause
-        """
-        SELECT
+        return f"""SELECT
             patient_id AS patient_id,
             CAST(date_of_birth AS date) AS date_of_birth,
             CASE
@@ -45,8 +86,8 @@ class EMISV2Backend(SQLBackend):
             END AS sex,
             CAST(date_of_death AS date) AS date_of_death
         FROM patient
+        {filter_condition}
         """
-    )
 
     clinical_events = QueryTable(
         # Note that we use the observation's effective date here rather than

--- a/tests/backend_schemas/emisv2/schema.py
+++ b/tests/backend_schemas/emisv2/schema.py
@@ -34,6 +34,7 @@ class Patient(Base):
     date_of_birth = mapped_column(trdt.TIMESTAMP(precision=6, timezone=False))
     date_of_death = mapped_column(trdt.TIMESTAMP(precision=6, timezone=False))
     imd_rounded = mapped_column(t.DOUBLE)
+    is_consent_93c1 = mapped_column(t.BOOLEAN)
     middle_level_super_output_area = mapped_column(t.VARCHAR)
     registration_end_datetime = mapped_column(
         trdt.TIMESTAMP(precision=6, timezone=False)

--- a/tests/backend_schemas/emisv2/update_schema.py
+++ b/tests/backend_schemas/emisv2/update_schema.py
@@ -52,6 +52,7 @@ INCLUDED_TABLES_AND_COLUMNS = {
         "registration_end_datetime",
         "imd_rounded",
         "middle_level_super_output_area",
+        "is_consent_93c1",
     },
     "medication_issue_record": {
         "patient_id",

--- a/tests/integration/backends/test_emisv2.py
+++ b/tests/integration/backends/test_emisv2.py
@@ -1,7 +1,9 @@
 from datetime import UTC, date, datetime
 
+import pytest
 import sqlalchemy
 
+from ehrql import create_dataset
 from ehrql.backends.emisv2 import EMISV2Backend
 from ehrql.tables import emisv2
 from ehrql.utils.sqlalchemy_query_utils import CreateTableAs, GeneratedTable
@@ -36,7 +38,6 @@ def test_extract_smoketest_dataset_definition(trino_engine):
 
     # This query is a copy of the smoketest dataset definition query in
     # tests/acceptance/external_studies/test-age-distribution/analysis/dataset_definition.py
-    from ehrql import create_dataset
     from ehrql.tables.smoketest import patients
 
     index_year = 2022
@@ -215,3 +216,137 @@ def test_addresses(select_all_emisv2):
             "imd_rounded": 11100,
         }
     ]
+
+
+@pytest.mark.parametrize(
+    "environ,expected",
+    [
+        pytest.param(
+            {"EHRQL_PERMISSIONS": '["include_t1oo"]'},
+            [
+                {"patient_id": bytes([1] * 16), "birth_year": 2001},
+                {"patient_id": bytes([2] * 16), "birth_year": 2002},
+                {"patient_id": bytes([3] * 16), "birth_year": 2003},
+                {"patient_id": bytes([4] * 16), "birth_year": 2004},
+            ],
+            id="with_permissions",
+        ),
+        pytest.param(
+            {},
+            [
+                {"patient_id": bytes([3] * 16), "birth_year": 2003},
+                {"patient_id": bytes([4] * 16), "birth_year": 2004},
+            ],
+            id="without_T1OO_permissions",
+        ),
+    ],
+)
+def test_t1oo_patients_excluded_as_specified(trino_engine, environ, expected):
+    trino_engine.setup(
+        Patient(
+            _pk=1,
+            patient_id=bytes([1] * 16).decode("utf-8"),
+            date_of_birth=datetime(2001, 1, 1, 0, 0, 0, 0),
+            is_consent_93c1=False,
+        ),
+        Patient(
+            _pk=2,
+            patient_id=bytes([2] * 16).decode("utf-8"),
+            date_of_birth=datetime(2002, 1, 1, 0, 0, 0, 0),
+            is_consent_93c1=False,
+        ),
+        Patient(
+            _pk=3,
+            patient_id=bytes([3] * 16).decode("utf-8"),
+            date_of_birth=datetime(2003, 1, 1, 0, 0, 0, 0),
+            is_consent_93c1=True,
+        ),
+        Patient(
+            _pk=4,
+            patient_id=bytes([4] * 16).decode("utf-8"),
+            date_of_birth=datetime(2004, 1, 1, 0, 0, 0, 0),
+        ),
+    )
+
+    from ehrql.tables import emisv2
+
+    dataset = create_dataset()
+    dataset.birth_year = emisv2.patients.date_of_birth.year
+    dataset.define_population(dataset.birth_year >= 2000)
+
+    results = trino_engine.extract(
+        dataset,
+        backend=EMISV2Backend(environ=environ),
+    )
+
+    assert list(results) == expected
+
+
+@pytest.mark.parametrize(
+    "environ,expected",
+    [
+        pytest.param(
+            {"EHRQL_PERMISSIONS": '["include_t1oo"]'},
+            [
+                {"patient_id": bytes([1] * 16), "registration_start_year": 2001},
+                {"patient_id": bytes([2] * 16), "registration_start_year": 2002},
+                {"patient_id": bytes([3] * 16), "registration_start_year": 2003},
+                {"patient_id": bytes([4] * 16), "registration_start_year": 2004},
+            ],
+            id="with_permissions",
+        ),
+        pytest.param(
+            {},
+            [
+                {"patient_id": bytes([3] * 16), "registration_start_year": 2003},
+                {"patient_id": bytes([4] * 16), "registration_start_year": 2004},
+            ],
+            id="without_T1OO_permissions",
+        ),
+    ],
+)
+def test_t1oo_patients_excluded_as_specified_when_population_definition_does_not_use_patients_table(
+    trino_engine, environ, expected
+):
+    trino_engine.setup(
+        Patient(
+            _pk=1,
+            patient_id=bytes([1] * 16).decode("utf-8"),
+            registration_start_datetime=datetime(2001, 1, 1, 0, 0, 0, 0),
+            is_consent_93c1=False,
+        ),
+        Patient(
+            _pk=2,
+            patient_id=bytes([2] * 16).decode("utf-8"),
+            registration_start_datetime=datetime(2002, 1, 1, 0, 0, 0, 0),
+            is_consent_93c1=False,
+        ),
+        Patient(
+            _pk=3,
+            patient_id=bytes([3] * 16).decode("utf-8"),
+            registration_start_datetime=datetime(2003, 1, 1, 0, 0, 0, 0),
+            is_consent_93c1=True,
+        ),
+        Patient(
+            _pk=4,
+            patient_id=bytes([4] * 16).decode("utf-8"),
+            registration_start_datetime=datetime(2004, 1, 1, 0, 0, 0, 0),
+        ),
+    )
+
+    from ehrql.tables import emisv2
+
+    dataset = create_dataset()
+    dataset.registration_start_year = (
+        emisv2.practice_registrations.sort_by(emisv2.practice_registrations.start_date)
+        .last_for_patient()
+        .start_date.year
+    )
+    dataset.define_population(dataset.registration_start_year >= 2000)
+
+    results = trino_engine.extract(
+        dataset,
+        backend=EMISV2Backend(environ=environ),
+    )
+
+    assert list(results) == expected


### PR DESCRIPTION
Draft implementation of #2802  to collect feedback.

This approach conditionally applies a `WHERE` clause to the `patients` table.
It then uses `modify_dataset` to ensure that only patients in the filtered `patients` table are included in the dataset population.

The ticket seems to expect filtering to occur all within the `modify_dataset` method, so this approach might not be what the ticket asked for.
An alternative approach using an internal list of patient IDs is explored in #2817.
https://github.com/opensafely-core/ehrql/compare/1f32b25..d76c242

Note that I have not taken extensibility for the NDOO stuff into account on purpose to keep the code simple.