### PR TITLE
Change `no cover file` to `exclude file`

### DIFF
--- a/ehrql/docs/__main__.py
+++ b/ehrql/docs/__main__.py
@@ -1,5 +1,5 @@
 # This is tested implicitly by running it in CI to check that the docs haven't changed.
-# pragma: no cover file
+# pragma: exclude file
 
 import shutil
 import sys

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ exclude_also = [
     "@function_body_as_string",
     # Custom multiline pragma to allow excluding whole files. See:
     # https://coverage.readthedocs.io/en/7.11.0/excluding.html#multi-line-exclusion-regexes
-    '\A(?s:.*# pragma: no cover file.*)\Z',
+    '\A(?s:.*# pragma: exclude file.*)\Z',
 ]
 omit = [
     "tests/acceptance/external_studies/*",

--- a/tests/autocomplete/autocomplete_definition.py
+++ b/tests/autocomplete/autocomplete_definition.py
@@ -1,5 +1,5 @@
 # This is loaded by the JS autocomplete engine and so doesn't show up in Python coverage
-# pragma: no cover file
+# pragma: exclude file
 from ehrql import days, maximum_of, minimum_of, weeks
 from ehrql.tables import core, emis, emisv2, tpp
 

--- a/tests/backend_schemas/emisv2/schema_diagram.py
+++ b/tests/backend_schemas/emisv2/schema_diagram.py
@@ -10,7 +10,7 @@ NOTE: The diagram is generated from the output of emisv2/script.py. To update th
 follow the instructions in emisv2/script.py first.
 """
 
-# pragma: no cover file
+# pragma: exclude file
 
 from pathlib import Path
 

--- a/tests/backend_schemas/emisv2/update_schema.py
+++ b/tests/backend_schemas/emisv2/update_schema.py
@@ -1,6 +1,6 @@
 # This is currently run manually with individual credentials. It may be run on a
 # schedule in future, but is not worth independently testing
-# pragma: no cover file
+# pragma: exclude file
 import csv
 import keyword
 import os

--- a/tests/backend_schemas/tpp/update_schema.py
+++ b/tests/backend_schemas/tpp/update_schema.py
@@ -1,5 +1,5 @@
 # This is run automatically on a schedule and not worth independently testing
-# pragma: no cover file
+# pragma: exclude file
 import csv
 import keyword
 import re

--- a/tests/lib/create_tables.py
+++ b/tests/lib/create_tables.py
@@ -10,7 +10,7 @@ Or use:
 
 """
 
-# pragma: no cover file
+# pragma: exclude file
 import importlib
 import os
 


### PR DESCRIPTION
See [this Slack discussion](https://bennettoxford.slack.com/archives/C069YDR4NCA/p1778231644424229).

When `coverage` sees `no cover` on the first line it only excludes the line from coverage. This means that it wouldn't try to match the line against our regex that would tell it to exclude the entire file.

Change the regex such that it no longer clashes with `pragma: no cover`, allowing any file that contains this (even on the
first line) to be entirely excluded from coverage as intended.

Note: I considered reverting the preamble comment added in https://github.com/opensafely-core/ehrql/commit/508a7016a9a730bf463257d3c2edf33508efb258 now that it's not needed to get our desired behaviour, but it might as well stay to be consistent with the TPP version of the script.