### PR TITLE
fix: Handle addresses with 'NFA' MSOACode

### DIFF
--- a/ehrql/backends/tpp.py
+++ b/ehrql/backends/tpp.py
@@ -333,10 +333,10 @@ class TPPBackend(SQLBackend):
                 NULLIF(addr.RuralUrbanClassificationCode, -1) AS rural_urban_classification,
                 NULLIF(addr.ImdRankRounded, -1) AS imd_rounded,
                 CASE
-                    WHEN addr.MSOACode NOT IN ('NPC', '') THEN addr.MSOACode
+                    WHEN addr.MSOACode NOT IN ('NPC', 'NFA', '') THEN addr.MSOACode
                 END AS msoa_code,
                 CASE
-                    WHEN addr.MSOACode NOT IN ('NPC', '') THEN 1
+                    WHEN addr.MSOACode NOT IN ('NPC', 'NFA', '') THEN 1
                     ELSE 0
                 END AS has_postcode,
                 CASE

--- a/tests/integration/backends/test_tpp.py
+++ b/tests/integration/backends/test_tpp.py
@@ -248,6 +248,16 @@ def test_addresses(select_all_tpp):
             ImdRankRounded=1000,
             MSOACode="NPC",
         ),
+        PatientAddress(
+            Patient_ID=1,
+            PatientAddress_ID=6,
+            StartDate="9999-12-31T00:00:00",
+            EndDate="9999-12-31T00:00:00",
+            AddressType=3,
+            RuralUrbanClassificationCode=4,
+            ImdRankRounded=1000,
+            MSOACode="NFA",
+        ),
     )
     assert results == [
         {
@@ -295,6 +305,20 @@ def test_addresses(select_all_tpp):
         {
             "patient_id": 1,
             "address_id": 5,
+            "start_date": None,
+            "end_date": None,
+            "address_type": 3,
+            "rural_urban_classification": 4,
+            "imd_rounded": 1000,
+            "msoa_code": None,
+            "has_postcode": False,
+            "care_home_is_potential_match": False,
+            "care_home_requires_nursing": None,
+            "care_home_does_not_require_nursing": None,
+        },
+        {
+            "patient_id": 1,
+            "address_id": 6,
             "start_date": None,
             "end_date": None,
             "address_type": 3,


### PR DESCRIPTION
MSOACode can take the values '', NPC and NFA in addition to valid MSOA codes. We handle '' and NPC (no postcode) already, and use these to set the msoa_code to NULL and determine the boolean has_postcode column, which we use as part of the logic for deciding the address to return for addresses.for_patient_on()
(we prefer addresses with a postcode over those without). This updates addresses with an MSOACode NFA (no fixed abode?) to be handled in the same way.

This is a change in the way ehrQL behaves. It would only affect patient addresses with multiple registered addresses on a specific date. Of these, we prefer those with a postcode, then the address with the most recent start date, then the one with the longest duration, and finally we tie-break on address ID. Previously, any address with NFA as the MSOA Code would be considered an address with a postcode, and depending on the start/end dates, could be the selected address returned by for_patient_on(). Now it is considered an address without a postcode, so will never be selected if another address exists on that date with a valid MSOA code.

Closes #2790 