### PR TITLE
Change table update frequency in docs

### DIFF
--- a/docs/includes/generated_docs/schemas/core.md
+++ b/docs/includes/generated_docs/schemas/core.md
@@ -150,7 +150,7 @@ Registered deaths
 Date and cause of death based on information recorded when deaths are
 certified and registered in England and Wales from February 2019 onwards.
 The data provider is the Office for National Statistics (ONS).
-This table is updated approximately weekly in OpenSAFELY.
+This table is updated approximately every four weeks in OpenSAFELY.
 
 This table includes the underlying cause of death and up to 15 medical conditions
 mentioned on the death certificate.  These codes (`cause_of_death_01` to

--- a/docs/includes/generated_docs/schemas/emis.md
+++ b/docs/includes/generated_docs/schemas/emis.md
@@ -151,7 +151,7 @@ Registered deaths
 Date and cause of death based on information recorded when deaths are
 certified and registered in England and Wales from February 2019 onwards.
 The data provider is the Office for National Statistics (ONS).
-This table is updated approximately weekly in OpenSAFELY.
+This table is updated approximately every four weeks in OpenSAFELY.
 
 This table includes the underlying cause of death and up to 15 medical conditions
 mentioned on the death certificate.  These codes (`cause_of_death_01` to

--- a/docs/includes/generated_docs/schemas/raw.tpp.md
+++ b/docs/includes/generated_docs/schemas/raw.tpp.md
@@ -960,7 +960,7 @@ Registered deaths
 Date and cause of death based on information recorded when deaths are
 certified and registered in England and Wales from February 2019 onwards.
 The data provider is the Office for National Statistics (ONS).
-This table is updated approximately weekly in OpenSAFELY.
+This table is updated approximately every four weeks in OpenSAFELY.
 
 This table includes the underlying cause of death, place of death, and up to
 15 medical conditions mentioned on the death certificate.

--- a/docs/includes/generated_docs/schemas/tpp.md
+++ b/docs/includes/generated_docs/schemas/tpp.md
@@ -1091,7 +1091,7 @@ and outpatient settings.
 * **Data provider** NHS England
 * **Participation / Coverage** Inpatients and outpatients treated with antivirals/nMABs for COVID-19 in England
 * **Provenance** Data sourced largely from BlueTeq system (forms completed by clinicians)
-* **Update frequency in OpenSAFELY** Approximately weekly
+* **Update frequency in OpenSAFELY** Approximately every four weeks
 * **Delay between event occurring and event appearing in OpenSAFELY** Approximately 2-9 days
 * **Collected information** Treatment start date; therapeutic intervention; COVID indication, current status, risk group, region
 
@@ -2037,7 +2037,7 @@ Registered deaths
 Date and cause of death based on information recorded when deaths are
 certified and registered in England and Wales from February 2019 onwards.
 The data provider is the Office for National Statistics (ONS).
-This table is updated approximately weekly in OpenSAFELY.
+This table is updated approximately every four weeks in OpenSAFELY.
 
 This table includes the underlying cause of death and up to 15 medical conditions
 mentioned on the death certificate.  These codes (`cause_of_death_01` to

--- a/ehrql/tables/core.py
+++ b/ehrql/tables/core.py
@@ -202,7 +202,7 @@ class ons_deaths(PatientFrame):
     Date and cause of death based on information recorded when deaths are
     certified and registered in England and Wales from February 2019 onwards.
     The data provider is the Office for National Statistics (ONS).
-    This table is updated approximately weekly in OpenSAFELY.
+    This table is updated approximately every four weeks in OpenSAFELY.
 
     This table includes the underlying cause of death and up to 15 medical conditions
     mentioned on the death certificate.  These codes (`cause_of_death_01` to

--- a/ehrql/tables/raw/tpp.py
+++ b/ehrql/tables/raw/tpp.py
@@ -470,7 +470,7 @@ class ons_deaths(EventFrame):
     Date and cause of death based on information recorded when deaths are
     certified and registered in England and Wales from February 2019 onwards.
     The data provider is the Office for National Statistics (ONS).
-    This table is updated approximately weekly in OpenSAFELY.
+    This table is updated approximately every four weeks in OpenSAFELY.
 
     This table includes the underlying cause of death, place of death, and up to
     15 medical conditions mentioned on the death certificate.

--- a/ehrql/tables/tpp.py
+++ b/ehrql/tables/tpp.py
@@ -784,7 +784,7 @@ class covid_therapeutics(EventFrame):
     * **Data provider** NHS England
     * **Participation / Coverage** Inpatients and outpatients treated with antivirals/nMABs for COVID-19 in England
     * **Provenance** Data sourced largely from BlueTeq system (forms completed by clinicians)
-    * **Update frequency in OpenSAFELY** Approximately weekly
+    * **Update frequency in OpenSAFELY** Approximately every four weeks
     * **Delay between event occurring and event appearing in OpenSAFELY** Approximately 2-9 days
     * **Collected information** Treatment start date; therapeutic intervention; COVID indication, current status, risk group, region
 
@@ -1241,7 +1241,7 @@ class ons_deaths(ehrql.tables.core.ons_deaths.__class__):
     Date and cause of death based on information recorded when deaths are
     certified and registered in England and Wales from February 2019 onwards.
     The data provider is the Office for National Statistics (ONS).
-    This table is updated approximately weekly in OpenSAFELY.
+    This table is updated approximately every four weeks in OpenSAFELY.
 
     This table includes the underlying cause of death and up to 15 medical conditions
     mentioned on the death certificate.  These codes (`cause_of_death_01` to


### PR DESCRIPTION
From the 7th of August 2026, TPP data will be refreshed every four weeks instead of every week.

https://docs.google.com/document/d/1W6TXJmD4BwBjUNwMeSalIzK9rqekH-0TCsn-AOJ-j_4

The ONS Deaths and Covid Therapeutics tables are the only ones which document the change frequency in the ehrQL docs, so update them to match the new cadence.