### PR TITLE
Add minimal Event Level Data docs

### DIFF
--- a/docs/explanation/event-level-data.md
+++ b/docs/explanation/event-level-data.md
@@ -1,0 +1,93 @@
+# Event Level Data
+
+Datasets in ehrQL are restricted to one row per patient (or "patient-level") outputs.
+The Event Level Data system allows you to add supplementary output files alongside the
+main dataset which can contain more than one row per patient.
+
+
+## Adding events to a dataset
+
+Events are added using the
+[`add_event_table()`](../reference/language.md#Dataset.add_event_table) method on
+datasets. As an example, suppose you wanted to retrieve all relevant vaccination and
+hospitalisation events for a set of patients:
+
+```python
+# ... imports etc ...
+
+dataset = create_dataset()
+
+dataset.define_population(
+  (patients.age_on(study_start) >= 18)
+  & (patients.age_on(study_start) <= 65)
+)
+
+# Get some vaccination events 
+vaxx = vaccinations.where(
+    vaccinations.date.is_on_or_between(study_start, study_end)
+    & (vaccinations.target_disease == "SARS-2 CORONAVIRUS")
+)
+
+# Get some hospital admissions with a certain diagnosis
+admissions = apcs.where(
+    apcs.primary_diagnosis.is_in(respiratory_codes)
+)
+
+# Add these events to the dataset as ancillary files
+
+dataset.add_event_table(
+    "covid_vaccinations",
+    date=vaxx.date,
+    product=vaxx.product_name,
+)
+
+dataset.add_event_table(
+    "respiratory_admissions",
+    admitted=admissions.admission_date,
+    discharged=admissions.discharge_date,
+)
+```
+
+As the example shows, the `add_event_table()` method takes a name string and then some
+number of column keywords. The table name can be whatever you want: it just affects what
+the output file is called. Likewise with the column names.
+
+You can add as many event tables to a dataset as you need.
+
+Note that events are only returned for patients who **match the population definition**
+of the dataset.
+
+
+## Configuring outputs
+
+Because event level output consists of multiple files rather than a single dataset file,
+the way you specify the `--output` argument to `generate-dataset` is slightly different.
+Instead of writing:
+```
+--output outputs/cohort.arrow
+```
+
+You write:
+```
+--output outputs/cohort/:arrow
+```
+
+Instead of a single file called `cohort` this will create a _directory_ called
+`cohort` which will contain multiple files: a `dataset.arrow` file with the normal
+one-row-per-patient output, and then one file for each of the event tables you've
+defined.
+
+Note that this works with any supported file format, not just Arrow.
+
+You will also need to change the `outputs:` specification in your `project.yaml` file to
+match, changing `output/cohort.arrow` to `output/cohort/*.arrow`.
+
+A complete example might look like:
+```yaml
+generate_dataset:
+  run: ehrql:v1 generate-dataset analysis/dataset_definition.py
+    --output output/cohort/:arrow
+  outputs:
+    highly_sensitive:
+      cohort: output/cohort/*.arrow
+```

--- a/docs/explanation/event-level-data.md
+++ b/docs/explanation/event-level-data.md
@@ -1,5 +1,7 @@
 # Event Level Data
 
+---8<-- 'includes/eld-warning.md'
+
 Datasets in ehrQL are restricted to one row per patient (or "patient-level") outputs.
 The Event Level Data system allows you to add supplementary output files alongside the
 main dataset which can contain more than one row per patient.

--- a/docs/explanation/index.md
+++ b/docs/explanation/index.md
@@ -8,3 +8,4 @@ These explanations provide background knowledge for learning ehrQL.
 * [Selecting populations for study](selecting-populations-for-study.md)
 * [The OpenSAFELY VS Code extension](vscode-extension.md)
 * [How ehrQL generates dummy data](dummy-data.md)
+* [Event level data](event-level-data.md)

--- a/docs/includes/eld-warning.md
+++ b/docs/includes/eld-warning.md
@@ -1,0 +1,3 @@
+!!! warning "This feature is currently only available for data development work"
+    The Event Level Data system is currently in the trial phase for use during data
+    development and is not generally available for research use.

--- a/docs/includes/generated_docs/language__dataset.md
+++ b/docs/includes/generated_docs/language__dataset.md
@@ -105,4 +105,81 @@ dataset.configure_dummy_data(population_size=10000)
 ```
 </div>
 
+<div class="attr-heading" id="Dataset.add_event_table">
+  <tt><strong>add_event_table</strong>(<em>name</em>, <em>&lt;column_name&gt;=event_series</em>, …)</tt>
+  <a class="headerlink" href="#Dataset.add_event_table" title="Permanent link">🔗</a>
+</div>
+<div markdown="block" class="indent">
+---8<-- 'includes/eld-warning.md'
+
+Add an [EventTable](#EventTable) to the dataset which can contain multiple rows
+of data per patient.
+
+See the [Event Level Data](../explanation/event-level-data.md) documentation for
+an overview of this feature.
+
+_name_<br>
+Name of the new table, used as the attribute name on the dataset and as
+the filename of the supplementary output file.
+
+_&lt;column_name&gt;=event_series arguments_<br>
+Additional keyword arguments define columns on the EventTable. Each argument
+should be a Series but, in contrast to a Dataset, they can contain more than one
+value per patient.
+
+Example usage:
+```python
+dataset.add_event_table(
+    "vaccinations",
+    date=vaccination_events.date,
+    product=vaccination_events.product,
+)
+```
+</div>
+
+</div>
+
+
+<h4 class="attr-heading" id="EventTable" data-toc-label="EventTable" markdown>
+  <tt><em>class</em> <strong>EventTable</strong>()</tt>
+</h4>
+
+<div markdown="block" class="indent">
+---8<-- 'includes/eld-warning.md'
+
+To create a new EventTable use the [`add_event_table`](#Dataset.add_event_table)
+method. For example:
+```python
+dataset.add_event_table(
+    "vaccinations",
+    date=vaccination_events.date,
+)
+```
+
+Additional columns can be added as attributes on the EventTable. For example:
+```python
+dataset.vaccinations.product = vaccination_events.product
+```
+
+See the [Event Level Data](../explanation/event-level-data.md) documentation for an
+overview of this feature.
+<div class="attr-heading" id="EventTable.add_column">
+  <tt><strong>add_column</strong>(<em>name</em>, <em>series</em>)</tt>
+  <a class="headerlink" href="#EventTable.add_column" title="Permanent link">🔗</a>
+</div>
+<div markdown="block" class="indent">
+Add a column to the EventTable.
+
+_column_name_<br>
+The name of the new column, as a string.
+
+_series_<br>
+An ehrQL query that returns multiple rows of data per patient.
+
+Example usage:
+```python
+dataset.vaccinations.add_column("product", vaccination_events.product)
+```
+</div>
+
 </div>

--- a/ehrql/docs/common.py
+++ b/ehrql/docs/common.py
@@ -37,6 +37,7 @@ def get_arguments(function, ignore_self=False):
         param.name: {
             "default": None if param.default is param.empty else repr(param.default),
             "repeatable": param.kind is param.VAR_POSITIONAL,
+            "is_kwargs": param.kind is param.VAR_KEYWORD,
         }
         for param in parameters
     }

--- a/ehrql/docs/language.py
+++ b/ehrql/docs/language.py
@@ -20,7 +20,6 @@ EXCLUDE_FROM_DOCS = {
     ql.DummyDataConfig,
     ql.Error,
     ql.int_property,  # Internal thing for type hints and autocomplete
-    ql.EventTable,
     ql.TableFromFileDecorator,
 }
 
@@ -77,6 +76,7 @@ def build_language():
         "dataset": dict(
             create_dataset=namespace["create_dataset"],
             Dataset=namespace["Dataset"],
+            EventTable=namespace["EventTable"],
         ),
         "frames": {
             name: attr

--- a/ehrql/docs/language.py
+++ b/ehrql/docs/language.py
@@ -167,6 +167,11 @@ def build_value_details(name, value):
 
 
 def build_class_details(name, cls):
+    if is_included_object(cls.__init__):
+        init_arguments = get_arguments(cls.__init__, ignore_self=True)
+    else:
+        init_arguments = {}
+
     return {
         "name": name,
         "docstring": get_class_docstring(cls),
@@ -178,7 +183,7 @@ def build_class_details(name, cls):
             ],
             key=method_order,
         ),
-        "init_arguments": get_arguments(cls.__init__, ignore_self=True),
+        "init_arguments": init_arguments,
     }
 
 

--- a/ehrql/docs/render_includes/language.py
+++ b/ehrql/docs/render_includes/language.py
@@ -88,9 +88,19 @@ def render_signature(name, arguments):
 
 
 def render_argument(name, details):
+    if details["is_kwargs"]:
+        return render_argument_kwargs(name, details)
     default = f"={details['default']}" if details["default"] is not None else ""
     prefix = "*" if details["repeatable"] else ""
     return f"<em>{prefix}{name}{default}</em>"
+
+
+def render_argument_kwargs(name, details):
+    assert "__" in name, (
+        f"Expected kwargs argument to be named like key__value, got: {name}"
+    )
+    key, value = name.split("__")
+    return f"<em>&lt;{key}&gt;={value}</em>, …"
 
 
 FUNCTION_TEMPLATE = """

--- a/ehrql/query_language.py
+++ b/ehrql/query_language.py
@@ -213,6 +213,8 @@ class Dataset:
 
     def add_event_table(self, name, **column_name__event_series):
         """
+        ---8<-- 'includes/eld-warning.md'
+
         Add an [EventTable](#EventTable) to the dataset which can contain multiple rows
         of data per patient.
 
@@ -251,6 +253,8 @@ class Dataset:
 
 class EventTable:
     """
+    ---8<-- 'includes/eld-warning.md'
+
     To create a new EventTable use the [`add_event_table`](#Dataset.add_event_table)
     method. For example:
     ```python

--- a/ehrql/query_language.py
+++ b/ehrql/query_language.py
@@ -216,6 +216,9 @@ class Dataset:
         Add an [EventTable](#EventTable) to the dataset which can contain multiple rows
         of data per patient.
 
+        See the [Event Level Data](../explanation/event-level-data.md) documentation for
+        an overview of this feature.
+
         _name_<br>
         Name of the new table, used as the attribute name on the dataset and as
         the filename of the supplementary output file.
@@ -261,6 +264,9 @@ class EventTable:
     ```python
     dataset.vaccinations.product = vaccination_events.product
     ```
+
+    See the [Event Level Data](../explanation/event-level-data.md) documentation for an
+    overview of this feature.
     """
 
     @exclude_from_docs

--- a/ehrql/query_language.py
+++ b/ehrql/query_language.py
@@ -17,6 +17,7 @@ from ehrql.query_model.column_specs import get_column_specs_from_schema
 from ehrql.query_model.nodes import get_series_type, has_one_row_per_patient
 from ehrql.query_model.population_validation import validate_population_definition
 from ehrql.utils import date_utils
+from ehrql.utils.docs_utils import exclude_from_docs
 from ehrql.utils.string_utils import strip_indent
 
 
@@ -199,10 +200,6 @@ class Dataset:
         self._variables[name] = value
 
     def __getattr__(self, name):
-        # Make this method accessible while hiding it from autocomplete until we make it
-        # generally available
-        if name == "add_event_table":
-            return self._internal
         if name in self._variables:
             return self._variables[name]
         if name in self._events:
@@ -214,11 +211,31 @@ class Dataset:
         else:
             raise AttributeError(f"Variable '{name}' has not been defined")
 
-    # This method ought to be called `add_event_table` but we're deliberately
-    # obfuscating its name for now
-    def _internal(self, name, **event_series):
+    def add_event_table(self, name, **column_name__event_series):
+        """
+        Add an [EventTable](#EventTable) to the dataset which can contain multiple rows
+        of data per patient.
+
+        _name_<br>
+        Name of the new table, used as the attribute name on the dataset and as
+        the filename of the supplementary output file.
+
+        _&lt;column_name&gt;=event_series arguments_<br>
+        Additional keyword arguments define columns on the EventTable. Each argument
+        should be a Series but, in contrast to a Dataset, they can contain more than one
+        value per patient.
+
+        Example usage:
+        ```python
+        dataset.add_event_table(
+            "vaccinations",
+            date=vaccination_events.date,
+            product=vaccination_events.product,
+        )
+        ```
+        """
         _validate_attribute_name(name, self._variables | self._events, context="table")
-        self._events[name] = EventTable(self, **event_series)
+        self._events[name] = EventTable(self, **column_name__event_series)
 
     def _compile(self):
         return qm.Dataset(
@@ -230,6 +247,23 @@ class Dataset:
 
 
 class EventTable:
+    """
+    To create a new EventTable use the [`add_event_table`](#Dataset.add_event_table)
+    method. For example:
+    ```python
+    dataset.add_event_table(
+        "vaccinations",
+        date=vaccination_events.date,
+    )
+    ```
+
+    Additional columns can be added as attributes on the EventTable. For example:
+    ```python
+    dataset.vaccinations.product = vaccination_events.product
+    ```
+    """
+
+    @exclude_from_docs
     def __init__(self, dataset, **series):
         # Store reference to the parent dataset to aid debug rendering
         object.__setattr__(self, "_dataset", dataset)
@@ -239,14 +273,28 @@ class EventTable:
         for name, value in series.items():
             self.add_column(name, value)
 
-    def add_column(self, name, value):
+    def add_column(self, name, series):
+        """
+        Add a column to the EventTable.
+
+        _column_name_<br>
+        The name of the new column, as a string.
+
+        _series_<br>
+        An ehrQL query that returns multiple rows of data per patient.
+
+        Example usage:
+        ```python
+        dataset.vaccinations.add_column("product", vaccination_events.product)
+        ```
+        """
         _validate_attribute_name(name, self._series, context="column")
-        validate_ehrql_series(value, context=f"column {name!r}")
+        validate_ehrql_series(series, context=f"column {name!r}")
         try:
             qm_node = qm.SeriesCollectionFrame(
                 {
-                    name: series._qm_node
-                    for name, series in (self._series | {name: value}).items()
+                    name: value._qm_node
+                    for name, value in (self._series | {name: series}).items()
                 }
             )
         except qm.PatientDomainError:
@@ -259,7 +307,7 @@ class EventTable:
                 "cannot combine series drawn from different tables; "
                 "create a new event table for these series"
             )
-        self._series[name] = value
+        self._series[name] = series
         object.__setattr__(self, "_qm_node", qm_node)
 
     def __setattr__(self, name, value):

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -75,6 +75,7 @@ nav:
     - Selecting populations for study: explanation/selecting-populations-for-study.md
     - The OpenSAFELY VS Code extension: explanation/vscode-extension.md
     - How ehrQL generates dummy data: explanation/dummy-data.md
+    - Event level data: explanation/event-level-data.md
 
 theme:
   name: material


### PR DESCRIPTION
As requested [on Slack][1] this adds some basic documentation on how to use Event Level Data, together with some clear warnings that this is not yet generally available.

Previews links:
 * https://evansd-eld-docs.databuilder.pages.dev/explanation/event-level-data/
 * https://evansd-eld-docs.databuilder.pages.dev/reference/language/#Dataset.add_event_table

Closes #2833

[1]: https://bennettoxford.slack.com/archives/C07UG9PCR6E/p1782297865242369