### PR TITLE
Pin hypothesis to 6.152.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,7 +135,7 @@ exclude-newer-package = {}
 [dependency-groups]
 dev = [
   "docker",
-  "hypothesis",
+  "hypothesis==6.152.8",
   "openpyxl>=3.1.5",
   "pre-commit",
   "pyright[nodejs]",

--- a/requirements.uvmirror
+++ b/requirements.uvmirror
@@ -36,7 +36,7 @@ ghp-import==2.1.0
     # via mkdocs
 greenlet==3.5.0 ; platform_machine == 'AMD64' or platform_machine == 'WIN32' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'ppc64le' or platform_machine == 'win32' or platform_machine == 'x86_64'
     # via sqlalchemy
-hypothesis==6.152.9
+hypothesis==6.152.8
 identify==2.6.19
     # via pre-commit
 idna==3.15

--- a/uv.lock
+++ b/uv.lock
@@ -287,14 +287,14 @@ wheels = [
 
 [[package]]
 name = "hypothesis"
-version = "6.152.9"
+version = "6.152.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "sortedcontainers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3b/fb/a5651eb0cd03ecee644e8f4d8cd2027b40a08bf1488f46201e794aebe9b5/hypothesis-6.152.9.tar.gz", hash = "sha256:de4711d69ce3a18009047c3b44882810fd0c0348c1558e920a4b0d2c45f59e1e", size = 472009, upload-time = "2026-05-19T17:10:19.586Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ac/81/9260841df522f923a1c9b5879f2192e237db22e68d3594939866a97f1120/hypothesis-6.152.8.tar.gz", hash = "sha256:9c0dd56c6ce5649ef3289555ae9fec40663401cf7134a99f926acf1b91fb6d9f", size = 468156, upload-time = "2026-05-18T23:19:27.866Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/79/d9/40ef7ed22f0c45c2316467edb9afb8fc172cd089cb329c0ee6da6b74416c/hypothesis-6.152.9-py3-none-any.whl", hash = "sha256:9c4fdccb1eac0b12ec740c12290d0e6a0bea3526a3f0bf812b7643bb563c2d8b", size = 538148, upload-time = "2026-05-19T17:10:16.131Z" },
+    { url = "https://files.pythonhosted.org/packages/54/59/0faf3a4ad69ac1d14988658f02b03a1384e32131abd17af8b8a6069db21c/hypothesis-6.152.8-py3-none-any.whl", hash = "sha256:61b1e6e14f0623e8afe27a4a1b1fce5a4611beefef015b987a5c7d0359babbda", size = 533809, upload-time = "2026-05-18T23:19:24.735Z" },
 ]
 
 [[package]]
@@ -650,7 +650,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "docker" },
-    { name = "hypothesis" },
+    { name = "hypothesis", specifier = "==6.152.8" },
     { name = "mkdocs" },
     { name = "mkdocs-material" },
     { name = "openpyxl", specifier = ">=3.1.5" },


### PR DESCRIPTION
uv add hypothesis==6.152.8 --dev
just upgrade-package hypothesis

It appears that the new changes in hypothesis 6.152.9 caused the generative tests to run much slower than before.
Pinning to avoid very long test runs in CI.