### PR TITLE
Fix bug in `QueryGraphRewriter`

### DIFF
--- a/ehrql/backends/tpp.py
+++ b/ehrql/backends/tpp.py
@@ -19,7 +19,7 @@ from ehrql.codes import CTV3Code, DMDCode, SNOMEDCTCode
 from ehrql.query_engines.mssql import MSSQLQueryEngine
 from ehrql.query_model import nodes as qm
 from ehrql.query_model.introspection import get_table_nodes
-from ehrql.query_model.transforms import replace_nodes
+from ehrql.query_model.query_graph_rewriter import QueryGraphRewriter
 
 
 logger = logging.getLogger(__name__)
@@ -194,7 +194,7 @@ class TPPBackend(SQLBackend):
         )
 
     def _apply_gp_activation_filtering(self, dataset, activated_table_node):
-        replacement_tables = {}
+        rewriter = QueryGraphRewriter()
         for table in get_table_nodes(dataset):
             if not table.activation_filter_field:
                 continue
@@ -209,9 +209,9 @@ class TPPBackend(SQLBackend):
                     qm.SelectColumn(source=activated_table_node, name="end_date"),
                 ),
             )
-            replacement_tables[table] = filtered_table
+            rewriter.replace(table, filtered_table)
 
-        dataset = replace_nodes(dataset, replacement_tables)
+        dataset = rewriter.rewrite(dataset)
 
         return dataset
 

--- a/ehrql/backends/tpp.py
+++ b/ehrql/backends/tpp.py
@@ -209,7 +209,7 @@ class TPPBackend(SQLBackend):
                     qm.SelectColumn(source=activated_table_node, name="end_date"),
                 ),
             )
-            rewriter.replace(table, filtered_table)
+            rewriter.wrap(table, filtered_table)
 
         dataset = rewriter.rewrite(dataset)
 

--- a/ehrql/query_model/query_graph_rewriter.py
+++ b/ehrql/query_model/query_graph_rewriter.py
@@ -13,12 +13,12 @@ class QueryGraphRewriter:
 
     def __init__(self):
         self.replacements = {}
-        self.cache = {}
 
     def replace(self, target_node, new_node):
         self.replacements[target_node] = new_node
 
     def rewrite(self, obj):
+        self.cache = {}
         return self._rewrite(obj, self.replacements)
 
     def _rewrite(self, obj, replacements):

--- a/ehrql/query_model/query_graph_rewriter.py
+++ b/ehrql/query_model/query_graph_rewriter.py
@@ -17,6 +17,26 @@ class QueryGraphRewriter:
     one but incorporating these replacements.
     """
 
+    # These are types which we don't attempt to recurse into and rewrite
+    PASS_THROUGH_TYPES = (
+        # We always return Values unchanged. It doesn't make much sense to, e.g. replace
+        # all the occurences of 4 in a query with 5. And by handling these explicitly we
+        # don't have to exhaustively list the types of object a Value can contain.
+        qm.Value
+        # InlinePatientTables are similar to Values in that they're wrappers around
+        # static data supplied by the user and we likewise don't want to recurse into
+        # these
+        | qm.InlinePatientTable
+        # Some non-Node types which appear in the query model
+        | qm.Position
+        | qm.TableSchema
+        # The few primitive types which appear in the query model and are not always
+        # wrapped in a `Value`
+        | NoneType
+        | int
+        | str
+    )
+
     def __init__(self, replacements=None):
         self.replacements = replacements or {}
 
@@ -61,16 +81,8 @@ class QueryGraphRewriter:
             raise
 
     def _rewrite(self, obj):
-        if isinstance(obj, qm.Value):
-            # We always return Values unchanged. It doesn't make much sense to, e.g.
-            # replace all the occurences of 4 in a query with 5. And by handling these
-            # explicitly we don't have to exhaustively list the types of object a Value
-            # can contain.
-            return obj
-        elif isinstance(obj, qm.InlinePatientTable):
-            # InlinePatientTables are similar to Values in that they're wrappers around
-            # static data supplied by the user and we likewise don't want to recurse
-            # into these
+        if isinstance(obj, self.PASS_THROUGH_TYPES):
+            # Certain types we don't attempt to unpack and just pass through unmodified
             return obj
         elif isinstance(obj, qm.Node):
             # This is where most the work gets done
@@ -81,9 +93,6 @@ class QueryGraphRewriter:
         elif isinstance(obj, frozenset | tuple):
             # As do frozensets and tuples
             return obj.__class__(self._rewrite(v) for v in obj)
-        elif isinstance(obj, NoneType | int | str | qm.Position | qm.TableSchema):
-            # Other expected types we return unchanged
-            return obj
         else:
             assert False, f"Unhandled value: {obj}"
 

--- a/ehrql/query_model/query_graph_rewriter.py
+++ b/ehrql/query_model/query_graph_rewriter.py
@@ -18,14 +18,14 @@ class QueryGraphRewriter:
         self.replacements[target_node] = new_node
 
     def rewrite(self, obj):
+        # Shortcut when there's no work to be done
+        if not self.replacements:
+            return obj
+
         self.cache = {}
         return self._rewrite(obj)
 
     def _rewrite(self, obj):
-        # Shortcut when there's no remaining work to be done
-        if not self.replacements:
-            return obj
-
         if isinstance(obj, qm.Value):
             # We always return Values unchanged. It doesn't make much sense to, e.g.
             # replace all the occurences of 4 in a query with 5. And by handling these

--- a/ehrql/query_model/query_graph_rewriter.py
+++ b/ehrql/query_model/query_graph_rewriter.py
@@ -1,6 +1,12 @@
+import enum
 from types import NoneType
 
 from ehrql.query_model import nodes as qm
+
+
+class ReplacementType(enum.Enum):
+    NON_WRAPPING = enum.auto()
+    WRAPPING = enum.auto()
 
 
 class QueryGraphRewriter:
@@ -15,7 +21,29 @@ class QueryGraphRewriter:
         self.replacements = replacements or {}
 
     def replace(self, target_node, new_node):
-        self.replacements[target_node] = new_node
+        """
+        Specify that `target_node` should be replaced by `new_node` wherever it appears.
+
+        Note that if you to use this to "wrap" a node by replacing it with something
+        that has the original target node as a child (e.g. replacing `A` with `X -> A`)
+        then you will encounter an infinite recursion error when attempting to rewrite a
+        graph.
+
+        For replacements of this sort you should use the `wrap()` method below, which is
+        less performant but handles this case correctly.
+        """
+        self.replacements[target_node] = new_node, ReplacementType.NON_WRAPPING
+
+    def wrap(self, target_node, new_node):
+        """
+        Specify that `target_node` should be replaced by `new_node` wherever it appears.
+
+        This method should be used whenever `new_node` contains `target_node`.
+        Attempting to use the default `replace()` method will lead to an infinite
+        recursion error. However as the replacement algorithm used here is much less
+        performant it should only be used when actually needed.
+        """
+        self.replacements[target_node] = new_node, ReplacementType.WRAPPING
 
     def rewrite(self, obj):
         # Shortcut when there's no work to be done
@@ -67,23 +95,30 @@ class QueryGraphRewriter:
             return self._rewrite_node_attributes(node)
 
     def _replace_node(self, node):
-        # Our replacements are sometimes insertions e.g. given the following graph:
-        #
-        #     A -> B -> C
-        #
-        # We might want to replace B with X, where X wraps B:
-        #
-        #     A -> X -> B -> C
-        #
-        # To do this we need to make sure that while we're in the process of generating
-        # B's replacement we don't attempt to replace B _again_ in any downstream
-        # segments of the graph, which would lead to infinite recursion. We avoid this
-        # by creating a new rewriter for the sub-graph which has the currently active
-        # replacement rule removed.
-        other_replacements = self.replacements.copy()
-        new_node = other_replacements.pop(node)
-        subgraph_rewriter = self.__class__(other_replacements)
-        return subgraph_rewriter.rewrite(new_node)
+        new_node, replacement_type = self.replacements[node]
+        if replacement_type is ReplacementType.WRAPPING:
+            # Our replacements are sometimes insertions e.g. given the following graph:
+            #
+            #     A -> B -> C
+            #
+            # We might want to replace B with X, where X wraps B:
+            #
+            #     A -> X -> B -> C
+            #
+            # To do this we need to make sure that while we're in the process of
+            # generating B's replacement we don't attempt to replace B _again_ in any
+            # downstream segments of the graph, which would lead to infinite recursion.
+            # We avoid this by creating a new rewriter for the sub-graph which has the
+            # currently active replacement rule removed.
+            other_replacements = self.replacements.copy()
+            other_replacements.pop(node)
+            subgraph_rewriter = self.__class__(other_replacements)
+            return subgraph_rewriter.rewrite(new_node)
+        elif replacement_type is ReplacementType.NON_WRAPPING:
+            # If our replacement is not of this kind then we can skip this additional work
+            return self._rewrite(new_node)
+        else:
+            assert False, f"unhandled: {replacement_type}"
 
     def _rewrite_node_attributes(self, node):
         attrs = {k: v for k, v in node.__dict__.items() if not k.startswith("_")}

--- a/ehrql/query_model/query_graph_rewriter.py
+++ b/ehrql/query_model/query_graph_rewriter.py
@@ -11,8 +11,8 @@ class QueryGraphRewriter:
     one but incorporating these replacements.
     """
 
-    def __init__(self):
-        self.replacements = {}
+    def __init__(self, replacements=None):
+        self.replacements = replacements or {}
 
     def replace(self, target_node, new_node):
         self.replacements[target_node] = new_node
@@ -70,7 +70,7 @@ class QueryGraphRewriter:
             return self._rewrite_node_attributes(node, replacements)
 
     def _replace_node(self, node, replacements):
-        # Our replacments are often insertions e.g. given the following graph:
+        # Our replacements are sometimes insertions e.g. given the following graph:
         #
         #     A -> B -> C
         #
@@ -78,14 +78,15 @@ class QueryGraphRewriter:
         #
         #     A -> X -> B -> C
         #
-        # To do this we need to make sure that while we're in the process of
-        # generating B's replacement we don't attempt to replace B _again_ in any
-        # downstream segments of the graph. We avoid this by removing any nodes
-        # we're in the process of replacing from the copy of the replacements dict
-        # which we pass down.
-        replacements = replacements.copy()
-        node = replacements.pop(node)
-        return self._rewrite(node, replacements)
+        # To do this we need to make sure that while we're in the process of generating
+        # B's replacement we don't attempt to replace B _again_ in any downstream
+        # segments of the graph, which would lead to infinite recursion. We avoid this
+        # by creating a new rewriter for the sub-graph which has the currently active
+        # replacement rule removed.
+        other_replacements = replacements.copy()
+        new_node = other_replacements.pop(node)
+        subgraph_rewriter = self.__class__(other_replacements)
+        return subgraph_rewriter.rewrite(new_node)
 
     def _rewrite_node_attributes(self, node, replacements):
         attrs = {k: v for k, v in node.__dict__.items() if not k.startswith("_")}

--- a/ehrql/query_model/query_graph_rewriter.py
+++ b/ehrql/query_model/query_graph_rewriter.py
@@ -19,11 +19,11 @@ class QueryGraphRewriter:
 
     def rewrite(self, obj):
         self.cache = {}
-        return self._rewrite(obj, self.replacements)
+        return self._rewrite(obj)
 
-    def _rewrite(self, obj, replacements):
+    def _rewrite(self, obj):
         # Shortcut when there's no remaining work to be done
-        if not replacements:
+        if not self.replacements:
             return obj
 
         if isinstance(obj, qm.Value):
@@ -39,37 +39,34 @@ class QueryGraphRewriter:
             return obj
         elif isinstance(obj, qm.Node):
             # This is where most the work gets done
-            return self._rewrite_node_with_cache(obj, replacements)
+            return self._rewrite_node_with_cache(obj)
         elif isinstance(obj, dict):
             # Dicts need rewriting because they may contain references to other nodes
-            return {
-                self._rewrite(k, replacements): self._rewrite(v, replacements)
-                for k, v in obj.items()
-            }
+            return {self._rewrite(k): self._rewrite(v) for k, v in obj.items()}
         elif isinstance(obj, frozenset | tuple):
             # As do frozensets and tuples
-            return obj.__class__(self._rewrite(v, replacements) for v in obj)
+            return obj.__class__(self._rewrite(v) for v in obj)
         elif isinstance(obj, NoneType | int | str | qm.Position | qm.TableSchema):
             # Other expected types we return unchanged
             return obj
         else:
             assert False, f"Unhandled value: {obj}"
 
-    def _rewrite_node_with_cache(self, node, replacements):
+    def _rewrite_node_with_cache(self, node):
         # Avoid rewriting identical sections of the graph multiple times
         new_node = self.cache.get(node)
         if new_node is None:
-            new_node = self._rewrite_node(node, replacements)
+            new_node = self._rewrite_node(node)
             self.cache[node] = new_node
         return new_node
 
-    def _rewrite_node(self, node, replacements):
-        if node in replacements:
-            return self._replace_node(node, replacements)
+    def _rewrite_node(self, node):
+        if node in self.replacements:
+            return self._replace_node(node)
         else:
-            return self._rewrite_node_attributes(node, replacements)
+            return self._rewrite_node_attributes(node)
 
-    def _replace_node(self, node, replacements):
+    def _replace_node(self, node):
         # Our replacements are sometimes insertions e.g. given the following graph:
         #
         #     A -> B -> C
@@ -83,14 +80,14 @@ class QueryGraphRewriter:
         # segments of the graph, which would lead to infinite recursion. We avoid this
         # by creating a new rewriter for the sub-graph which has the currently active
         # replacement rule removed.
-        other_replacements = replacements.copy()
+        other_replacements = self.replacements.copy()
         new_node = other_replacements.pop(node)
         subgraph_rewriter = self.__class__(other_replacements)
         return subgraph_rewriter.rewrite(new_node)
 
-    def _rewrite_node_attributes(self, node, replacements):
+    def _rewrite_node_attributes(self, node):
         attrs = {k: v for k, v in node.__dict__.items() if not k.startswith("_")}
-        new_attrs = self._rewrite(attrs, replacements)
+        new_attrs = self._rewrite(attrs)
         # If nothing about the node has changed then return the original rather than
         # constructing an identical replacement. This avoids unnecessarily revalidating
         # the node.

--- a/ehrql/query_model/query_graph_rewriter.py
+++ b/ehrql/query_model/query_graph_rewriter.py
@@ -51,7 +51,14 @@ class QueryGraphRewriter:
             return obj
 
         self.cache = {}
-        return self._rewrite(obj)
+        try:
+            return self._rewrite(obj)
+        except RecursionError as exc:
+            exc.add_note(
+                "\nYou may need to use `wrap()` instead of `replace()`. "
+                "See docstrings on `QueryGraphRewriter`"
+            )
+            raise
 
     def _rewrite(self, obj):
         if isinstance(obj, qm.Value):

--- a/ehrql/query_model/transforms.py
+++ b/ehrql/query_model/transforms.py
@@ -171,18 +171,6 @@ def apply_optimizations(root_node):
     return rewriter.rewrite(root_node)
 
 
-def replace_nodes(root_node, replacements):
-    """
-    Takes a root_node and a dict of nodes that exist within the root, and
-    replacements for them.
-    Replaces the nodes in the root and returns the modified root node.
-    """
-    rewriter = QueryGraphRewriter()
-    for node, replacement in replacements.items():
-        rewriter.replace(node, replacement)
-    return rewriter.rewrite(root_node)
-
-
 def rewrite_sorts(rewriter, node, reverse_index):
     # What columns are select from this patient frame?
     selected_column_names = {

--- a/tests/unit/query_model/test_query_graph_rewriter.py
+++ b/tests/unit/query_model/test_query_graph_rewriter.py
@@ -1,3 +1,7 @@
+import re
+
+import pytest
+
 from ehrql.query_model.nodes import (
     AggregateByPatient,
     Case,
@@ -157,3 +161,15 @@ def test_query_graph_rewriter_mixed_replace_and_wrap():
     new_graph = rewriter.rewrite({"v": events_i})
 
     assert new_graph == {"v": Function.Add(events_i, Function.Add(events_k, Value(1)))}
+
+
+def test_query_graph_rewriter_recursion_error_hint():
+    events = SelectTable("events", schema=TableSchema(i=Column(int)))
+    events_i = SelectColumn(source=events, name="i")
+    rewriter = QueryGraphRewriter()
+    rewriter.replace(events_i, Function.Add(events_i, Value(1)))
+
+    with pytest.raises(
+        RecursionError, match=re.escape("use `wrap()` instead of `replace()`")
+    ):
+        rewriter.rewrite({"v": events_i})

--- a/tests/unit/query_model/test_query_graph_rewriter.py
+++ b/tests/unit/query_model/test_query_graph_rewriter.py
@@ -139,3 +139,21 @@ def test_query_graph_rewriter_edge_case():
     new_graph = rewriter.rewrite(example)
 
     assert new_graph == expected
+
+
+def test_query_graph_rewriter_mixed_replace_and_wrap():
+    events = SelectTable(
+        "events", schema=TableSchema(i=Column(int), j=Column(int), k=Column(int))
+    )
+    events_i = SelectColumn(source=events, name="i")
+    events_j = SelectColumn(source=events, name="j")
+    events_k = SelectColumn(source=events, name="k")
+
+    rewriter = QueryGraphRewriter()
+    rewriter.wrap(events_i, Function.Add(events_i, events_j))
+    rewriter.replace(events_j, events_k)
+    rewriter.wrap(events_k, Function.Add(events_k, Value(1)))
+
+    new_graph = rewriter.rewrite({"v": events_i})
+
+    assert new_graph == {"v": Function.Add(events_i, Function.Add(events_k, Value(1)))}

--- a/tests/unit/query_model/test_query_graph_rewriter.py
+++ b/tests/unit/query_model/test_query_graph_rewriter.py
@@ -1,4 +1,5 @@
 from ehrql.query_model.nodes import (
+    AggregateByPatient,
     Case,
     Column,
     Filter,
@@ -81,3 +82,60 @@ def test_query_graph_rewriter_handles_replacing_node_with_value():
     new_graph = rewriter.rewrite(graph)
 
     assert new_graph == {"i": Value(10), "s": Value("a")}
+
+
+def test_query_graph_rewriter_edge_case():
+    # We construct a simple graph containing two tables. The first table is filtered
+    # using a value obtained by aggregating over that table itself. The second table is
+    # only there to prevent some short-circuiting logic from kicking in and masking the
+    # bug.
+    def make_graph(table_1, table_2):
+        table_1_i = SelectColumn(source=table_1, name="i")
+        return {
+            "t1": Filter(
+                source=table_1,
+                condition=Function.EQ(
+                    lhs=table_1_i,
+                    # This is the construct which triggers the bug. While `table_1` is
+                    # being rewritten there is a temporary period in which the node
+                    # cache contains incorrect values. The expression below gets
+                    # rewritten using the incorrect values which means that it doesn't
+                    # get the appropriate replacements applied
+                    rhs=AggregateByPatient.Max(table_1_i),
+                ),
+            ),
+            "t2": table_2,
+        }
+
+    # This takes a table and returns that table with a simple filter applied
+    def make_filtered_table(table):
+        return Filter(
+            source=table,
+            condition=Function.LE(
+                lhs=SelectColumn(source=table, name="i"),
+                rhs=Value(2000),
+            ),
+        )
+
+    schema = TableSchema(i=Column(int))
+    table_1_orig = SelectTable(name="table_1", schema=schema)
+    table_2_orig = SelectTable(name="table_2", schema=schema)
+
+    # We start by constructing a graph using two base tables
+    example = make_graph(table_1_orig, table_2_orig)
+
+    # We then create filtered versions of those tables and construct a new graph using
+    # those filtered tables
+    table_1_filtered = make_filtered_table(table_1_orig)
+    table_2_filtered = make_filtered_table(table_2_orig)
+    expected = make_graph(table_1_filtered, table_2_filtered)
+
+    # This is exactly the graph we should expect if we take the original graph and
+    # replace the table references with filtered tables. However due to a bug, this
+    # fails.
+    rewriter = QueryGraphRewriter()
+    rewriter.replace(table_1_orig, table_1_filtered)
+    rewriter.replace(table_2_orig, table_2_filtered)
+    new_graph = rewriter.rewrite(example)
+
+    assert new_graph == expected

--- a/tests/unit/query_model/test_query_graph_rewriter.py
+++ b/tests/unit/query_model/test_query_graph_rewriter.py
@@ -25,7 +25,7 @@ def test_query_graph_rewriter():
     # Inject a new filter between 20 and 30
     filter_25 = Filter(filter_20, condition=Function.GT(col_i, Value(25)))
     rewriter = QueryGraphRewriter()
-    rewriter.replace(filter_20, filter_25)
+    rewriter.wrap(filter_20, filter_25)
 
     # Rewrite the graph
     new_graph = rewriter.rewrite(graph)
@@ -134,8 +134,8 @@ def test_query_graph_rewriter_edge_case():
     # table references with filtered tables. However there was a historic bug which
     # caused this to fail.
     rewriter = QueryGraphRewriter()
-    rewriter.replace(table_1_orig, table_1_filtered)
-    rewriter.replace(table_2_orig, table_2_filtered)
+    rewriter.wrap(table_1_orig, table_1_filtered)
+    rewriter.wrap(table_2_orig, table_2_filtered)
     new_graph = rewriter.rewrite(example)
 
     assert new_graph == expected

--- a/tests/unit/query_model/test_query_graph_rewriter.py
+++ b/tests/unit/query_model/test_query_graph_rewriter.py
@@ -96,10 +96,10 @@ def test_query_graph_rewriter_edge_case():
                 source=table_1,
                 condition=Function.EQ(
                     lhs=table_1_i,
-                    # This is the construct which triggers the bug. While `table_1` is
-                    # being rewritten there is a temporary period in which the node
-                    # cache contains incorrect values. The expression below gets
-                    # rewritten using the incorrect values which means that it doesn't
+                    # This is the construct which triggered the bug. While `table_1` is
+                    # being rewritten there was a temporary period in which the node
+                    # cache contains incorrect values. The expression below got
+                    # rewritten using the incorrect values which meant that it didn't
                     # get the appropriate replacements applied
                     rhs=AggregateByPatient.Max(table_1_i),
                 ),
@@ -130,9 +130,9 @@ def test_query_graph_rewriter_edge_case():
     table_2_filtered = make_filtered_table(table_2_orig)
     expected = make_graph(table_1_filtered, table_2_filtered)
 
-    # This is exactly the graph we should expect if we take the original graph and
-    # replace the table references with filtered tables. However due to a bug, this
-    # fails.
+    # This is exactly the graph we expect if we take the original graph and replace the
+    # table references with filtered tables. However there was a historic bug which
+    # caused this to fail.
     rewriter = QueryGraphRewriter()
     rewriter.replace(table_1_orig, table_1_filtered)
     rewriter.replace(table_2_orig, table_2_filtered)


### PR DESCRIPTION
This was identified due to an alert triggered by a failing [user job][1] and [discussed][2] on Slack.

Unfortunately the really simple fixes (the simplest being: get rid of caching altogether) aren't viable because the performance costs on large and deeply nested graphs are too great. I've run through a number of alternative approaches here and I think this one of exposing "fast" and "slow" methods and shifting the burden on the caller to explicitly use the slower method only when needed is the least worst.

The "slow" method is slightly misleadingly named in that it's only slow in certain pathological cases which don't occur in the use cases we have for it. So the performance impact of this change isn't really detectable.

It fails safe in the sense that if you hold it wrong you'll get either an immedatiate error or unacceptable slowness, but you shouldn't ever get incorrect results.

[1]: https://jobs.opensafely.org/trends-and-variation-in-vitamin-d-testing-and-prescribing/vitamin-d-trends/26772/5gz7i55b5236s5tv/
[2]: https://bennettoxford.slack.com/archives/C069YDR4NCA/p1788795770251499
