### PR TITLE
fix: Update the NDOO table name

### DIFF
--- a/ehrql/backends/tpp.py
+++ b/ehrql/backends/tpp.py
@@ -73,8 +73,8 @@ class TPPBackend(SQLBackend):
             # It doesn't need any columns: it's just a list of patient IDs
             schema=qm.TableSchema(),
         ),
-        "ndoo": qm.SelectPatientTable(
-            "ndoo",
+        "patients_without_ndoo": qm.SelectPatientTable(
+            "patients_without_ndoo",
             # It doesn't need any columns: it's just a list of patient IDs
             schema=qm.TableSchema(),
         ),
@@ -150,7 +150,9 @@ class TPPBackend(SQLBackend):
             # https://github.com/opensafely/documentation/blob/7f8d660480fdc5e798ebe6dff6f9ed9762431736/docs/national-data-opt-outs.md
             logger.info("Applying NDOO filtering")
             modification_queries.append(
-                qm.AggregateByPatient.Exists(self.internal_tables["ndoo"])
+                qm.AggregateByPatient.Exists(
+                    self.internal_tables["patients_without_ndoo"]
+                )
             )
 
         if self.apply_gp_activations:
@@ -258,8 +260,8 @@ class TPPBackend(SQLBackend):
         columns={},
     )
 
-    ndoo = MappedTable(
-        source="NationalDataOptOut",
+    patients_without_ndoo = MappedTable(
+        source="PatientsWithoutNDOO",
         # The allowed patients table (those who have NOT opted out) doesn't need any columns:
         # it's just a list of patient IDs
         columns={},

--- a/tests/backend_schemas/tpp/schema.py
+++ b/tests/backend_schemas/tpp/schema.py
@@ -6876,8 +6876,8 @@ class MedicationSensitivity(Base):
     StartDate = mapped_column(t.DateTime, nullable=False, default="9999-12-31T00:00:00")
 
 
-class NationalDataOptOut(Base):
-    __tablename__ = "NationalDataOptOut"
+class PatientsWithoutNDOO(Base):
+    __tablename__ = "PatientsWithoutNDOO"
     _pk = mapped_column(t.Integer, primary_key=True)
 
     Patient_ID = mapped_column(t.BIGINT, nullable=False, default=0)

--- a/tests/backend_schemas/tpp/update_schema.py
+++ b/tests/backend_schemas/tpp/update_schema.py
@@ -151,8 +151,8 @@ def add_extra_tables(by_table):
     # These tables do not yet exist in the database and/or the schema information table.
     # Once they're included there and we publish the new schema then the automated action
     # will create a PR which will fail until we remove the below code.
-    assert "NationalDataOptOut" not in by_table
-    by_table["NationalDataOptOut"] = [
+    assert "PatientsWithoutNDOO" not in by_table
+    by_table["PatientsWithoutNDOO"] = [
         {"ColumnName": "Patient_ID", "ColumnType": "bigint", "IsNullable": "False"},
     ]
 

--- a/tests/functional/test_generate_dataset.py
+++ b/tests/functional/test_generate_dataset.py
@@ -7,9 +7,9 @@ from ehrql.file_formats import FILE_FORMATS
 from ehrql.tables import EventFrame, core, table
 from tests.backend_schemas.tpp.schema import (
     DirectionsAcknowledged,
-    NationalDataOptOut,
     Organisation,
     Patient,
+    PatientsWithoutNDOO,
     RegistrationHistory,
 )
 from tests.lib.file_utils import read_file_as_dicts
@@ -829,8 +829,8 @@ def test_generate_dataset_with_ndoo_permissions(
         Patient(Patient_ID=2, DateOfBirth=datetime(2002, 5, 5)),
         Patient(Patient_ID=3, DateOfBirth=datetime(2003, 5, 5)),
         # NDOO table contains patients who are allowed (i.e. not opted-out)
-        NationalDataOptOut(Patient_ID=2),
-        NationalDataOptOut(Patient_ID=3),
+        PatientsWithoutNDOO(Patient_ID=2),
+        PatientsWithoutNDOO(Patient_ID=3),
     )
 
     dataset_definition_path = tmp_path / "dataset_definition.py"

--- a/tests/integration/backends/test_tpp.py
+++ b/tests/integration/backends/test_tpp.py
@@ -43,7 +43,6 @@ from tests.backend_schemas.tpp.schema import (
     MedicationDictionary,
     MedicationIssue,
     MedicationRepeat,
-    NationalDataOptOut,
     ONS_Deaths,
     OPA_Cost,
     OPA_Cost_ARCHIVED,
@@ -55,6 +54,7 @@ from tests.backend_schemas.tpp.schema import (
     Organisation,
     Patient,
     PatientAddress,
+    PatientsWithoutNDOO,
     PatientsWithTypeOneDissent,
     PotentialCareHomeAddress,
     RegistrationHistory,
@@ -179,12 +179,12 @@ def test_activated(select_all_tpp):
     ]
 
 
-@register_test_for(TPPBackend.internal_tables["ndoo"])
+@register_test_for(TPPBackend.internal_tables["patients_without_ndoo"])
 def test_ndoo(select_all_tpp):
     results = select_all_tpp(
         Patient(Patient_ID=1),
         Patient(Patient_ID=2),
-        NationalDataOptOut(Patient_ID=1),
+        PatientsWithoutNDOO(Patient_ID=1),
     )
     assert results == [{"patient_id": 1}]
 
@@ -3244,8 +3244,8 @@ def test_ndoo_patients_excluded_as_specified(mssql_database, environ, expected):
         Patient(Patient_ID=3, DateOfBirth=date(2003, 1, 1)),
         Patient(Patient_ID=4, DateOfBirth=date(2004, 1, 1)),
         # NDOO table contains patients who are allowed (i.e. not opted-out)
-        NationalDataOptOut(Patient_ID=1),
-        NationalDataOptOut(Patient_ID=4),
+        PatientsWithoutNDOO(Patient_ID=1),
+        PatientsWithoutNDOO(Patient_ID=4),
     )
 
     dataset = create_dataset()
@@ -4354,8 +4354,8 @@ def test_t1oo_and_ndoo_patients_excluded_as_specified(
         Patient(Patient_ID=3, DateOfBirth=date(2003, 1, 1)),
         Patient(Patient_ID=4, DateOfBirth=date(2004, 1, 1)),
         # NDOO table contains patients who are allowed (i.e. not opted-out)
-        NationalDataOptOut(Patient_ID=1),
-        NationalDataOptOut(Patient_ID=4),
+        PatientsWithoutNDOO(Patient_ID=1),
+        PatientsWithoutNDOO(Patient_ID=4),
         # T1OO table contains patients who are NOT allowed (i.e. have opted-out)
         PatientsWithTypeOneDissent(Patient_ID=2),
         PatientsWithTypeOneDissent(Patient_ID=4),


### PR DESCRIPTION
The NDOO table name is PatientsWithoutNDOO, rather than NationalDataOptOut, as previously assumed. I've also updated the backend table name (to patients_without_ndoo) so it's clearer what it actually contains. The existing filtering logic is correct (if a job does not have permission to use NDOO, we filter the dataset population to only those patients that exist in the patients_without_ndoo table).

Note that we still need the exemption in the test schema, until the database reports have been rerun and published.