### PR TITLE
Implement NDOO filtering for EmisV2

### DIFF
--- a/ehrql/backends/emisv2.py
+++ b/ehrql/backends/emisv2.py
@@ -36,6 +36,11 @@ class EMISV2Backend(SQLBackend):
             # It doesn't need any columns: it's just a list of patient IDs
             schema=qm.TableSchema(),
         ),
+        "ndoo": qm.SelectPatientTable(
+            "ndoo",
+            # It doesn't need any columns: it's just a list of patient IDs
+            schema=qm.TableSchema(),
+        ),
     }
 
     @classmethod
@@ -56,6 +61,14 @@ class EMISV2Backend(SQLBackend):
             modification_queries.append(
                 qm.Function.Not(
                     qm.AggregateByPatient.Exists(self.internal_tables["t1oo"])
+                )
+            )
+        if "include_ndoo" not in self.permissions:
+            # TODO: Add reference to docs, similar to TPP, once available
+            logger.info("Applying NDOO filtering")
+            modification_queries.append(
+                qm.Function.Not(
+                    qm.AggregateByPatient.Exists(self.internal_tables["ndoo"])
                 )
             )
 
@@ -150,5 +163,23 @@ class EMISV2Backend(SQLBackend):
         FROM patient
         WHERE
             is_consent_9nu0 = false
+        """
+    )
+
+    ndoo = QueryTable(
+        # is_national_data_opted_in is based on an active verification process where
+        # practices periodically check each patient's status against the NHS National
+        # Data Opt-Out service. If a patient hasn't been verified (or their check has
+        # expired after 21 days), this value defaults to FALSE rather than assuming
+        # they're opted in.
+        # The field is false if the patient has opted out, and true or NULL if the
+        # patient has opted in.
+        # See https://docs.partner.emis-x.uk/explorer/opensafely/patient/schema/
+        """
+        SELECT
+            patient_id
+        FROM patient
+        WHERE
+            is_national_data_opted_in = false
         """
     )

--- a/tests/backend_schemas/emisv2/schema.py
+++ b/tests/backend_schemas/emisv2/schema.py
@@ -35,6 +35,7 @@ class Patient(Base):
     date_of_death = mapped_column(trdt.TIMESTAMP(precision=6, timezone=False))
     imd_rounded = mapped_column(t.DOUBLE)
     is_consent_9nu0 = mapped_column(t.BOOLEAN)
+    is_national_data_opted_in = mapped_column(t.BOOLEAN)
     middle_level_super_output_area = mapped_column(t.VARCHAR)
     registration_end_datetime = mapped_column(
         trdt.TIMESTAMP(precision=6, timezone=False)

--- a/tests/backend_schemas/emisv2/update_schema.py
+++ b/tests/backend_schemas/emisv2/update_schema.py
@@ -53,6 +53,7 @@ INCLUDED_TABLES_AND_COLUMNS = {
         "imd_rounded",
         "middle_level_super_output_area",
         "is_consent_9nu0",
+        "is_national_data_opted_in",
     },
     "medication_issue_record": {
         "patient_id",

--- a/tests/integration/backends/test_emisv2.py
+++ b/tests/integration/backends/test_emisv2.py
@@ -296,3 +296,160 @@ def test_t1oo_patients_excluded_as_specified(trino_engine, environ, expected):
     results = trino_engine.extract(dataset, backend=EMISV2Backend(environ=environ))
 
     assert list(results) == expected
+
+
+@register_test_for(EMISV2Backend.internal_tables["ndoo"])
+def test_ndoo(select_all_emisv2):
+    results = select_all_emisv2(
+        Patient(
+            _pk=1,
+            patient_id=(b"1" * 16).decode("utf-8"),
+            is_national_data_opted_in=False,
+        ),
+        Patient(
+            _pk=2,
+            patient_id=(b"2" * 16).decode("utf-8"),
+            is_national_data_opted_in=True,
+        ),
+        Patient(
+            _pk=3,
+            patient_id=(b"3" * 16).decode("utf-8"),
+        ),
+    )
+    assert results == [{"patient_id": (b"1" * 16)}]
+
+
+@pytest.mark.parametrize(
+    "environ,expected",
+    [
+        pytest.param(
+            {"EHRQL_PERMISSIONS": '["include_ndoo"]'},
+            [
+                {"patient_id": (b"1" * 16), "birth_year": 2001},
+                {"patient_id": (b"2" * 16), "birth_year": 2002},
+                {"patient_id": (b"3" * 16), "birth_year": 2003},
+                {"patient_id": (b"4" * 16), "birth_year": 2004},
+            ],
+            id="with_permissions",
+        ),
+        pytest.param(
+            {},
+            [
+                {"patient_id": (b"3" * 16), "birth_year": 2003},
+                {"patient_id": (b"4" * 16), "birth_year": 2004},
+            ],
+            id="without_NDOO_permissions",
+        ),
+    ],
+)
+def test_ndoo_patients_excluded_as_specified(trino_engine, environ, expected):
+    trino_engine.setup(
+        Patient(
+            _pk=1,
+            patient_id=(b"1" * 16).decode("utf-8"),
+            date_of_birth=datetime(2001, 1, 1, 0, 0, 0, 0),
+            is_national_data_opted_in=False,
+        ),
+        Patient(
+            _pk=2,
+            patient_id=(b"2" * 16).decode("utf-8"),
+            date_of_birth=datetime(2002, 1, 1, 0, 0, 0, 0),
+            is_national_data_opted_in=False,
+        ),
+        Patient(
+            _pk=3,
+            patient_id=(b"3" * 16).decode("utf-8"),
+            date_of_birth=datetime(2003, 1, 1, 0, 0, 0, 0),
+            is_national_data_opted_in=True,
+        ),
+        Patient(
+            _pk=4,
+            patient_id=(b"4" * 16).decode("utf-8"),
+            date_of_birth=datetime(2004, 1, 1, 0, 0, 0, 0),
+        ),
+    )
+
+    dataset = create_dataset()
+    dataset.birth_year = emisv2.patients.date_of_birth.year
+    dataset.define_population(dataset.birth_year >= 2000)
+
+    results = trino_engine.extract(dataset, backend=EMISV2Backend(environ=environ))
+
+    assert list(results) == expected
+
+
+@pytest.mark.parametrize(
+    "environ,expected",
+    [
+        pytest.param(
+            {"EHRQL_PERMISSIONS": '["include_ndoo"]'},
+            [
+                {"patient_id": (b"3" * 16), "birth_year": 2003},
+                {"patient_id": (b"4" * 16), "birth_year": 2004},
+            ],
+            id="NDOO permission only",
+        ),
+        pytest.param(
+            {"EHRQL_PERMISSIONS": '["include_t1oo"]'},
+            [
+                {"patient_id": (b"2" * 16), "birth_year": 2002},
+                {"patient_id": (b"4" * 16), "birth_year": 2004},
+            ],
+            id="T1OO permission only",
+        ),
+        pytest.param(
+            {"EHRQL_PERMISSIONS": '["include_ndoo", "include_t1oo"]'},
+            [
+                {"patient_id": (b"1" * 16), "birth_year": 2001},
+                {"patient_id": (b"2" * 16), "birth_year": 2002},
+                {"patient_id": (b"3" * 16), "birth_year": 2003},
+                {"patient_id": (b"4" * 16), "birth_year": 2004},
+            ],
+            id="NDOO and T1OO permissions",
+        ),
+        pytest.param(
+            {}, [{"patient_id": (b"4" * 16), "birth_year": 2004}], id="no permissions"
+        ),
+    ],
+)
+def test_t1oo_and_ndoo_patients_excluded_as_specified(trino_engine, environ, expected):
+    trino_engine.setup(
+        # opted OUT of both, only include if we have both include_ndoo and include_t1oo permissions
+        Patient(
+            _pk=1,
+            patient_id=(b"1" * 16).decode("utf-8"),
+            date_of_birth=datetime(2001, 1, 1, 0, 0, 0, 0),
+            is_national_data_opted_in=False,
+            is_consent_9nu0=False,
+        ),
+        # Opted out of T1OO, in to NDOO; only include if we have the include_t1oo permission
+        Patient(
+            _pk=2,
+            patient_id=(b"2" * 16).decode("utf-8"),
+            date_of_birth=datetime(2002, 1, 1, 0, 0, 0, 0),
+            is_national_data_opted_in=True,
+            is_consent_9nu0=False,
+        ),
+        # Opted out of NDOO, in to T1OO; only include if we have the include_ndoo permission
+        Patient(
+            _pk=3,
+            patient_id=(b"3" * 16).decode("utf-8"),
+            date_of_birth=datetime(2003, 1, 1, 0, 0, 0, 0),
+            is_national_data_opted_in=False,
+            is_consent_9nu0=True,
+        ),
+        # Null values are counted as opted IN for both, always include
+        Patient(
+            _pk=4,
+            patient_id=(b"4" * 16).decode("utf-8"),
+            date_of_birth=datetime(2004, 1, 1, 0, 0, 0, 0),
+        ),
+    )
+
+    dataset = create_dataset()
+    dataset.birth_year = emisv2.patients.date_of_birth.year
+    dataset.define_population(dataset.birth_year >= 2000)
+
+    results = trino_engine.extract(dataset, backend=EMISV2Backend(environ=environ))
+
+    assert list(results) == expected


### PR DESCRIPTION
This is implemented in the same way as T1OO, by creating an internal table that contains only a list of patient IDs, corresponding to the patients who have opted OUT of national data sharing.

Note that according to the EMIS schema docs, if is_national_data_opted_in is NULL, the patient is considered to have opted in.

Closes #2804 