### PR TITLE
fix: Fix the hes cutoff date check output

### DIFF
--- a/ehrql/backend_admin/tpp/hes_cutoff_date_check.py
+++ b/ehrql/backend_admin/tpp/hes_cutoff_date_check.py
@@ -64,6 +64,6 @@ def run(*, backend_class, dsn, expected_activity_month, environ, user_args):
             if next(result)[0] == 0:
                 check_ok = False
                 break
-    # Print true/false so a wrapping `docker run` (i.e. a RAP agent job) can read whether the
+    # Print OK/FAILED so a wrapping `docker run` (i.e. a RAP agent job) can read whether the
     # check succeeded or not from the container's stdout and report the results to the RAP controller.
-    print("true" if check_ok else "false")
+    print("OK" if check_ok else "FAILED")

--- a/tests/integration/backend_admin/tpp/test_hes_cutoff_date_check.py
+++ b/tests/integration/backend_admin/tpp/test_hes_cutoff_date_check.py
@@ -9,7 +9,7 @@ from tests.backend_schemas.tpp.schema import APCS, EC, OPA
     [
         (
             # True when all tables contain at least one instance of target month
-            "true",
+            "OK",
             {
                 "APCS": ["202301", "202304", "202305"],
                 "EC": ["202301", "202304", "202305"],
@@ -18,7 +18,7 @@ from tests.backend_schemas.tpp.schema import APCS, EC, OPA
         ),
         (
             # False if a single table does not contain the target month
-            "false",
+            "FAILED",
             {
                 "APCS": ["202301", "202304", "202305"],
                 "EC": ["202301", "202304", "202305"],
@@ -27,7 +27,7 @@ from tests.backend_schemas.tpp.schema import APCS, EC, OPA
         ),
         (
             # False if no tables contain the target month
-            "false",
+            "FAILED",
             {
                 "APCS": ["202301"],
                 "EC": ["202301"],


### PR DESCRIPTION
It needs to match the expected output in the agent task, which is "OK" or "FAILED"
https://github.com/opensafely-core/job-runner/blob/6ea6404a17db88a7be635db9c4af39ef0c173da4/agent/main.py#L472